### PR TITLE
Prevent event loops when navigating caret and making selections in tool window

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,4 +1,7 @@
 # SARIF Viewer Visual Studio extension Release History
+## **v2.1.14** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
+* BUGFIX: Prevent event loops when navigating editor and selecting items in SARIF tool window. [#183](https://github.com/microsoft/sarif-visualstudio-extension/issues/183)
+
 ## **v2.1.13** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
 * BUGFIX: Bump version and ensure all assemblies have correct version. [#180](https://github.com/microsoft/sarif-visualstudio-extension/issues/180)
 

--- a/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
@@ -309,7 +309,7 @@ namespace Microsoft.Sarif.Viewer
                         }
                         catch (WebException wex)
                         {
-                            VsShellUtilities.ShowMessageBox(Microsoft.VisualStudio.Shell.ServiceProvider.GlobalProvider,
+                            VsShellUtilities.ShowMessageBox(ServiceProvider.GlobalProvider,
                                        Resources.DownloadFail_DialogMessage + Environment.NewLine + wex.Message,
                                        null, // title
                                        OLEMSGICON.OLEMSGICON_CRITICAL,
@@ -603,7 +603,7 @@ namespace Microsoft.Sarif.Viewer
 
         public int OnAfterDocumentWindowHide(uint docCookie, IVsWindowFrame pFrame)
         {
-            DetachFromDocumentChanges(docCookie);
+            DetachFromDocumentChanges();
             return S_OK;
         }
 
@@ -674,13 +674,13 @@ namespace Microsoft.Sarif.Viewer
         }
 
         /// <summary>
-        /// Try to get documentname for current document with <param name="docCookie" />
+        /// Try to get document name for current document with <param name="docCookie" />
         /// and invoke attach for each item in analysis results collection. 
         /// </summary>
         private void AttachToDocumentChanges(uint docCookie, IVsWindowFrame pFrame)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            string documentName = GetDocumentName(docCookie, pFrame);
+            string documentName = GetDocumentName(docCookie);
 
             if (!string.IsNullOrEmpty(documentName))
             {
@@ -690,7 +690,7 @@ namespace Microsoft.Sarif.Viewer
                     {
                         foreach (SarifErrorListItem sarifError in RunDataCaches[key].SarifErrors)
                         {
-                            sarifError.AttachToDocument(documentName, (long)docCookie, pFrame);
+                            sarifError.TryAttachToDocument(documentName, (long)docCookie, pFrame);
                         }
                     }
                 }
@@ -700,7 +700,7 @@ namespace Microsoft.Sarif.Viewer
         /// <summary>
         /// Invoke detach for each item in analysis results collection
         /// </summary>
-        private void DetachFromDocumentChanges(uint docCookie)
+        private void DetachFromDocumentChanges()
         {
             if (RunDataCaches != null)
             {
@@ -708,7 +708,7 @@ namespace Microsoft.Sarif.Viewer
                 {
                     foreach (SarifErrorListItem sarifError in RunDataCaches[key].SarifErrors)
                     {
-                        sarifError.DetachFromDocument((long)docCookie);
+                        sarifError.DetachFromDocument();
                     }
                 }
             }
@@ -737,13 +737,13 @@ namespace Microsoft.Sarif.Viewer
                         }
 
                         // Detach from document.
-                        DetachFromDocumentChanges(cookies[0]);
+                        DetachFromDocumentChanges();
                     }
                 }
             }
         }
 
