### PR TITLE
Upgrade to SARIF SDK version 2.2.5

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -2,6 +2,7 @@
 
 ## **v2.1.9** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
 * FEATURE: Display messages for locations and related locations in the Locations tab.
+* FEATURE: Updated to Sarif SDK 2.2.5
 * BUGFIX: Display locations and related locations in the correct order in the Locations tab.
 * BUGFIX: Display default rule level in the Info tab. [#92](https://github.com/microsoft/sarif-visualstudio-extension/issues/92)
 * BUGFIX: Navigate to inline links with integer targets even if the target location has no region.

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
@@ -17,8 +17,8 @@
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="CommandLine, Version=2.7.82.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
-      <HintPath>..\packages\CommandLineParser.2.7.82\lib\net461\CommandLine.dll</HintPath>
+    <Reference Include="CommandLine, Version=2.5.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineParser.2.5.0\lib\net461\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="CsvHelper, Version=7.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
       <HintPath>..\packages\CsvHelper.7.1.1\lib\net45\CsvHelper.dll</HintPath>
@@ -129,16 +129,16 @@
     <Reference Include="Moq, Version=4.8.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.8.3\lib\net45\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="Sarif, Version=2.2.5.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sarif.Sdk.2.2.5\lib\net461\Sarif.dll</HintPath>
+    <Reference Include="Sarif, Version=2.1.13.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Sdk.2.1.13\lib\net461\Sarif.dll</HintPath>
     </Reference>
-    <Reference Include="Sarif.Driver, Version=2.2.5.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sarif.Driver.2.2.5\lib\net461\Sarif.Driver.dll</HintPath>
+    <Reference Include="Sarif.Driver, Version=2.1.13.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Driver.2.1.13\lib\net461\Sarif.Driver.dll</HintPath>
     </Reference>
     <Reference Include="StreamJsonRpc, Version=1.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\StreamJsonRpc.1.3.23\lib\net45\StreamJsonRpc.dll</HintPath>

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
@@ -17,8 +17,8 @@
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="CommandLine, Version=2.5.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
-      <HintPath>..\packages\CommandLineParser.2.5.0\lib\net461\CommandLine.dll</HintPath>
+    <Reference Include="CommandLine, Version=2.7.82.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineParser.2.7.82\lib\net461\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="CsvHelper, Version=7.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
       <HintPath>..\packages\CsvHelper.7.1.1\lib\net45\CsvHelper.dll</HintPath>
@@ -129,16 +129,16 @@
     <Reference Include="Moq, Version=4.8.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.8.3\lib\net45\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="Sarif, Version=2.1.13.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sarif.Sdk.2.1.13\lib\net461\Sarif.dll</HintPath>
+    <Reference Include="Sarif, Version=2.2.5.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Sdk.2.2.5\lib\net461\Sarif.dll</HintPath>
     </Reference>
-    <Reference Include="Sarif.Driver, Version=2.1.13.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sarif.Driver.2.1.13\lib\net461\Sarif.Driver.dll</HintPath>
+    <Reference Include="Sarif.Driver, Version=2.2.5.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Driver.2.2.5\lib\net461\Sarif.Driver.dll</HintPath>
     </Reference>
     <Reference Include="StreamJsonRpc, Version=1.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\StreamJsonRpc.1.3.23\lib\net45\StreamJsonRpc.dll</HintPath>

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/packages.config
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.3.1" targetFramework="net461" />
-  <package id="CommandLineParser" version="2.5.0" targetFramework="net461" />
+  <package id="CommandLineParser" version="2.7.82" targetFramework="net461" />
   <package id="CsvHelper" version="7.1.1" targetFramework="net461" />
   <package id="FluentAssertions" version="5.4.1" targetFramework="net461" />
   <package id="Microsoft.ApplicationInsights" version="2.6.4" targetFramework="net461" />
@@ -30,9 +30,9 @@
   <package id="Microsoft.VisualStudio.Utilities" version="15.7.27703" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.58" targetFramework="net461" />
   <package id="Moq" version="4.8.3" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
-  <package id="Sarif.Driver" version="2.1.13" targetFramework="net461" />
-  <package id="Sarif.Sdk" version="2.1.13" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
+  <package id="Sarif.Driver" version="2.2.5" targetFramework="net461" />
+  <package id="Sarif.Sdk" version="2.2.5" targetFramework="net461" />
   <package id="StreamJsonRpc" version="1.3.23" targetFramework="net461" />
   <package id="System.Collections" version="4.3.0" targetFramework="net461" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net461" />

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/packages.config
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.3.1" targetFramework="net461" />
-  <package id="CommandLineParser" version="2.7.82" targetFramework="net461" />
+  <package id="CommandLineParser" version="2.5.0" targetFramework="net461" />
   <package id="CsvHelper" version="7.1.1" targetFramework="net461" />
   <package id="FluentAssertions" version="5.4.1" targetFramework="net461" />
   <package id="Microsoft.ApplicationInsights" version="2.6.4" targetFramework="net461" />
@@ -30,9 +30,9 @@
   <package id="Microsoft.VisualStudio.Utilities" version="15.7.27703" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.58" targetFramework="net461" />
   <package id="Moq" version="4.8.3" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
-  <package id="Sarif.Driver" version="2.2.5" targetFramework="net461" />
-  <package id="Sarif.Sdk" version="2.2.5" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+  <package id="Sarif.Driver" version="2.1.13" targetFramework="net461" />
+  <package id="Sarif.Sdk" version="2.1.13" targetFramework="net461" />
   <package id="StreamJsonRpc" version="1.3.23" targetFramework="net461" />
   <package id="System.Collections" version="4.3.0" targetFramework="net461" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net461" />

--- a/src/Sarif.Viewer.VisualStudio/CodeFlowToTreeConverter.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeFlowToTreeConverter.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio
 
                 foreach (ThreadFlowLocation location in threadFlow.Locations)
                 {
-                    ArtifactLocation artifactLocation = location.Location?.PhysicalLocation?.ArtifactLocation;
+                    ArtifactLocation artifactLocation = location.Location.PhysicalLocation?.ArtifactLocation;
 
                     if (artifactLocation != null)
                     {

--- a/src/Sarif.Viewer.VisualStudio/CodeFlowToTreeConverter.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeFlowToTreeConverter.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio
 
                 foreach (ThreadFlowLocation location in threadFlow.Locations)
                 {
-                    ArtifactLocation artifactLocation = location.Location.PhysicalLocation?.ArtifactLocation;
+                    ArtifactLocation artifactLocation = location.Location?.PhysicalLocation?.ArtifactLocation;
 
                     if (artifactLocation != null)
                     {

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/SarifSnapshot.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/SarifSnapshot.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                 }
                 else if (columnName == "suppressionstate")
                 {
-                    content = error.SuppressionState != SuppressionState.None ? "Suppressed" : "Active";
+                    content = error.SuppressionStatus != SuppressionStatus.None ? "Suppressed" : "Active";
                 }
             }
 

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/SarifSnapshot.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/SarifSnapshot.cs
@@ -141,9 +141,9 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                         content = error.Rule.Id + ":" + error.Rule.Name;
                     }
                 }
-                else if (columnName == "suppressionstate")
+                else if (columnName == "suppressionstatus")
                 {
-                    content = error.SuppressionState != SuppressionState.None ? "Suppressed" : "Active";
+                    content = error.SuppressionStatus != SuppressionStatus.None ? "Suppressed" : "Active";
                 }
             }
 

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/SarifSnapshot.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/SarifSnapshot.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                 }
                 else if (columnName == "suppressionstate")
                 {
-                    content = error.SuppressionStatus != SuppressionStatus.None ? "Suppressed" : "Active";
+                    content = error.SuppressionState != SuppressionState.None ? "Suppressed" : "Active";
                 }
             }
 

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -59,9 +59,9 @@ namespace Microsoft.Sarif.Viewer
             Category = result.GetCategory();
             Region = result.GetPrimaryTargetRegion();
             Level = result.Level != FailureLevel.Warning ? result.Level : Rule.FailureLevel;
