### PR TITLE
Fix #106: Crash when navigating to relative path with no uriBaseId.

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -30,3 +30,6 @@
 
 ## **v2.1.5** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
 * BUGFIX: The open file dialog did not offer an "All files" ("*.*") option. https://github.com/microsoft/sarif-visualstudio-extension/issues/104
+
+## **v2.1.6** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
+* BUGFIX: The viewer crashed when navigating to a result with relative path and no `uriBaseId`. https://github.com/microsoft/sarif-visualstudio-extension/issues/106

--- a/src/Sarif.Viewer.VisualStudio.sln
+++ b/src/Sarif.Viewer.VisualStudio.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28917.181
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.779
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sarif.Viewer.VisualStudio", "Sarif.Viewer.VisualStudio\Sarif.Viewer.VisualStudio.csproj", "{689AF24B-33F0-44E9-AA2E-FACA775736A8}"
 EndProject

--- a/src/Sarif.Viewer.VisualStudio/source.extension.vsixmanifest
+++ b/src/Sarif.Viewer.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Microsoft.Sarif.Viewer.Michael C. Fanning.f17e897a-fd38-4e1f-99db-19fa34a4e184" Version="2.1.5" Language="en-US" Publisher="Microsoft DevLabs" />
+        <Identity Id="Microsoft.Sarif.Viewer.Michael C. Fanning.f17e897a-fd38-4e1f-99db-19fa34a4e184" Version="2.1.6" Language="en-US" Publisher="Microsoft DevLabs" />
         <DisplayName>Microsoft SARIF Viewer</DisplayName>
         <Description xml:space="preserve">Visual Studio Static Analysis Results Interchange Format (SARIF) log file viewer</Description>
         <License>License.txt</License>


### PR DESCRIPTION
Please see #106 for a full explanation.

Also:
- Clean up several IDE warnings with recent C# features.