### PR TITLE
Fix #132, file open does not work in absence of artifactLocation URI.

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/CallTreeTraversalTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/CallTreeTraversalTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             var mockToolWindow = new Mock<IToolWindow>();
             mockToolWindow.Setup(s => s.UpdateSelectionList(It.IsAny<object[]>()));
 
-            CallTree callTree = new CallTree(CodeFlowToTreeConverter.Convert(codeFlow), mockToolWindow.Object);
+            CallTree callTree = new CallTree(CodeFlowToTreeConverter.Convert(codeFlow, run: null), mockToolWindow.Object);
 
             callTree.FindPrevious().Should().Be(null);
             callTree.FindNext().Should().Be(null);
@@ -86,7 +86,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             var mockToolWindow = new Mock<IToolWindow>();
             mockToolWindow.Setup(s => s.UpdateSelectionList(It.IsAny<object[]>()));
 
-            CallTree callTree = new CallTree(CodeFlowToTreeConverter.Convert(codeFlow), mockToolWindow.Object);
+            CallTree callTree = new CallTree(CodeFlowToTreeConverter.Convert(codeFlow, run: null), mockToolWindow.Object);
 
             callTree.SelectedItem = callTree.TopLevelNodes[0];
             callTree.FindPrevious().Should().Be(callTree.TopLevelNodes[0]);

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Models/CallTreeCollectionTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Models/CallTreeCollectionTests.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
             var mockToolWindow = new Mock<IToolWindow>();
             mockToolWindow.Setup(s => s.UpdateSelectionList(It.IsAny<object[]>()));
 
-            CallTree callTree = new CallTree(CodeFlowToTreeConverter.Convert(codeFlow), mockToolWindow.Object);
+            CallTree callTree = new CallTree(CodeFlowToTreeConverter.Convert(codeFlow, run: null), mockToolWindow.Object);
 
             return callTree;
         }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Models/CallTreeTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Models/CallTreeTests.cs
@@ -589,7 +589,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
             var mockToolWindow = new Mock<IToolWindow>();
             mockToolWindow.Setup(s => s.UpdateSelectionList(It.IsAny<object[]>()));
 
-            CallTree callTree = new CallTree(CodeFlowToTreeConverter.Convert(codeFlow), mockToolWindow.Object);
+            CallTree callTree = new CallTree(CodeFlowToTreeConverter.Convert(codeFlow, run: null), mockToolWindow.Object);
 
             return callTree;
         }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ThreadFlowToTreeConverterTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ThreadFlowToTreeConverterTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 }
             });
 
-            List<CallTreeNode> topLevelNodes = CodeFlowToTreeConverter.Convert(codeFlow);
+            List<CallTreeNode> topLevelNodes = CodeFlowToTreeConverter.Convert(codeFlow, run: null);
 
             topLevelNodes.Count.Should().Be(2);
             topLevelNodes[0].Children.Count.Should().Be(4);
@@ -181,7 +181,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             });
 
-            List<CallTreeNode> topLevelNodes = CodeFlowToTreeConverter.Convert(codeFlow);
+            List<CallTreeNode> topLevelNodes = CodeFlowToTreeConverter.Convert(codeFlow, run: null);
 
             topLevelNodes.Count.Should().Be(2);
             topLevelNodes[0].Children.Count.Should().Be(4);
@@ -225,7 +225,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             });
 
-            List<CallTreeNode> topLevelNodes = CodeFlowToTreeConverter.Convert(codeFlow);
+            List<CallTreeNode> topLevelNodes = CodeFlowToTreeConverter.Convert(codeFlow, run: null);
 
             topLevelNodes.Count.Should().Be(3);
             topLevelNodes[0].Children.Should().BeEmpty();