-            SuppressionStatus = (result.Suppressions != null && result.Suppressions.Count > 0) ?
-                result.Suppressions[0].Status :
-                SuppressionStatus.None;
+            SuppressionState = (result.Suppressions != null && result.Suppressions.Count > 0) ?
+                result.Suppressions[0].State :
+                SuppressionState.None;
             LogFilePath = logFilePath;
 
             if (Region != null)
@@ -244,9 +244,9 @@ namespace Microsoft.Sarif.Viewer
         [Browsable(false)]
         public string HelpLink { get; set; }
 
-        [DisplayName("Suppression status")]
+        [DisplayName("Suppression state")]
         [ReadOnly(true)]
-        public SuppressionStatus SuppressionStatus { get; set; }
+        public SuppressionState SuppressionState { get; set; }
 
         [DisplayName("Log file")]
         [ReadOnly(true)]

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -59,9 +59,9 @@ namespace Microsoft.Sarif.Viewer
             Category = result.GetCategory();
             Region = result.GetPrimaryTargetRegion();
             Level = result.Level != FailureLevel.Warning ? result.Level : Rule.FailureLevel;
-            SuppressionState = (result.Suppressions != null && result.Suppressions.Count > 0) ?
-                result.Suppressions[0].State :
-                SuppressionState.None;
+            SuppressionStatus = (result.Suppressions != null && result.Suppressions.Count > 0) ?
+                result.Suppressions[0].Status :
+                SuppressionStatus.None;
             LogFilePath = logFilePath;
 
             if (Region != null)
