### PR TITLE
Fix #98: Some files won't open.

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -21,3 +21,6 @@
 * FEATURE: add support for embedded hyperlinks in the error list that point to web URLs
 * Updated SDK compatibility with [v2.1.0-rtm.2](https://www.nuget.org/packages/Sarif.Sdk/2.1.2)
 * Optimized file loading, transform, and SARIF version check logic
+
+## **v2.1.3** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
+* BUGFIX: Some valid SARIF files would not open in the viewer. https://github.com/microsoft/sarif-visualstudio-extension/issues/98

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/ErrorListServiceTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/ErrorListServiceTests.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Microsoft.Sarif.Viewer.ErrorList;
+using Xunit;
+
+namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
+{
+    public class ErrorListServiceTests
+    {
+        private struct TestCase
+        {
+            public string Title { get; set; }
+            public string Input { get; set; }
+            public bool ExpectedMatchSuccess { get; set; }
+            public string ExpectedVersion { get; set; }
+        }
+
+        private static readonly TestCase[] s_testCases = new TestCase[]
+        {
+            new TestCase
+            {
+                Title = "Simplest case",
+                Input = @"""version"": ""2.1.0""",
+                ExpectedMatchSuccess = true,
+                ExpectedVersion = "2.1.0"
+            },
+            new TestCase
+            {
+                Title = "White space before colon",
+                Input = @"""version"" : ""2.1.0""",
+                ExpectedMatchSuccess = true,
+                ExpectedVersion = "2.1.0"
+            },
+            new TestCase
+            {
+                Title = "Version near start of file",
+                Input = @"01234567890123456789 ""version"" : ""2.1.0""",
+                ExpectedMatchSuccess = true,
+                ExpectedVersion = "2.1.0"
+            },
+            new TestCase
+            {
+                Title = "Version not near start of file",
+                Input = @"01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789 ""version"" : ""2.1.0""",
+                ExpectedMatchSuccess = false
+            },
+            new TestCase
+            {
+                Title = "Invalid version",
+                Input = @"""version"": ""a.b.c""",
+                ExpectedMatchSuccess = false
+            }
+        };
+
+        [Fact]
+        [Trait(TestTraits.Bug, "98")]
+        public void ErrorListService_MatchesVersionProperty()
+        {
+            var failedTestCases = new List<TestCase>();
+
+            foreach (TestCase testCase in s_testCases)
+            {
+                Match match = ErrorListService.MatchVersionProperty(testCase.Input);
+
+                bool failed = false;
+                if (match.Success != testCase.ExpectedMatchSuccess) { failed = true; }
+
+                if (!failed && testCase.ExpectedMatchSuccess)
+                {
+                    if (match.Groups["version"].Value != testCase.ExpectedVersion) { failed = true; }
+                }
+
+                if (failed) { failedTestCases.Add(testCase); }
+            }
+
+            failedTestCases.Should().BeEmpty();
+        }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
@@ -216,6 +216,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CodeAnalysisResultManagerTests.cs" />
+    <Compile Include="ErrorList\ErrorListServiceTests.cs" />
     <Compile Include="ErrorList\MultipleRunsPerSarifTests.cs" />
     <Compile Include="ErrorList\SarifErrorListItemTests.cs" />
     <Compile Include="ErrorList\SarifFileWithContentsTests.cs" />
@@ -227,6 +228,7 @@
     <Compile Include="ProjectNameCacheTests.cs" />
     <Compile Include="SdkUIUtilitiesTests.cs" />
     <Compile Include="TelemetryProviderTests.cs" />
+    <Compile Include="TestTraits.cs" />
     <Compile Include="TestUtilities.cs" />
     <Compile Include="UriExtensionsTests.cs" />
     <Compile Include="CallTreeTraversalTests.cs" />

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/TestTraits.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/TestTraits.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft. All rights reserved. Licensed under the MIT        
+// license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
+{
+    public static class TestTraits
+    {
+        public const string Bug = nameof(Bug);
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -29,8 +29,6 @@ namespace Microsoft.Sarif.Viewer.ErrorList
     public class ErrorListService
     {
         public static readonly ErrorListService Instance = new ErrorListService();
-        private const string VersionRegexPattern = @"\""version\"":\s*\""(?<version>[\d.]+)\""";
-        const int HeadSegmentLength = 200;
 
         public static void ProcessLogFile(string filePath, Solution solution, string toolFormat = ToolFormat.None)
         {
@@ -44,10 +42,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             {
                 logText = File.ReadAllText(filePath);
 
-                // Get the schema version of the unmodified input log
-                string headSegment = logText.Substring(0, HeadSegmentLength);
-                Match match = Regex.Match(headSegment, VersionRegexPattern, RegexOptions.Compiled);                
-
+                Match match = MatchVersionProperty(logText);
                 if (match.Success)
                 {
                     string inputVersion = match.Groups["version"].Value;
@@ -184,6 +179,16 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             ProcessSarifLog(log, outputPath, solution);
 
             SarifTableDataSource.Instance.BringToFront();
+        }
+
+        private const string VersionRegexPattern = @"""version""\s*:\s*""(?<version>[\d.]+)""";
+        private const int HeadSegmentLength = 200;
+
+        internal static Match MatchVersionProperty(string logText)
+        {
+            int headSegmentLength = Math.Min(logText.Length, HeadSegmentLength);
+            string headSegment = logText.Substring(0, headSegmentLength);
+            return Regex.Match(headSegment, VersionRegexPattern, RegexOptions.Compiled);
         }
 
         private static MessageDialogCommand PromptToSaveProcessedLog(string dialogMessage)

--- a/src/Sarif.Viewer.VisualStudio/SarifToolWindow.cs
+++ b/src/Sarif.Viewer.VisualStudio/SarifToolWindow.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Sarif.Viewer
         }
 
         /// <summary>
-        /// Replaces the collection of objects who's values are displayed in the Properties window.
+        /// Replaces the collection of objects whose values are displayed in the Properties window.
         /// </summary>
         /// <param name="items"></param>
         public void UpdateSelectionList(params object[] items)

--- a/src/Sarif.Viewer.VisualStudio/source.extension.vsixmanifest
+++ b/src/Sarif.Viewer.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Microsoft.Sarif.Viewer.Michael C. Fanning.f17e897a-fd38-4e1f-99db-19fa34a4e184" Version="2.1.2" Language="en-US" Publisher="Microsoft DevLabs" />
+        <Identity Id="Microsoft.Sarif.Viewer.Michael C. Fanning.f17e897a-fd38-4e1f-99db-19fa34a4e184" Version="2.1.3" Language="en-US" Publisher="Microsoft DevLabs" />
         <DisplayName>Microsoft SARIF Viewer</DisplayName>
         <Description xml:space="preserve">Visual Studio Static Analysis Results Interchange Format (SARIF) log file viewer</Description>
         <License>License.txt</License>


### PR DESCRIPTION
In the last commit, the regex that describes the `version` property was broken. Spurious backslash characters were introduced, and the optional whitespace before the colon character (which _is_ permitted by the JSON spec) was removed.

Also:
- Even though `ErrorListService` as a whole is not unit testable (I filed #100), I extracted a small static method that I could test. This is the Sprout Method (59) pattern from Feathers, "Working Effectively With Legacy Code".

Adding the unit tests revealed another bug: the extension would not have opened a SARIF file that was fewer than 200 characters long.