### PR TITLE
Display related location messages in SARIF Explorer

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -76,20 +76,22 @@ namespace Microsoft.Sarif.Viewer
             Invocation = run.Invocations?[0]?.ToInvocationModel();
             WorkingDirectory = Path.Combine(Path.GetTempPath(), _runId.ToString());
 
-            if (result.Locations != null)
+            if (result.Locations?.Any() == true)
             {
-                foreach (Location location in result.Locations)
+                // Adding in reverse order will make them display in the correct order in the UI.
+                for (int i = result.Locations.Count - 1; i >= 0; --i)
                 {
-                    Locations.Add(location.ToLocationModel());
+                    Locations.Add(result.Locations[i].ToLocationModel());
                 }
             }
 
-            if (result.RelatedLocations != null)
+            if (result.RelatedLocations?.Any() == true)
             {
-                foreach (Location location in result.RelatedLocations)
+                for (int i = result.RelatedLocations.Count - 1; i >= 0; --i)
                 {
-                    RelatedLocations.Add(location.ToLocationModel());
+                    RelatedLocations.Add(result.RelatedLocations[i].ToLocationModel());
                 }
+
             }
 
             if (result.CodeFlows != null)

--- a/src/Sarif.Viewer.VisualStudio/Themes/LocationsStyles.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Themes/LocationsStyles.xaml
@@ -63,6 +63,10 @@
         <Setter Property="Margin" Value="5,0,0,0"/>
     </Style>
 
+    <Style x:Key="LocationTextStyleNoMargin" BasedOn="{StaticResource LocationTextBaseStyle}" TargetType="TextBlock">
+        <Setter Property="Margin" Value="0,0,0,0"/>
+    </Style>
+
     <Style x:Key="RelatedLocationsTreeViewItemHeaderTextStyle" BasedOn="{StaticResource PanelHeader}" TargetType="TextBlock">
         <Setter Property="DockPanel.Dock" Value="Left"/>
         <Setter Property="Margin" Value="5,0,0,0"/>

--- a/src/Sarif.Viewer.VisualStudio/Themes/LocationsStyles.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Themes/LocationsStyles.xaml
@@ -39,7 +39,7 @@
         <Setter Property="LastChildFill" Value="False"/>
     </Style>
 
-    <Style x:Key="ListBoxItemContainerStyl" TargetType="ListBoxItem">
+    <Style x:Key="ListBoxItemContainerStyle" TargetType="ListBoxItem">
         <Setter Property="DockPanel.Dock" Value="Bottom" />
         <Setter Property="Foreground" Value="{DynamicResource {x:Static vs_shell:EnvironmentColors.ToolWindowTextBrushKey}}"/>
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />

--- a/src/Sarif.Viewer.VisualStudio/Views/Information.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Views/Information.xaml
@@ -43,7 +43,7 @@
                            Style="{StaticResource PropertyKey}" />
                 <TextBlock Grid.Row="1"
                            Grid.Column="1"
-                           Text="{Binding Rule.DefaultLevel}"
+                           Text="{Binding Rule.DefaultFailureLevel}"
                            Style="{StaticResource PropertyValue}" />
                 <TextBlock Grid.Row="2"
                            Grid.Column="0"

--- a/src/Sarif.Viewer.VisualStudio/Views/InformationStringResources.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Views/InformationStringResources.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
 
-    <system:String x:Key="Information_Property_RuleLevel_Text_String">Level</system:String>
+    <system:String x:Key="Information_Property_RuleLevel_Text_String">Level:</system:String>
     <system:String x:Key="Information_Property_RuleCategory_Text_String">Category</system:String>
     <system:String x:Key="Information_Property_RuleHelpLink_Text_String">Help</system:String>
     <system:String x:Key="Information_Property_InvocationCommandLine_Text_String">Command line</system:String>

