### PR TITLE
Add option for cleaning results to prevent clearing

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,5 +1,8 @@
 # SARIF Viewer Visual Studio extension Release History
 
+## **v2.1.10** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
+* BUGFIX: Ensure "load logs" API shows results from all log files. [#163](https://github.com/microsoft/sarif-visualstudio-extension/issues/163)
+
 ## **v2.1.9** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
 * FEATURE: Open and close multiple SARIF files at once.
 * FEATURE: Display messages for locations and related locations in the Locations tab.

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifFileWithContentsTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifFileWithContentsTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
     [Collection("SarifObjectTests")]
     public class SarifFileWithContentsTests : SarifViewerPackageUnitTests
     {
-        private const int RunId = 1;
+        private const int RunId = 0;
         private const string Key1 = "/item.cpp#fragment";
         private const string Key2 = "/binary.cpp";
         private const string Key3 = "/text.cpp";

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/TestUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/TestUtilities.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             InitializeTestEnvironment();
             CodeAnalysisResultManager.Instance.CurrentRunId = 0;
 
-            ErrorListService.ProcessSarifLog(sarifLog, "", null, showMessageOnNoResults: true);
+            ErrorListService.ProcessSarifLog(sarifLog, "", null, showMessageOnNoResults: true, cleanErrors: true);
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/LoadSarifLogService.cs
+++ b/src/Sarif.Viewer.VisualStudio/LoadSarifLogService.cs
@@ -34,19 +34,9 @@ namespace Microsoft.Sarif.Viewer
         /// <inheritdoc/>
         public void LoadSarifLogs(IEnumerable<string> paths, bool promptOnSchemaUpgrade)
         {
-            if (!paths.Any())
-            {
-                return;
-            }
-
             var cleanErrors = true;
-            foreach (string path in paths)
+            foreach (string path in paths.Where((path) => !string.IsNullOrEmpty(path)))
             {
-                if (string.IsNullOrWhiteSpace(path))
-                {
-                    continue;
-                }
-
                 ErrorListService.ProcessLogFile(path, SarifViewerPackage.Dte.Solution, ToolFormat.None, promptOnLogConversions: false, cleanErrors: cleanErrors);
                 cleanErrors = false;
             }

--- a/src/Sarif.Viewer.VisualStudio/LoadSarifLogService.cs
+++ b/src/Sarif.Viewer.VisualStudio/LoadSarifLogService.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.Sarif.Converters;

--- a/src/Sarif.Viewer.VisualStudio/LoadSarifLogService.cs
+++ b/src/Sarif.Viewer.VisualStudio/LoadSarifLogService.cs
@@ -19,13 +19,13 @@ namespace Microsoft.Sarif.Viewer
                 return;
             }
 
-            ErrorListService.ProcessLogFile(path, SarifViewerPackage.Dte.Solution, ToolFormat.None, promptOnSchemaUpgrade);
+            ErrorListService.ProcessLogFile(path, SarifViewerPackage.Dte.Solution, ToolFormat.None, promptOnSchemaUpgrade, cleanErrors: true);
         }
 
         /// <inheritdoc/>
         public void LoadSarifLog(string path)
         {
-            ErrorListService.ProcessLogFile(path, SarifViewerPackage.Dte.Solution, ToolFormat.None, promptOnLogConversions: true);
+            ErrorListService.ProcessLogFile(path, SarifViewerPackage.Dte.Solution, ToolFormat.None, promptOnLogConversions: true, cleanErrors: true);
         }
 
         /// <inheritdoc/>
@@ -39,9 +39,16 @@ namespace Microsoft.Sarif.Viewer
                 return;
             }
 
+            var cleanErrors = true;
             foreach (string path in paths)
             {
-                this.LoadSarifLog(path, promptOnSchemaUpgrade);
+                if (string.IsNullOrWhiteSpace(path))
+                {
+                    continue;
+                }
+
+                ErrorListService.ProcessLogFile(path, SarifViewerPackage.Dte.Solution, ToolFormat.None, promptOnLogConversions: false, cleanErrors: cleanErrors);
+                cleanErrors = false;
             }
         }
     }

