### PR TITLE
Fix #127: originalUriBaseIds must end with slash

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,5 +1,11 @@
 # SARIF Viewer Visual Studio extension Release History
 
+## **v2.1.9** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
+* FEATURE: Display messages for locations and related locations in the Locations tab.
+* BUGFIX: Display locations and related locations in the correct order in the Locations tab.
+* BUGFIX: Display default rule level in the Info tab. [#92](https://github.com/microsoft/sarif-visualstudio-extension/issues/92)
+* BUGFIX: Navigate to inline links with integer targets even if the target location has no region.
+
 ## **v2.1.8** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
 * BUGFIX: Make embedded links with a slash in the anchor text work. [#118](https://github.com/microsoft/sarif-visualstudio-extension/issues/118)
 

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -5,6 +5,7 @@
 * BUGFIX: Display locations and related locations in the correct order in the Locations tab.
 * BUGFIX: Display default rule level in the Info tab. [#92](https://github.com/microsoft/sarif-visualstudio-extension/issues/92)
 * BUGFIX: Navigate to inline links with integer targets even if the target location has no region.
+* BUGFIX: Ensure trailing slash on `originalUriBaseIds`. [#127](https://github.com/microsoft/sarif-visualstudio-extension/issues/127)
 
 ## **v2.1.8** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
 * BUGFIX: Make embedded links with a slash in the anchor text work. [#118](https://github.com/microsoft/sarif-visualstudio-extension/issues/118)

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/CodeAnalysisResultManagerTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/CodeAnalysisResultManagerTests.cs
@@ -222,6 +222,34 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             remappedPathPrefixes[0].Item2.Should().Be(@"C:\Users\Mary");
         }
 
+        [Fact]
+        public void CodeAnalysisResultManager_CacheUriBasePaths_EnsuresTrailingSlash()
+        {
+            var run = new Run
+            {
+                OriginalUriBaseIds = new Dictionary<string, ArtifactLocation>
+                {
+                    ["HAS_SLASH"] = new ArtifactLocation
+                    {
+                        Uri = new Uri("file:///C:/code/myProject/src/")
+                    },
+                    ["NO_SLASH"] = new ArtifactLocation
+                    {
+                        Uri = new Uri("file:///C:/code/myProject/test")
+                    }
+                }
+            };
+
+            var resultManager = new CodeAnalysisResultManager(fileSystem: null, promptForResolvedPathDelegate: null);
+
+            RunDataCache dataCache = new RunDataCache(run);
+            resultManager.RunDataCaches.Add(++resultManager.CurrentRunId, dataCache);
+            resultManager.CacheUriBasePaths(run);
+
+            resultManager.CurrentRunDataCache.OriginalUriBasePaths["HAS_SLASH"].Should().Be("file:///C:/code/myProject/src/");
+            resultManager.CurrentRunDataCache.OriginalUriBasePaths["NO_SLASH"].Should().Be("file:///C:/code/myProject/test/");
+        }
+
         private string FakePromptForResolvedPath(string fullPathFromLogFile)
         {
             ++this.numPrompts;

--- a/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Sarif.Viewer
             {
                 var target = CurrentRunDataCache.OriginalUriBasePaths as Dictionary<string, Uri>;
                 // This line assumes an empty dictionary
-                source.ToList().ForEach(x => target.Add(x.Key, x.Value.Uri));
+                source.ToList().ForEach(x => target.Add(x.Key, x.Value.Uri.WithTrailingSlash()));
             }
         }
 

--- a/src/Sarif.Viewer.VisualStudio/Uri.extensions.cs
+++ b/src/Sarif.Viewer.VisualStudio/Uri.extensions.cs
@@ -40,5 +40,15 @@ namespace Microsoft.Sarif.Viewer.Sarif
         {
             return s_httpSchemes.Contains(uri.Scheme);
         }
+
+        public static Uri WithTrailingSlash(this Uri uri)
+        {
+            const string Slash = "/";
+
+            string uriString = uri.ToString();
+            if (!uriString.EndsWith(Slash)) { uriString += Slash; }
+
+            return new Uri(uriString);
+        }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/source.extension.vsixmanifest
+++ b/src/Sarif.Viewer.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Microsoft.Sarif.Viewer.Michael C. Fanning.f17e897a-fd38-4e1f-99db-19fa34a4e184" Version="2.1.8" Language="en-US" Publisher="Microsoft DevLabs" />
+        <Identity Id="Microsoft.Sarif.Viewer.Michael C. Fanning.f17e897a-fd38-4e1f-99db-19fa34a4e184" Version="2.1.9" Language="en-US" Publisher="Microsoft DevLabs" />
         <DisplayName>Microsoft SARIF Viewer</DisplayName>
         <Description xml:space="preserve">Visual Studio Static Analysis Results Interchange Format (SARIF) log file viewer</Description>
         <License>License.txt</License>

--- a/src/build.props
+++ b/src/build.props
@@ -19,7 +19,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF Viewer for Visual Studio</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix Condition=" '$(VersionPrefix)' == ''">2.1.8</VersionPrefix>
+    <VersionPrefix Condition=" '$(VersionPrefix)' == ''">2.1.9</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == ''"></VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
Also:
- Bring release history up to date and bump version in preparation for next publish.