-        private string GetDocumentName(uint docCookie, IVsWindowFrame pFrame)
+        private string GetDocumentName(uint docCookie)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
             string documentName = null;

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListCommand.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListCommand.cs
@@ -98,8 +98,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             switch (menuCommand.CommandID.ID)
             {
                 case ClearSarifResultsCommandId:
-                    SarifTableDataSource.Instance.CleanAllErrors();
-                    CodeAnalysisResultManager.Instance.RunDataCaches.Clear();
+                    ErrorListService.CleanAllErrors();
                     break;
             }
         }

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                 {
                     // The version property wasn't found within the first 100 characters.
                     // Per the spec, it should appear first in the sarifLog object.
-                    VsShellUtilities.ShowMessageBox(Microsoft.VisualStudio.Shell.ServiceProvider.GlobalProvider,
+                    VsShellUtilities.ShowMessageBox(ServiceProvider.GlobalProvider,
                                                     Resources.VersionPropertyNotFound_DialogTitle,
                                                     null, // title
                                                     OLEMSGICON.OLEMSGICON_QUERY,
@@ -205,7 +205,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
         /// </summary>
         public static void CloseAllSarifLogs()
         {
-            SarifTableDataSource.Instance.CleanAllErrors();
+            CleanAllErrors();
         }
 
         private const string VersionRegexPattern = @"""version""\s*:\s*""(?<version>[\d.]+)""";
@@ -226,7 +226,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             // is fixed.
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            int result = VsShellUtilities.ShowMessageBox(Microsoft.VisualStudio.Shell.ServiceProvider.GlobalProvider,
+            int result = VsShellUtilities.ShowMessageBox(ServiceProvider.GlobalProvider,
                                                          dialogMessage,
                                                          null, // title
                                                          OLEMSGICON.OLEMSGICON_QUERY,
@@ -292,7 +292,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
             if (error != null)
             {
-                VsShellUtilities.ShowMessageBox(Microsoft.VisualStudio.Shell.ServiceProvider.GlobalProvider,
+                VsShellUtilities.ShowMessageBox(ServiceProvider.GlobalProvider,
                                                 error,
                                                 null, // title
                                                 OLEMSGICON.OLEMSGICON_CRITICAL,
@@ -306,10 +306,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             // Clear previous data
             if (cleanErrors)
             {
-                CodeAnalysisResultManager.Instance.ClearCurrentMarkers();
-                SarifTableDataSource.Instance.CleanAllErrors();
-                CodeAnalysisResultManager.Instance.RunDataCaches.Clear();
-                CodeAnalysisResultManager.Instance.CurrentRunId = -1;
+                CleanAllErrors();
             }
 
             bool hasResults = false;
@@ -338,10 +335,10 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
             if (!hasResults && showMessageOnNoResults)
             {
-                ThreadHelper.JoinableTaskFactory.Run(async ()  =>
+               ThreadHelper.JoinableTaskFactory.RunAsync(async ()  =>
                {
                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                   VsShellUtilities.ShowMessageBox(Microsoft.VisualStudio.Shell.ServiceProvider.GlobalProvider,
+                   VsShellUtilities.ShowMessageBox(ServiceProvider.GlobalProvider,
                                                    string.Format(Resources.NoResults_DialogMessage, logFilePath),
                                                    null, // title
                                                    OLEMSGICON.OLEMSGICON_INFO,
@@ -349,6 +346,14 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                                                    OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST);
                });
             }
+        }
+
+        public static void CleanAllErrors()
+        {
+            CodeAnalysisResultManager.Instance.ClearCurrentMarkers();
+            SarifTableDataSource.Instance.CleanAllErrors();
+            CodeAnalysisResultManager.Instance.RunDataCaches.Clear();
+            CodeAnalysisResultManager.Instance.CurrentRunId = -1;
         }
 
         private ErrorListService()
@@ -465,5 +470,5 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                 }
             }
         }
-    }
+     }
 }

--- a/src/Sarif.Viewer.VisualStudio/Models/CallTree.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/CallTree.cs
@@ -80,9 +80,9 @@ namespace Microsoft.Sarif.Viewer.Models
                         _selectedItem.NavigateTo();
                         _selectedItem.ApplySelectionSourceFileHighlighting();
                     }
-                }
 
-                this.NotifyPropertyChanged(nameof(SelectedItem));
+                    this.NotifyPropertyChanged(nameof(SelectedItem));
+                }
             }
         }
 

--- a/src/Sarif.Viewer.VisualStudio/Models/CallTreeNode.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/CallTreeNode.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Windows;
+using System.Windows.Media.Animation;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.Sarif;
 using Microsoft.VisualStudio.Shell;

--- a/src/Sarif.Viewer.VisualStudio/NotifyPropertyChangedObject.cs
+++ b/src/Sarif.Viewer.VisualStudio/NotifyPropertyChangedObject.cs
@@ -12,10 +12,7 @@ namespace Microsoft.Sarif.Viewer
 
         protected void NotifyPropertyChanged(String info)
         {
-            if (PropertyChanged != null)
-            {
-                PropertyChanged(this, new PropertyChangedEventArgs(info));
-            }
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(info));
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/Properties/AssemblyInfo.cs
+++ b/src/Sarif.Viewer.VisualStudio/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("Microsoft SARIF Viewer for Visual Studio")]
 [assembly: AssemblyDescription("Visual Studio Extension for viewing SARIF log files")]
 