--- a/src/Sarif.Viewer.VisualStudio/CodeFlowToTreeConverter.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeFlowToTreeConverter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.Models;
@@ -9,7 +10,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio
 {
     internal static class CodeFlowToTreeConverter
     {
-        internal static List<CallTreeNode> Convert(CodeFlow codeFlow)
+        internal static List<CallTreeNode> Convert(CodeFlow codeFlow, Run run)
         {
             var root = new CallTreeNode { Children = new List<CallTreeNode>() };
             ThreadFlow threadFlow = codeFlow.ThreadFlows?[0];
@@ -22,6 +23,18 @@ namespace Microsoft.Sarif.Viewer.VisualStudio
 
                 foreach (ThreadFlowLocation location in threadFlow.Locations)
                 {
+                    ArtifactLocation artifactLocation = location.Location.PhysicalLocation?.ArtifactLocation;
+
+                    if (artifactLocation != null)
+                    {
+                        Uri uri = location.Location.PhysicalLocation?.ArtifactLocation?.Uri;
+
+                        if (uri == null && artifactLocation.Index > -1)
+                        {
+                            artifactLocation.Uri = run.Artifacts[artifactLocation.Index].Location.Uri;
+                        }
+                    }
+
                     var newNode = new CallTreeNode
                     {
                         Location = location,

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -44,8 +44,7 @@ namespace Microsoft.Sarif.Viewer
         public SarifErrorListItem(Run run, Result result, string logFilePath, ProjectNameCache projectNameCache) : this()
         {
             _runId = CodeAnalysisResultManager.Instance.CurrentRunId;
-            ReportingDescriptor rule;
-            run.TryGetRule(result.RuleId, out rule);
+            ReportingDescriptor rule = result.GetRule(run);
             Tool = run.Tool.ToToolModel();
             Rule = rule.ToRuleModel(result.RuleId);
             Invocation = run.Invocations?[0]?.ToInvocationModel();
@@ -55,7 +54,7 @@ namespace Microsoft.Sarif.Viewer
             {
                 ShortMessage = ShortMessage.TrimEnd('.');
             }
-            FileName = result.GetPrimaryTargetFile();
+            FileName = result.GetPrimaryTargetFile(run);
             ProjectName = projectNameCache.GetName(FileName);
             Category = result.GetCategory();
             Region = result.GetPrimaryTargetRegion();
@@ -80,7 +79,7 @@ namespace Microsoft.Sarif.Viewer
             {
                 foreach (Location location in result.Locations)
                 {
-                    Locations.Add(location.ToLocationModel());
+                    Locations.Add(location.ToLocationModel(run));
                 }
             }
 
@@ -88,7 +87,7 @@ namespace Microsoft.Sarif.Viewer
             {
                 foreach (Location location in result.RelatedLocations)
                 {
-                    RelatedLocations.Add(location.ToLocationModel());
+                    RelatedLocations.Add(location.ToLocationModel(run));
                 }
             }
 
@@ -96,7 +95,7 @@ namespace Microsoft.Sarif.Viewer
             {
                 foreach (CodeFlow codeFlow in result.CodeFlows)
                 {
-                    CallTrees.Add(codeFlow.ToCallTree());
+                    CallTrees.Add(codeFlow.ToCallTree(run));
                 }
 
                 CallTrees.Verbosity = 100;

--- a/src/Sarif.Viewer.VisualStudio/Sarif/CodeFlow.extensions.cs
+++ b/src/Sarif.Viewer.VisualStudio/Sarif/CodeFlow.extensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Sarif.Viewer.Sarif
 {
     static class CodeFlowExtensions
     {
-        public static LocationCollection ToThreadFlowLocationCollection(this CodeFlow codeFlow)
+        public static LocationCollection ToThreadFlowLocationCollection(this CodeFlow codeFlow, Run run)
         {
             if (codeFlow == null)
             {
@@ -28,21 +28,21 @@ namespace Microsoft.Sarif.Viewer.Sarif
                     // far as SARIF producers). For now we skip these.
                     if (location.Location?.PhysicalLocation == null) { continue; }
 
-                    model.Add(location.ToLocationModel());
+                    model.Add(location.ToLocationModel(run));
                 }
             }
 
             return model;
         }
 
-        public static CallTree ToCallTree(this CodeFlow codeFlow)
+        public static CallTree ToCallTree(this CodeFlow codeFlow, Run run)
         {
             if (codeFlow.ThreadFlows?[0]?.Locations?.Count == 0)
             {
                 return null;
             }
 
-            List<CallTreeNode> topLevelNodes = CodeFlowToTreeConverter.Convert(codeFlow);
+            List<CallTreeNode> topLevelNodes = CodeFlowToTreeConverter.Convert(codeFlow, run);
 
             return new CallTree(topLevelNodes, SarifViewerPackage.SarifToolWindow);
         }

--- a/src/Sarif.Viewer.VisualStudio/Sarif/Location.extensions.cs
+++ b/src/Sarif.Viewer.VisualStudio/Sarif/Location.extensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Sarif.Viewer.Sarif
 {
     static class LocationExtensions
     {
-        public static LocationModel ToLocationModel(this Location location)
+        public static LocationModel ToLocationModel(this Location location, Run run)
         {
             var model = new LocationModel();
             PhysicalLocation physicalLocation = location.PhysicalLocation;
@@ -20,6 +20,12 @@ namespace Microsoft.Sarif.Viewer.Sarif
                 model.Region = physicalLocation.Region;
 
                 Uri uri = physicalLocation.ArtifactLocation.Uri;
+
+                int artifactIndex = physicalLocation.ArtifactLocation.Index;
+                if (uri == null && artifactIndex > -1)
+                {
+                    uri = run.Artifacts[artifactIndex].Location.Uri;
+                }
 
                 if (uri != null)
                 {

--- a/src/Sarif.Viewer.VisualStudio/Sarif/Result.extensions.cs
+++ b/src/Sarif.Viewer.VisualStudio/Sarif/Result.extensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Sarif.Viewer.Sarif
     {
         const string NOTARGETFILEPATH = "NOTARGETFILEPATH";
 
-        public static string GetPrimaryTargetFile(this Result result)
+        public static string GetPrimaryTargetFile(this Result result, Run run)
         {
             if (result == null)
             {
@@ -26,7 +26,20 @@ namespace Microsoft.Sarif.Viewer.Sarif
 
             if (primaryLocation.PhysicalLocation?.ArtifactLocation != null)
             {
-                return primaryLocation.PhysicalLocation.ArtifactLocation.Uri.ToPath();
+                Uri uri = primaryLocation.PhysicalLocation.ArtifactLocation.Uri;
+
+                if (uri == null)
+                {
+                    ArtifactLocation artifactLocation = primaryLocation.PhysicalLocation.ArtifactLocation;
+
+                    if (artifactLocation.Index > -1)
+                    {
+                        artifactLocation = run.Artifacts[artifactLocation.Index].Location;
+                        uri = artifactLocation.Uri;
+                    }
+                }
+
+                return uri.ToPath();
             }
             else if (primaryLocation.LogicalLocation?.FullyQualifiedName != null)
             {

--- a/src/Sarif.Viewer.VisualStudio/Sarif/ThreadFlowLocation.extensions.cs
+++ b/src/Sarif.Viewer.VisualStudio/Sarif/ThreadFlowLocation.extensions.cs
@@ -8,10 +8,10 @@ namespace Microsoft.Sarif.Viewer.Sarif
 {
     static class ThreadFlowLocationExtensions
     {
-        public static LocationModel ToLocationModel(this ThreadFlowLocation threadFlowLocation)
+        public static LocationModel ToLocationModel(this ThreadFlowLocation threadFlowLocation, Run run)
         {
             var model = threadFlowLocation.Location != null
-                ? threadFlowLocation.Location.ToLocationModel()
+                ? threadFlowLocation.Location.ToLocationModel(run)
                 : new LocationModel();
 
             model.IsEssential = threadFlowLocation.Importance == ThreadFlowLocationImportance.Essential;


### PR DESCRIPTION
@lgolding, this is a much needed fix. Could use a test but I don't have time to work on one. 

What we really need here is better helper support in the SDK for retrieving a comprehensively populated location object, analogous to the Result.GetRule(Run) helper.