### PR TITLE
Fix issue #16 result description

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
@@ -80,8 +80,11 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         {
             var result = new Result
             {
-                RuleId = "TST0001",
-                RuleMessageId = "nonExistentMessageId"
+                Message = new Message
+                {
+                    MessageId = "nonExistentMessageId"
+                },
+                RuleId = "TST0001"
             };
 
             var run = new Run
@@ -99,8 +102,11 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         {
             var result = new Result
             {
-                RuleId = "TST0001",
-                RuleMessageId = "nonExistentMessageId"
+                Message = new Message
+                {
+                    MessageId = "nonExistentMessageId"
+                },
+                RuleId = "TST0001"
             };
 
             var run = new Run
@@ -130,8 +136,11 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         {
             var result = new Result
             {
-                RuleId = "TST0001",
-                RuleMessageId = "nonExistentFormatId"
+                Message = new Message
+                {
+                    MessageId = "nonExistentFormatId"
+                },
+                RuleId = "TST0001"
             };
 
             var run = new Run
@@ -159,20 +168,20 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
 
             item.Message.Should().Be(string.Empty);
         }
-
-        [Fact]
+        
+        [Fact(Skip = "Requires SDK changes not yet published to NuGet")]
         public void SarifErrorListItem_WhenResultRefersToExistingMessageString_ContainsExpectedMessage()
         {
             var result = new Result
             {
-                RuleId = "TST0001",
-                RuleMessageId = "greeting", 
+                RuleId = "TST0001", 
                 Message = new Message()
                 {
                     Arguments = new string[]
                     {
                         "Mary"
-                    }
+                    },
+                    MessageId = "greeting"
                 }
             };
 

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             item.Message.Should().Be(string.Empty);
         }
         
-        [Fact(Skip = "Requires SDK changes not yet published to NuGet")]
+        [Fact(Skip = "Requires SDK changes not yet published to NuGet (issue #22)")]
         public void SarifErrorListItem_WhenResultRefersToExistingMessageString_ContainsExpectedMessage()
         {
             var result = new Result

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/SdkUiUtilitiesTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/SdkUiUtilitiesTests.cs
@@ -41,14 +41,10 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         {
             string message = @"The quick \[brown fox\] jumps over the lazy dog.";
 
-            var expected = new List<Inline>
-            {
-                new Run("The quick [brown fox] jumps over the lazy dog.")
-            };
-
+            // Because there are no embedded links, we shouldn't get anything back
             var actual = SdkUIUtilities.GetMessageInlines(message, index: 1, clickHandler: Hyperlink_Click);
 
-            VerifyTextRun(expected[0], actual[0]);
+            actual.Count.Should().Be(0);
         }
 
         [Fact]

--- a/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
@@ -1086,10 +1086,10 @@ namespace Microsoft.Sarif.Viewer
             var inlines = new List<Inline>();
 
             MatchCollection matches = Regex.Matches(message, EmbeddedLinkPattern, RegexOptions.Compiled | RegexOptions.CultureInvariant);
-            int start = 0;
 
             if (matches.Count > 0)
             {
+                int start = 0;
                 Group group = null;
 
                 foreach (Match match in matches)
@@ -1120,12 +1120,12 @@ namespace Microsoft.Sarif.Viewer
 
                     start = match.Index + match.Length;
                 }
-            }
 
-            if (start < message.Length)
-            {
-                // Add the plain text segment after the last link
-                inlines.Add(new Run(UnescapeBrackets(message.Substring(start))));
+                if (start < message.Length)
+                {
+                    // Add the plain text segment after the last link
+                    inlines.Add(new Run(UnescapeBrackets(message.Substring(start))));
+                }
             }
 
             return inlines;

--- a/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
@@ -1086,10 +1086,10 @@ namespace Microsoft.Sarif.Viewer
             var inlines = new List<Inline>();
 
             MatchCollection matches = Regex.Matches(message, EmbeddedLinkPattern, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+            int start = 0;
 
             if (matches.Count > 0)
             {
-                int start = 0;
                 Group group = null;
 
                 foreach (Match match in matches)
@@ -1120,12 +1120,12 @@ namespace Microsoft.Sarif.Viewer
 
                     start = match.Index + match.Length;
                 }
+            }
 
-                if (start < message.Length)
-                {
-                    // Add the plain text segment after the last link
-                    inlines.Add(new Run(UnescapeBrackets(message.Substring(start))));
-                }
+            if (inlines.Count > 0 && start < message.Length)
+            {
+                // Add the plain text segment after the last link
+                inlines.Add(new Run(UnescapeBrackets(message.Substring(start))));
             }
 
             return inlines;


### PR DESCRIPTION
When we create an error list entry, we check the Message string (the full rule description) for embedded links. Currently, if none are found, an inline is created for the entire string. What *should* happen is no inlines be returned, and a different part of the code provides a shortened string. The fix is to demote the scope of the inline block so it only executes when embedded links are present.