### PR TITLE
Fix NuGet packaging warnings in build

### DIFF
--- a/src/build.props
+++ b/src/build.props
@@ -35,9 +35,14 @@
     <Authors Condition=" '$(Authors)' == '' ">$(Company)</Authors>
     <Owners Condition=" '$(Authors)' == '' ">$(Company),tse-securitytools</Owners>
     <PackageRequireLicenseAcceptance Condition=" '$(PackageRequireLicenseAcceptance)' == '' ">false</PackageRequireLicenseAcceptance>
-    <PackageLicenseUrl Condition=" '$(PackageLicenseUrl)' == '' ">https://github.com/Microsoft/sarif-sdk/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl Condition=" '$(PackageProjectUrl)' == '' ">https://github.com/Microsoft/sarif-sdk</PackageProjectUrl>
     <PackageIconUrl Condition=" '$(PackageIconUrl)' == '' ">https://go.microsoft.com/fwlink/?linkid=2008860</PackageIconUrl>
+    <!--
+    Don't complain about SemVer 2.0.0-compatible version strings.
+    See https://github.com/NuGet/Home/issues/4687#issuecomment-393302779.
+    -->
+    <NoWarn>NU5105</NoWarn>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
- Suppress NU5105 with `NoWarn` in build.props: Don't complain about SemVer 2.0.0-specific version numbers.
- Fix NU5125: Replace deprecated `licenseUrl` with `licenseExpression`.