### PR TITLE
Set correct version number in build.props so interop assembly gets proper version

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,4 +1,7 @@
 # SARIF Viewer Visual Studio extension Release History
+## **v2.1.13** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
+* BUGFIX: Bump version and ensure all assemblies have correct version. [#180](https://github.com/microsoft/sarif-visualstudio-extension/issues/180)
+
 ## **v2.1.12** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
 * BUGFIX: Handle multi-select from Visual Studio's open file dialog. [#174](https://github.com/microsoft/sarif-visualstudio-extension/issues/174), [#170](https://github.com/microsoft/sarif-visualstudio-extension/issues/170), [#169](https://github.com/microsoft/sarif-visualstudio-extension/issues/169), [#168](https://github.com/microsoft/sarif-visualstudio-extension/issues/168)
 

--- a/src/Sarif.Viewer.VisualStudio.sln
+++ b/src/Sarif.Viewer.VisualStudio.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.779
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30413.136
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sarif.Viewer.VisualStudio", "Sarif.Viewer.VisualStudio\Sarif.Viewer.VisualStudio.csproj", "{689AF24B-33F0-44E9-AA2E-FACA775736A8}"
 EndProject
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\BeforeBuild.cmd = ..\BeforeBuild.cmd
 		build.common.props = build.common.props
 		build.netfx-only.props = build.netfx-only.props
+		build.props = build.props
 		..\BuildAndTest.cmd = ..\BuildAndTest.cmd
 		ReleaseHistory.md = ReleaseHistory.md
 		..\RunUnitTests.ps1 = ..\RunUnitTests.ps1

--- a/src/Sarif.Viewer.VisualStudio/Properties/AssemblyInfo.cs
+++ b/src/Sarif.Viewer.VisualStudio/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("Microsoft SARIF Viewer for Visual Studio")]
 [assembly: AssemblyDescription("Visual Studio Extension for viewing SARIF log files")]
 
-[assembly: AssemblyVersion("2.1.12.0")]
-[assembly: AssemblyFileVersion("2.1.12.0")]
+[assembly: AssemblyVersion("2.1.13.0")]
+[assembly: AssemblyFileVersion("2.1.13.0")]
 
 [assembly: InternalsVisibleTo("Sarif.Viewer.VisualStudio.UnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100433fbf156abe9718142bdbd48a440e779a1b708fd21486ee0ae536f4c548edf8a7185c1e3ac89ceef76c15b8cc2497906798779a59402f9b9e27281fb15e7111566cdc9a9f8326301d45320623c5222089cf4d0013f365ae729fb0a9c9d15138042825cd511a0f3d4887a7b92f4c2749f81b410813d297b73244cf64995effb1")]

--- a/src/Sarif.Viewer.VisualStudio/source.extension.vsixmanifest
+++ b/src/Sarif.Viewer.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Microsoft.Sarif.Viewer.Michael C. Fanning.f17e897a-fd38-4e1f-99db-19fa34a4e184" Version="2.1.12" Language="en-US" Publisher="Microsoft DevLabs" />
+        <Identity Id="Microsoft.Sarif.Viewer.Michael C. Fanning.f17e897a-fd38-4e1f-99db-19fa34a4e184" Version="2.1.13" Language="en-US" Publisher="Microsoft DevLabs" />
         <DisplayName>Microsoft SARIF Viewer</DisplayName>
         <Description xml:space="preserve">Visual Studio Static Analysis Results Interchange Format (SARIF) log file viewer</Description>
         <License>License.txt</License>

--- a/src/build.props
+++ b/src/build.props
@@ -19,7 +19,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF Viewer for Visual Studio</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix Condition=" '$(VersionPrefix)' == ''">2.1.10</VersionPrefix>
+    <VersionPrefix Condition=" '$(VersionPrefix)' == ''">2.1.12</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == ''"></VersionSuffix>
   </PropertyGroup>
 

--- a/src/build.props
+++ b/src/build.props
@@ -19,7 +19,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF Viewer for Visual Studio</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix Condition=" '$(VersionPrefix)' == ''">2.1.12</VersionPrefix>
+    <VersionPrefix Condition=" '$(VersionPrefix)' == ''">2.1.13</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == ''"></VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
The pull request #180 missed one file that sets the version number for the API interop assembly (build.props).

This change addresses so a new Nuget package can be published with the proper version.