### PR TITLE
Fix #119, Fix #121: Integer & embedded content links don't work without regions

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/CodeLocationObject.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeLocationObject.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.IO;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
@@ -149,7 +150,22 @@ namespace Microsoft.Sarif.Viewer
 
         public void NavigateTo(bool usePreviewPane = true)
         {
-            LineMarker?.NavigateTo(usePreviewPane);
+            if (LineMarker != null)
+            {
+                LineMarker?.NavigateTo(usePreviewPane);
+            }
+            else
+            {
+                if (!File.Exists(this.FilePath))
+                {
+                    CodeAnalysisResultManager.Instance.TryRebaselineAllSarifErrors(RunId, this.UriBaseId, this.FilePath);
+                }
+
+                if (File.Exists(this.FilePath))
+                {
+                    SdkUIUtilities.OpenDocument(SarifViewerPackage.ServiceProvider, this.FilePath, usePreviewPane);
+                }
+            }
         }
 
         public void ApplyDefaultSourceFileHighlighting()

--- a/src/Sarif.Viewer.VisualStudio/CodeLocationObject.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeLocationObject.cs
@@ -156,6 +156,9 @@ namespace Microsoft.Sarif.Viewer
             }
             else
             {
+                // The user clicked an inline link with an integer target, which points to
+                // a Location object that does NOT have a region associated with it.
+
                 // Before anything else, see if this is an external link we should open in the browser.
                 if (Uri.TryCreate(this.FilePath, UriKind.Absolute, out Uri uri))
                 {

--- a/src/Sarif.Viewer.VisualStudio/CodeLocationObject.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeLocationObject.cs
@@ -156,6 +156,16 @@ namespace Microsoft.Sarif.Viewer
             }
             else
             {
+                // Before anything else, see if this is an external link we should open in the browser.
+                if (Uri.TryCreate(this.FilePath, UriKind.Absolute, out Uri uri))
+                {
+                    if (!uri.IsFile)
+                    {
+                        System.Diagnostics.Process.Start(uri.OriginalString);
+                        return;
+                    }
+                }
+
                 if (!File.Exists(this.FilePath))
                 {
                     CodeAnalysisResultManager.Instance.TryRebaselineAllSarifErrors(RunId, this.UriBaseId, this.FilePath);

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/SarifSnapshot.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/SarifSnapshot.cs
@@ -162,9 +162,8 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
                 SarifErrorListItem sarifResult = _errors[Convert.ToInt32(data.Item1)];
 
-                if (data.Item2 is int)
+                if (data.Item2 is int id)
                 {
-                    int id = (int)data.Item2;
                     LocationModel location = sarifResult.RelatedLocations.Where(l => l.Id == id).FirstOrDefault();
                     if (location == null)
                     {

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/SarifSnapshot.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/SarifSnapshot.cs
@@ -166,6 +166,10 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                 {
                     int id = (int)data.Item2;
                     LocationModel location = sarifResult.RelatedLocations.Where(l => l.Id == id).FirstOrDefault();
+                    if (location == null)
+                    {
+                        location = sarifResult.Locations.Where(l => l.Id == id).FirstOrDefault();
+                    }
 
                     if (location != null)
                     {

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/SarifSnapshot.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/SarifSnapshot.cs
@@ -164,6 +164,11 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
                 if (data.Item2 is int id)
                 {
+                    // The user clicked an inline link with an integer target. Look for a Location object
+                    // whose Id property matches that integer. The spec says that might be _any_ Location
+                    // object under the current result. At present, we only support Location objects that
+                    // occur in Result.Locations or Result.RelatedLocations. So, for example, we don't
+                    // look in Result.CodeFlows or Result.Stacks.
                     LocationModel location = sarifResult.RelatedLocations.Where(l => l.Id == id).FirstOrDefault();
                     if (location == null)
                     {

--- a/src/Sarif.Viewer.VisualStudio/ResultTextMarker.cs
+++ b/src/Sarif.Viewer.VisualStudio/ResultTextMarker.cs
@@ -63,6 +63,8 @@ namespace Microsoft.Sarif.Viewer
             Color = DEFAULT_SELECTION_COLOR;
         }
 
+        // This method is called when you click an inline link, with an integer target, which
+        // points to a Location object that has a region associated with it.
         internal IVsWindowFrame NavigateTo(bool usePreviewPane)
         {
             // Before anything else, see if this is an external link we should open in the browser.

--- a/src/Sarif.Viewer.VisualStudio/ResultTextMarker.cs
+++ b/src/Sarif.Viewer.VisualStudio/ResultTextMarker.cs
@@ -65,6 +65,17 @@ namespace Microsoft.Sarif.Viewer
 
         internal IVsWindowFrame NavigateTo(bool usePreviewPane)
         {
+            // Before anything else, see if this is an external link we should open in the browser.
+            Uri uri;
+            if (Uri.TryCreate(this.FullFilePath, UriKind.Absolute, out uri))
+            {
+                if (!uri.IsFile)
+                {
+                    System.Diagnostics.Process.Start(uri.OriginalString);
+                    return null;
+                }
+            }
+
             // Fall back to the file and line number
             if (!File.Exists(this.FullFilePath))
             {
@@ -74,7 +85,7 @@ namespace Microsoft.Sarif.Viewer
                 }
             }
             
-            if (File.Exists(this.FullFilePath) && Uri.TryCreate(this.FullFilePath, UriKind.Absolute, out Uri uri))
+            if (File.Exists(this.FullFilePath) && Uri.TryCreate(this.FullFilePath, UriKind.Absolute, out uri))
             {
                 // Fill out the region's properties
                 FileRegionsCache regionsCache = CodeAnalysisResultManager.Instance.RunDataCaches[_runId].FileRegionsCache;


### PR DESCRIPTION
Whoever knows most about the VS Extension please take this PR. I'm afraid it might be @michaelcfanning but don't want to put this on him unless necessary.

In both scenarios (clicking an integer link, and navigating to embedded context without a region specified), the code went down a path that refused to navigate unless there was a region. I fixed it by adding to `CodeLocationObject.NavigateTo` just that portion of `ResultTextMarker.NavigateTo` that handled the file navigation, leaving out the portion that dealt with highlighting the region.

Normally I would refactor the code that is common between the two methods, but I didn't see an easy way to do that here.