--- a/src/Sarif.Viewer.VisualStudio/OpenLogFileCommands.cs
+++ b/src/Sarif.Viewer.VisualStudio/OpenLogFileCommands.cs
@@ -279,7 +279,7 @@ namespace Microsoft.Sarif.Viewer
 
             try
             {
-                ErrorListService.ProcessLogFile(logFile, SarifViewerPackage.Dte.Solution, toolFormat);
+                ErrorListService.ProcessLogFile(logFile, SarifViewerPackage.Dte.Solution, toolFormat, promptOnLogConversions: true, cleanErrors: true);
             }
             catch (InvalidOperationException)
             {

--- a/src/Sarif.Viewer.VisualStudio/Properties/AssemblyInfo.cs
+++ b/src/Sarif.Viewer.VisualStudio/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("Microsoft SARIF Viewer for Visual Studio")]
 [assembly: AssemblyDescription("Visual Studio Extension for viewing SARIF log files")]
 
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
+[assembly: AssemblyVersion("2.1.10.0")]
+[assembly: AssemblyFileVersion("2.1.10.0")]
 
 [assembly: InternalsVisibleTo("Sarif.Viewer.VisualStudio.UnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100433fbf156abe9718142bdbd48a440e779a1b708fd21486ee0ae536f4c548edf8a7185c1e3ac89ceef76c15b8cc2497906798779a59402f9b9e27281fb15e7111566cdc9a9f8326301d45320623c5222089cf4d0013f365ae729fb0a9c9d15138042825cd511a0f3d4887a7b92f4c2749f81b410813d297b73244cf64995effb1")]

--- a/src/Sarif.Viewer.VisualStudio/SarifEditorFactory.cs
+++ b/src/Sarif.Viewer.VisualStudio/SarifEditorFactory.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Security.Permissions;
+using Microsoft.CodeAnalysis.Sarif.Converters;
 using Microsoft.Sarif.Viewer.ErrorList;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
@@ -205,7 +206,7 @@ namespace Microsoft.Sarif.Viewer
             {
                 TelemetryProvider.WriteEvent(TelemetryEvent.LogFileOpenedByEditor,
                                              TelemetryProvider.CreateKeyValuePair("Format", "SARIF"));
-                ErrorListService.ProcessLogFile(pszMkDocument, SarifViewerPackage.Dte.Solution);
+                ErrorListService.ProcessLogFile(pszMkDocument, SarifViewerPackage.Dte.Solution, ToolFormat.None, promptOnLogConversions: true, cleanErrors: true);
             }
 
             return VSConstants.S_OK;

--- a/src/Sarif.Viewer.VisualStudio/source.extension.vsixmanifest
+++ b/src/Sarif.Viewer.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Microsoft.Sarif.Viewer.Michael C. Fanning.f17e897a-fd38-4e1f-99db-19fa34a4e184" Version="2.1.9" Language="en-US" Publisher="Microsoft DevLabs" />
+        <Identity Id="Microsoft.Sarif.Viewer.Michael C. Fanning.f17e897a-fd38-4e1f-99db-19fa34a4e184" Version="2.1.10" Language="en-US" Publisher="Microsoft DevLabs" />
         <DisplayName>Microsoft SARIF Viewer</DisplayName>
         <Description xml:space="preserve">Visual Studio Static Analysis Results Interchange Format (SARIF) log file viewer</Description>
         <License>License.txt</License>


### PR DESCRIPTION
This addresses issue #163.

The issue was simply that the LoadSarifLogs implementation was relying on LoadSarifLog which always cleared the error list.

LoadSarifLogs does not leverage LoadSarifLog to process the logs in a loop, and an option as added to the error service indicating whether to clear previous errors when it processes a log.