### PR TITLE
Fix #85: Can't open files containing empty string URIs

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -24,3 +24,6 @@
 
 ## **v2.1.3** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
 * BUGFIX: Some valid SARIF files would not open in the viewer. https://github.com/microsoft/sarif-visualstudio-extension/issues/98
+
+## **v2.1.4** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
+* BUGFIX: Some valid SARIF files would not open in the viewer. https://github.com/microsoft/sarif-visualstudio-extension/issues/98

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -26,4 +26,4 @@
 * BUGFIX: Some valid SARIF files would not open in the viewer. https://github.com/microsoft/sarif-visualstudio-extension/issues/98
 
 ## **v2.1.4** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
-* BUGFIX: Some valid SARIF files would not open in the viewer. https://github.com/microsoft/sarif-visualstudio-extension/issues/98
+* BUGFIX: SARIF files with empty URI properties would not open in the viewer. https://github.com/microsoft/sarif-visualstudio-extension/issues/85

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
@@ -134,11 +134,11 @@
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="Sarif, Version=2.1.9.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sarif.Sdk.2.1.9\lib\net461\Sarif.dll</HintPath>
+    <Reference Include="Sarif, Version=2.1.13.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Sdk.2.1.13\lib\net461\Sarif.dll</HintPath>
     </Reference>
-    <Reference Include="Sarif.Driver, Version=2.1.9.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sarif.Driver.2.1.9\lib\net461\Sarif.Driver.dll</HintPath>
+    <Reference Include="Sarif.Driver, Version=2.1.13.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Driver.2.1.13\lib\net461\Sarif.Driver.dll</HintPath>
     </Reference>
     <Reference Include="StreamJsonRpc, Version=1.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\StreamJsonRpc.1.3.23\lib\net45\StreamJsonRpc.dll</HintPath>

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/packages.config
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/packages.config
@@ -31,8 +31,8 @@
   <package id="Microsoft.VisualStudio.Validation" version="15.3.58" targetFramework="net461" />
   <package id="Moq" version="4.8.3" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
-  <package id="Sarif.Driver" version="2.1.9" targetFramework="net461" />
-  <package id="Sarif.Sdk" version="2.1.9" targetFramework="net461" />
+  <package id="Sarif.Driver" version="2.1.13" targetFramework="net461" />
+  <package id="Sarif.Sdk" version="2.1.13" targetFramework="net461" />
   <package id="StreamJsonRpc" version="1.3.23" targetFramework="net461" />
   <package id="System.Collections" version="4.3.0" targetFramework="net461" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net461" />

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -301,15 +301,15 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="PresentationFramework.Aero2" />
-    <Reference Include="Sarif, Version=2.1.9.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sarif.Sdk.2.1.9\lib\net461\Sarif.dll</HintPath>
+    <Reference Include="Sarif, Version=2.1.13.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Sdk.2.1.13\lib\net461\Sarif.dll</HintPath>
     </Reference>
-    <Reference Include="Sarif.Converters, Version=2.1.9.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sarif.Converters.2.1.9\lib\net461\Sarif.Converters.dll</HintPath>
+    <Reference Include="Sarif.Converters, Version=2.1.13.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Converters.2.1.13\lib\net461\Sarif.Converters.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sarif.Driver, Version=2.1.9.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sarif.Driver.2.1.9\lib\net461\Sarif.Driver.dll</HintPath>
+    <Reference Include="Sarif.Driver, Version=2.1.13.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Driver.2.1.13\lib\net461\Sarif.Driver.dll</HintPath>
     </Reference>
     <Reference Include="stdole, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>

--- a/src/Sarif.Viewer.VisualStudio/packages.config
+++ b/src/Sarif.Viewer.VisualStudio/packages.config
@@ -38,9 +38,9 @@
   <package id="Microsoft.VisualStudio.Validation" version="15.3.58" targetFramework="net461" />
   <package id="Microsoft.VSSDK.BuildTools" version="15.7.109" targetFramework="net461" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
-  <package id="Sarif.Converters" version="2.1.9" targetFramework="net461" />
-  <package id="Sarif.Driver" version="2.1.9" targetFramework="net461" />
-  <package id="Sarif.Sdk" version="2.1.9" targetFramework="net461" />
+  <package id="Sarif.Converters" version="2.1.13" targetFramework="net461" />
+  <package id="Sarif.Driver" version="2.1.13" targetFramework="net461" />
+  <package id="Sarif.Sdk" version="2.1.13" targetFramework="net461" />
   <package id="stdole" version="7.0.3303" targetFramework="net461" />
   <package id="StreamJsonRpc" version="1.3.23" targetFramework="net461" />
   <package id="System.Collections" version="4.0.11-rc2-24027" targetFramework="net461" />

--- a/src/Sarif.Viewer.VisualStudio/source.extension.vsixmanifest
+++ b/src/Sarif.Viewer.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Microsoft.Sarif.Viewer.Michael C. Fanning.f17e897a-fd38-4e1f-99db-19fa34a4e184" Version="2.1.3" Language="en-US" Publisher="Microsoft DevLabs" />
+        <Identity Id="Microsoft.Sarif.Viewer.Michael C. Fanning.f17e897a-fd38-4e1f-99db-19fa34a4e184" Version="2.1.4" Language="en-US" Publisher="Microsoft DevLabs" />
         <DisplayName>Microsoft SARIF Viewer</DisplayName>
         <Description xml:space="preserve">Visual Studio Static Analysis Results Interchange Format (SARIF) log file viewer</Description>
         <License>License.txt</License>

--- a/src/build.props
+++ b/src/build.props
@@ -19,7 +19,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF Viewer for Visual Studio</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix Condition=" '$(VersionPrefix)' == ''">2.1.0</VersionPrefix>
+    <VersionPrefix Condition=" '$(VersionPrefix)' == ''">2.1.4</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == ''">rtm.4</VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR updates the VSIX to use version 2.1.13 of the SARIF SDK, which fixes Microsoft/sarif-sdk#1632, the root cause of #85.