@@ -244,9 +244,9 @@ namespace Microsoft.Sarif.Viewer
         [Browsable(false)]
         public string HelpLink { get; set; }
 
-        [DisplayName("Suppression state")]
+        [DisplayName("Suppression status")]
         [ReadOnly(true)]
-        public SuppressionState SuppressionState { get; set; }
+        public SuppressionStatus SuppressionStatus { get; set; }
 
         [DisplayName("Log file")]
         [ReadOnly(true)]

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -161,8 +161,8 @@
     </VSCTCompile>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="CommandLine, Version=2.5.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
-      <HintPath>..\packages\CommandLineParser.2.5.0\lib\net461\CommandLine.dll</HintPath>
+    <Reference Include="CommandLine, Version=2.7.82.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineParser.2.7.82\lib\net461\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="CsvHelper, Version=7.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
       <HintPath>..\packages\CsvHelper.7.1.1\lib\net45\CsvHelper.dll</HintPath>
@@ -295,21 +295,20 @@
       <HintPath>..\packages\Microsoft.VisualStudio.Validation.15.3.58\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="PresentationFramework.Aero2" />
-    <Reference Include="Sarif, Version=2.1.13.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sarif.Sdk.2.1.13\lib\net461\Sarif.dll</HintPath>
+    <Reference Include="Sarif, Version=2.2.5.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Sdk.2.2.5\lib\net461\Sarif.dll</HintPath>
     </Reference>
-    <Reference Include="Sarif.Converters, Version=2.1.13.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sarif.Converters.2.1.13\lib\net461\Sarif.Converters.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Sarif.Converters, Version=2.2.5.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Converters.2.2.5\lib\net461\Sarif.Converters.dll</HintPath>
     </Reference>
-    <Reference Include="Sarif.Driver, Version=2.1.13.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sarif.Driver.2.1.13\lib\net461\Sarif.Driver.dll</HintPath>
+    <Reference Include="Sarif.Driver, Version=2.2.5.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Driver.2.2.5\lib\net461\Sarif.Driver.dll</HintPath>
     </Reference>
     <Reference Include="stdole, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -161,8 +161,8 @@
     </VSCTCompile>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="CommandLine, Version=2.7.82.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
-      <HintPath>..\packages\CommandLineParser.2.7.82\lib\net461\CommandLine.dll</HintPath>
+    <Reference Include="CommandLine, Version=2.5.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineParser.2.5.0\lib\net461\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="CsvHelper, Version=7.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
       <HintPath>..\packages\CsvHelper.7.1.1\lib\net45\CsvHelper.dll</HintPath>
@@ -295,20 +295,21 @@
       <HintPath>..\packages\Microsoft.VisualStudio.Validation.15.3.58\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="PresentationFramework.Aero2" />