--- a/src/Sarif.Viewer.VisualStudio/Views/Locations.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Views/Locations.xaml
@@ -139,14 +139,21 @@
                                                                    Style="{StaticResource ListBoxItemToolTipRegionTextStyle}">
                                                             <Run Text="{Binding Region.StartColumn, Mode=OneWay, StringFormat={StaticResource Locations_ListBoxItem_ToolTip_RegionStartColumn_Text_FormatString}}" />
                                                         </TextBlock>
+                                                        <TextBlock Visibility="{Binding Message, Converter={StaticResource StringToVisibilityConverter}}">
+                                                            <Run Text="{Binding Message, Mode=OneWay, StringFormat={StaticResource Locations_TreeViewItem_Header_Message_FormatString}}" />
+                                                        </TextBlock>
                                                     </WrapPanel>
                                                 </WrapPanel.ToolTip>
-                                                <TextBlock>
+                                                <TextBlock Style="{StaticResource LocationTextStyle}">
                                                     <Run Text="{Binding FileName, Mode=OneWay}" />
                                                 </TextBlock>
                                                 <TextBlock Visibility="{Binding RegionDisplayString, Converter={StaticResource StringToVisibilityConverter}}"
                                                            Style="{StaticResource LocationTextStyle}">
                                                     <Run Text="{Binding RegionDisplayString, Mode=OneWay}" />
+                                                </TextBlock>
+                                                <TextBlock Visibility="{Binding Message, Converter={StaticResource StringToVisibilityConverter}}"
+                                                           Style="{StaticResource LocationTextStyleNoMargin}">
+                                                    <Run Text="{Binding Message, Mode=OneWay, StringFormat={StaticResource Locations_TreeViewItem_Header_Message_FormatString}}" />
                                                 </TextBlock>
                                             </WrapPanel>
                                         </DataTemplate>

--- a/src/Sarif.Viewer.VisualStudio/Views/Locations.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Views/Locations.xaml
@@ -38,7 +38,7 @@
                             <DockPanel>
                                 <ListBox ItemsSource="{Binding Locations}"
                                          SelectedItem="{Binding Locations.SelectedItem, Mode=TwoWay}"
-                                         ItemContainerStyle="{StaticResource ListBoxItemContainerStyl}"
+                                         ItemContainerStyle="{StaticResource ListBoxItemContainerStyle}"
                                          Style="{StaticResource TreeViewItemListBoxStyle}">
                                     <ListBox.ItemsPanel>
                                         <ItemsPanelTemplate>
@@ -110,7 +110,7 @@
                             <DockPanel Visibility="{Binding RelatedLocations, Converter={StaticResource CollectionToVisibilityConverter}, ConverterParameter=0}">
                                 <ListBox ItemsSource="{Binding RelatedLocations}"
                                          SelectedItem="{Binding RelatedLocations.SelectedItem, Mode=TwoWay}"
-                                         ItemContainerStyle="{StaticResource ListBoxItemContainerStyl}"
+                                         ItemContainerStyle="{StaticResource ListBoxItemContainerStyle}"
                                          Style="{StaticResource TreeViewItemListBoxStyle}">
                                     <ListBox.ItemsPanel>
                                         <ItemsPanelTemplate>

--- a/src/Sarif.Viewer.VisualStudio/Views/LocationsStringResources.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Views/LocationsStringResources.xaml
@@ -4,6 +4,7 @@
 
     <system:String x:Key="Locations_TreeViewItem_Header_Label_Text_String">Defect Locations</system:String>
     <system:String x:Key="Locations_TreeViewItem_Header_Count_Text_FormatString">({0})</system:String>
+    <system:String x:Key="Locations_TreeViewItem_Header_Message_FormatString">: {0}</system:String>
     <system:String x:Key="Locations_ListBoxItem_ToolTip_RegionStartLine_Text_FormatString">Line {0}</system:String>
     <system:String x:Key="Locations_ListBoxItem_ToolTip_RegionStartColumn_Text_FormatString">Col {0}</system:String>
 


### PR DESCRIPTION
Also:
- Fix #92: Info tab does not display level.
- Emit the locations in the correct order (they were reversed).

@rtaket FYI