-[assembly: AssemblyVersion("2.1.13.0")]
-[assembly: AssemblyFileVersion("2.1.13.0")]
+[assembly: AssemblyVersion("2.1.14.0")]
+[assembly: AssemblyFileVersion("2.1.14.0")]
 
 [assembly: InternalsVisibleTo("Sarif.Viewer.VisualStudio.UnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100433fbf156abe9718142bdbd48a440e779a1b708fd21486ee0ae536f4c548edf8a7185c1e3ac89ceef76c15b8cc2497906798779a59402f9b9e27281fb15e7111566cdc9a9f8326301d45320623c5222089cf4d0013f365ae729fb0a9c9d15138042825cd511a0f3d4887a7b92f4c2749f81b410813d297b73244cf64995effb1")]

--- a/src/Sarif.Viewer.VisualStudio/SarifTextViewCreationListener.cs
+++ b/src/Sarif.Viewer.VisualStudio/SarifTextViewCreationListener.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.ComponentModel.Composition;
-using EnvDTE;
-using EnvDTE80;
 using Microsoft.CodeAnalysis.Sarif.Converters;
 using Microsoft.Sarif.Viewer.ContentTypes;
 using Microsoft.Sarif.Viewer.ErrorList;

--- a/src/Sarif.Viewer.VisualStudio/TreeViewSelectionHelper.cs
+++ b/src/Sarif.Viewer.VisualStudio/TreeViewSelectionHelper.cs
@@ -104,14 +104,15 @@ namespace Microsoft.Sarif.Viewer
                     node.BringIntoView();
                     node.UpdateLayout();
 
+                    // You might be tempted to set focus to this node
+                    // as well as select it. If the node is focused
+                    // then when a user is navigating through a source file
+                    // in the editor and a "Tagged" region is selected (See ResultTextMark)
+                    // due to the caret entering a region, then focus is moved off the editor
+                    // which means it's nearly impossible for the user to edit highlighted text.
                     if (!node.IsSelected)
                     {
                         node.IsSelected = true;
-                    }
-
-                    if (!node.IsFocused)
-                    {
-                        node.Focus();
                     }
                 }
             }

--- a/src/Sarif.Viewer.VisualStudio/source.extension.vsixmanifest
+++ b/src/Sarif.Viewer.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Microsoft.Sarif.Viewer.Michael C. Fanning.f17e897a-fd38-4e1f-99db-19fa34a4e184" Version="2.1.13" Language="en-US" Publisher="Microsoft DevLabs" />
+        <Identity Id="Microsoft.Sarif.Viewer.Michael C. Fanning.f17e897a-fd38-4e1f-99db-19fa34a4e184" Version="2.1.14" Language="en-US" Publisher="Microsoft DevLabs" />
         <DisplayName>Microsoft SARIF Viewer</DisplayName>
         <Description xml:space="preserve">Visual Studio Static Analysis Results Interchange Format (SARIF) log file viewer</Description>
         <License>License.txt</License>

--- a/src/build.props
+++ b/src/build.props
@@ -19,7 +19,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF Viewer for Visual Studio</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix Condition=" '$(VersionPrefix)' == ''">2.1.13</VersionPrefix>
+    <VersionPrefix Condition=" '$(VersionPrefix)' == ''">2.1.14</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == ''"></VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
We've had reports that the performance of Visual Studio's editor was sluggish after selecting an SARIF result from the error list and having the SARIF pane (tool window) visible. That's tracked in issue #183 

I would go beyond that and say it wasn't usable at all :) You couldn't actually get the caret in the editor inside any highlighted text that the SARIF extension highlighted.

All of this was due to an event loop that didn't end up in a stack overflow, but a never ending "go here, go there, select this, select that" events being queued to the VS UI thread to handle. Result, super super slow VS performance.

I worked with a Visual Studio developer who specifically works on the editor to go through this issue and make sure that my changes where appropriate. After this change, the editor is usable and it  solve this immediate issue, but there's more work to do to make the performance even better. That is tracked in #185 .