-    <Reference Include="Sarif, Version=2.2.5.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sarif.Sdk.2.2.5\lib\net461\Sarif.dll</HintPath>
+    <Reference Include="Sarif, Version=2.1.13.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Sdk.2.1.13\lib\net461\Sarif.dll</HintPath>
     </Reference>
-    <Reference Include="Sarif.Converters, Version=2.2.5.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sarif.Converters.2.2.5\lib\net461\Sarif.Converters.dll</HintPath>
+    <Reference Include="Sarif.Converters, Version=2.1.13.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Converters.2.1.13\lib\net461\Sarif.Converters.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sarif.Driver, Version=2.2.5.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sarif.Driver.2.2.5\lib\net461\Sarif.Driver.dll</HintPath>
+    <Reference Include="Sarif.Driver, Version=2.1.13.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Driver.2.1.13\lib\net461\Sarif.Driver.dll</HintPath>
     </Reference>
     <Reference Include="stdole, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>

--- a/src/Sarif.Viewer.VisualStudio/packages.config
+++ b/src/Sarif.Viewer.VisualStudio/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommandLineParser" version="2.7.82" targetFramework="net461" />
+  <package id="CommandLineParser" version="2.5.0" targetFramework="net461" />
   <package id="CsvHelper" version="7.1.1" targetFramework="net461" />
   <package id="EnvDTE" version="8.0.2" targetFramework="net461" />
   <package id="EnvDTE80" version="8.0.3" targetFramework="net461" />
@@ -37,10 +37,10 @@
   <package id="Microsoft.VisualStudio.Utilities" version="15.7.27703" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.58" targetFramework="net461" />
   <package id="Microsoft.VSSDK.BuildTools" version="15.7.109" targetFramework="net461" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
-  <package id="Sarif.Converters" version="2.2.5" targetFramework="net461" />
-  <package id="Sarif.Driver" version="2.2.5" targetFramework="net461" />
-  <package id="Sarif.Sdk" version="2.2.5" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+  <package id="Sarif.Converters" version="2.1.13" targetFramework="net461" />
+  <package id="Sarif.Driver" version="2.1.13" targetFramework="net461" />
+  <package id="Sarif.Sdk" version="2.1.13" targetFramework="net461" />
   <package id="stdole" version="7.0.3303" targetFramework="net461" />
   <package id="StreamJsonRpc" version="1.3.23" targetFramework="net461" />
   <package id="System.Collections" version="4.0.11-rc2-24027" targetFramework="net461" />

--- a/src/Sarif.Viewer.VisualStudio/packages.config
+++ b/src/Sarif.Viewer.VisualStudio/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommandLineParser" version="2.5.0" targetFramework="net461" />
+  <package id="CommandLineParser" version="2.7.82" targetFramework="net461" />
   <package id="CsvHelper" version="7.1.1" targetFramework="net461" />
   <package id="EnvDTE" version="8.0.2" targetFramework="net461" />
   <package id="EnvDTE80" version="8.0.3" targetFramework="net461" />
@@ -37,10 +37,10 @@
   <package id="Microsoft.VisualStudio.Utilities" version="15.7.27703" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.58" targetFramework="net461" />
   <package id="Microsoft.VSSDK.BuildTools" version="15.7.109" targetFramework="net461" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
-  <package id="Sarif.Converters" version="2.1.13" targetFramework="net461" />
-  <package id="Sarif.Driver" version="2.1.13" targetFramework="net461" />
-  <package id="Sarif.Sdk" version="2.1.13" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
+  <package id="Sarif.Converters" version="2.2.5" targetFramework="net461" />
+  <package id="Sarif.Driver" version="2.2.5" targetFramework="net461" />
+  <package id="Sarif.Sdk" version="2.2.5" targetFramework="net461" />
   <package id="stdole" version="7.0.3303" targetFramework="net461" />
   <package id="StreamJsonRpc" version="1.3.23" targetFramework="net461" />
   <package id="System.Collections" version="4.0.11-rc2-24027" targetFramework="net461" />


### PR DESCRIPTION
Changes:
- updating sarif packages from `src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj`
- updating sarif packages from `src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj`
- updating test to prevent null reference exception
- updated `SuprresionState` to `SuppressionStatus`
- added to release notes 2.1.9