### PR TITLE
Return LocalPath instead of AbsoluteUri for absolute URIs

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Models/FileChangeModelTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Models/FileChangeModelTests.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.Sarif.Viewer.Models;
+using Microsoft.Sarif.Viewer.Sarif;
+using Xunit;
+
+namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests.Models
+{
+    public class FileChangeModelTests
+    {
+        [Fact]
+        public void FileChangeModel_FromFileChange_LocalPath()
+        {
+            FileChange fileChange = new FileChange
+            {
+                FileLocation = new FileLocation
+                {
+                    Uri = new Uri("file://C:/src/tools/util.cs", UriKind.RelativeOrAbsolute)
+                },
+                Replacements = new List<Replacement>()
+            };
+
+            FileChangeModel model = fileChange.ToFileChangeModel();
+            model.FilePath.Should().Be(@"C:\src\tools\util.cs");
+        }
+
+        [Fact]
+        public void FileChangeModel_FromFileChange_RelativePath()
+        {
+            FileChange fileChange = new FileChange
+            {
+                FileLocation = new FileLocation
+                {
+                    Uri = new Uri(@"\src\tools\util.cs", UriKind.RelativeOrAbsolute)
+                },
+                Replacements = new List<Replacement>()
+            };
+
+            FileChangeModel model = fileChange.ToFileChangeModel();
+            model.FilePath.Should().Be(@"\src\tools\util.cs");
+        }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
@@ -224,6 +224,7 @@
     <Compile Include="ErrorList\SarifSnapshotTests.cs" />
     <Compile Include="Models\CallTreeCollectionTests.cs" />
     <Compile Include="Models\CallTreeTests.cs" />
+    <Compile Include="Models\FileChangeModelTests.cs" />
     <Compile Include="Models\FixModelTests.cs" />
     <Compile Include="ProjectNameCacheTests.cs" />
     <Compile Include="SdkUIUtilitiesTests.cs" />

--- a/src/Sarif.Viewer.VisualStudio/Sarif/FileChange.extensions.cs
+++ b/src/Sarif.Viewer.VisualStudio/Sarif/FileChange.extensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Sarif.Viewer.Sarif
             if (fileChange.Replacements != null)
             {
                 model.FilePath = fileChange.FileLocation.Uri.IsAbsoluteUri ?
-                    fileChange.FileLocation.Uri.AbsoluteUri :
+                    fileChange.FileLocation.Uri.LocalPath :
                     fileChange.FileLocation.Uri.OriginalString;
 
                 foreach (Replacement replacement in fileChange.Replacements)


### PR DESCRIPTION
File.Exists doesn't handle URI-formatted local paths