### PR TITLE
Fix #199: Display non-failure results appropriately

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,4 +1,10 @@
 # SARIF Viewer Visual Studio extension Release History
+
+## **v2.1.17** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
+BUGFIX: Display non-failure results appropriately [#199](https://github.com/microsoft/sarif-visualstudio-extension/issues/199)
+BUGFIX: Double-clicking result does not navigate to source file [#201](https://github.com/microsoft/sarif-visualstudio-extension/issues/201)
+FEATURE: A new script `New-AtomXml.ps` allows you to create a private Atom feed for pre-release versions of the viewer.=
+
 ## **v2.1.16** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
 * BUGFIX: Offload file reading and parsing from Visual Studio's UI thread. [#160](https://github.com/microsoft/sarif-visualstudio-extension/issues/160)
 

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
@@ -418,6 +418,19 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         }
 
         [Fact]
+        public void SarifErrorListItem_TreatsPassResultAsNote()
+        {
+            var result = new Result
+            {
+                Kind = ResultKind.Pass,
+                Level = FailureLevel.None
+            };
+
+            SarifErrorListItem item = MakeErrorListItem(result);
+            item.Level.Should().Be(FailureLevel.Note);
+        }
+
+        [Fact]
         public void SarifErrorListItem_TreatsOpenResultAsWarning()
         {
             var result = new Result

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
@@ -391,6 +391,71 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             item.HasEmbeddedLinks.Should().BeTrue();
         }
 
+        [Fact]
+        public void SarifErrorListItem_TreatsInformationalResultAsNote()
+        {
+            var result = new Result
+            {
+                Kind = ResultKind.Informational,
+                Level = FailureLevel.None
+            };
+
+            SarifErrorListItem item = MakeErrorListItem(result);
+            item.Level.Should().Be(FailureLevel.Note);
+        }
+
+        [Fact]
+        public void SarifErrorListItem_TreatsNotApplicableResultAsNote()
+        {
+            var result = new Result
+            {
+                Kind = ResultKind.NotApplicable,
+                Level = FailureLevel.None
+            };
+
+            SarifErrorListItem item = MakeErrorListItem(result);
+            item.Level.Should().Be(FailureLevel.Note);
+        }
+
+        [Fact]
+        public void SarifErrorListItem_TreatsOpenResultAsWarning()
+        {
+            var result = new Result
+            {
+                Kind = ResultKind.Open,
+                Level = FailureLevel.None
+            };
+
+            SarifErrorListItem item = MakeErrorListItem(result);
+            item.Level.Should().Be(FailureLevel.Warning);
+        }
+
+        [Fact]
+        public void SarifErrorListItem_TreatsReviewResultAsWarning()
+        {
+            var result = new Result
+            {
+                Kind = ResultKind.Review,
+                Level = FailureLevel.None
+            };
+
+            SarifErrorListItem item = MakeErrorListItem(result);
+            item.Level.Should().Be(FailureLevel.Warning);
+        }
+
+        [Fact]
+        public void SarifErrorListItem_TreatsFailResultAccordingToLevel()
+        {
+            var result = new Result
+            {
+                Level = FailureLevel.Error,
+                Kind = ResultKind.Fail
+            };
+
+            SarifErrorListItem item = MakeErrorListItem(result);
+            item.Level.Should().Be(FailureLevel.Error);
+        }
+
         // Run object used in tests that don't require a populated run object.
         private static readonly Run EmptyRun = new Run();
 

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         [Fact]
         public void SarifErrorListItem_WhenRegionHasStartLine_HasLineMarker()
         {
-            var item = new SarifErrorListItem
+            SarifErrorListItem item = new SarifErrorListItem
             {
                 FileName = "file.ext",
                 Region = new Region
@@ -36,7 +36,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         [Fact]
         public void SarifErrorListItem_WhenRegionHasNoStartLine_HasNoLineMarker()
         {
-            var item = new SarifErrorListItem
+            SarifErrorListItem item = new SarifErrorListItem
             {
                 FileName = "file.ext",
                 Region = new Region
@@ -53,7 +53,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         [Fact]
         public void SarifErrorListItem_WhenRegionIsAbsent_HasNoLineMarker()
         {
-            var item = new SarifErrorListItem
+            SarifErrorListItem item = new SarifErrorListItem
             {
                 FileName = "file.ext"
             };
@@ -70,7 +70,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             {
             };
 
-            var item = MakeErrorListItem(result);
+            SarifErrorListItem item = MakeErrorListItem(result);
 
             item.Message.Should().Be(string.Empty);
         }
@@ -92,7 +92,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 Tool = new Tool()
             };
 
-            var item = MakeErrorListItem(run, result);
+            SarifErrorListItem item = MakeErrorListItem(run, result);
 
             item.Message.Should().Be(string.Empty);
         }
@@ -126,7 +126,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 }
             };
 
-            var item = MakeErrorListItem(run, result);
+            SarifErrorListItem item = MakeErrorListItem(run, result);
 
             item.Message.Should().Be(string.Empty);
         }
@@ -164,7 +164,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 }
             };
 
-            var item = MakeErrorListItem(run, result);
+            SarifErrorListItem item = MakeErrorListItem(run, result);
 
             item.Message.Should().Be(string.Empty);
         }
@@ -206,7 +206,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 }
             };
 
-            var item = MakeErrorListItem(run, result);
+            SarifErrorListItem item = MakeErrorListItem(run, result);
 
             item.Message.Should().Be("Hello, Mary!");
         }
@@ -245,7 +245,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 }
             };
 
-            var item = MakeErrorListItem(result);
+            SarifErrorListItem item = MakeErrorListItem(result);
 
             item.Fixes[0].ArtifactChanges[0].FilePath.Should().Be("path/to/file.html");
         }
@@ -275,7 +275,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 }
             };
 
-            var item = MakeErrorListItem(run, result);
+            SarifErrorListItem item = MakeErrorListItem(run, result);
 
             item.Rule.Id.Should().Be("TST0001");
         }
@@ -302,7 +302,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 }
             };
 
-            var item = MakeErrorListItem(run, result);
+            SarifErrorListItem item = MakeErrorListItem(run, result);
 
             item.Rule.Id.Should().Be("TST0001");
         }
@@ -334,7 +334,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 }
             };
 
-            var item = MakeErrorListItem(run, result);
+            SarifErrorListItem item = MakeErrorListItem(run, result);
 
             item.Message.Should().Be(string.Empty);
         }
@@ -352,7 +352,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 }
             };
 
-            var item = MakeErrorListItem(result);
+            SarifErrorListItem item = MakeErrorListItem(result);
             item.Message.Should().Be($"{s1} {s2}");
             item.ShortMessage.Should().Be(s1);
         }
@@ -369,7 +369,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 }
             };
 
-            var item = MakeErrorListItem(result);
+            SarifErrorListItem item = MakeErrorListItem(result);
             item.Message.Should().Be(s1);
             item.ShortMessage.Should().Be(s1);
         }
@@ -387,7 +387,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 }
             };
 
-            var item = MakeErrorListItem(result);
+            SarifErrorListItem item = MakeErrorListItem(result);
             item.HasEmbeddedLinks.Should().BeTrue();
         }
 

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
@@ -391,9 +391,12 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             item.HasEmbeddedLinks.Should().BeTrue();
         }
 
+        // Run object used in tests that don't require a populated run object.
+        private static readonly Run EmptyRun = new Run();
+
         private static SarifErrorListItem MakeErrorListItem(Result result)
         {
-            return MakeErrorListItem(new Run(), result);
+            return MakeErrorListItem(EmptyRun, result);
         }
 
         private static SarifErrorListItem MakeErrorListItem(Run run, Result result)

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -268,17 +268,6 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                 null;
         }
 
-        private static void SaveLogFile(string filePath, SarifLog log)
-        {
-            // For now this is being done on the UI thread
-            // and is only required due to the message box being shown below.
-            // This will be addressed when https://github.com/microsoft/sarif-visualstudio-extension/issues/160
-            // is fixed.
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            SaveLogFile(filePath, JsonConvert.SerializeObject(log));
-        }
-
         private static void SaveLogFile(string filePath, string logText)
         {
             // For now this is being done on the UI thread

--- a/src/Sarif.Viewer.VisualStudio/LoadSarifLogService.cs
+++ b/src/Sarif.Viewer.VisualStudio/LoadSarifLogService.cs
@@ -3,14 +3,16 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using EnvDTE;
-using EnvDTE80;
 using Microsoft.CodeAnalysis.Sarif.Converters;
 using Microsoft.Sarif.Viewer.ErrorList;
 using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.Sarif.Viewer
 {
+    /// <summary>
+    /// Provides an interface through which other extensions can interact with the this extension,
+    /// in particular, to ask this extension to load a log file.
+    /// </summary>
     public class LoadSarifLogService : SLoadSarifLogService, ILoadSarifLogService, ILoadSarifLogService2
     {
         /// <inheritdoc/>

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -147,6 +147,7 @@ namespace Microsoft.Sarif.Viewer
 
                 case ResultKind.NotApplicable:
                 case ResultKind.Informational:
+                case ResultKind.Pass:
                     effectiveLevel = FailureLevel.Note;
                     break;
 

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -13,13 +13,9 @@ using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.Models;
 using Microsoft.Sarif.Viewer.Sarif;
 using Microsoft.Sarif.Viewer.Tags;
-using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Editor;
-using Microsoft.VisualStudio.Text.Tagging;
-using Microsoft.VisualStudio.TextManager.Interop;
 using XamlDoc = System.Windows.Documents;
 
 namespace Microsoft.Sarif.Viewer

--- a/src/Sarif.Viewer.VisualStudio/OpenLogFileCommands.cs
+++ b/src/Sarif.Viewer.VisualStudio/OpenLogFileCommands.cs
@@ -298,11 +298,6 @@ namespace Microsoft.Sarif.Viewer
             }
         }
 
-        bool IsSarifProtocol(string path)
-        {
-            return path.StartsWith("sarif://", StringComparison.OrdinalIgnoreCase);
-        }
-
         string ConvertSarifProtocol(string inputUrl)
         {
             int sarifProtocolLength;

--- a/src/Sarif.Viewer.VisualStudio/Properties/AssemblyInfo.cs
+++ b/src/Sarif.Viewer.VisualStudio/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("Microsoft SARIF Viewer for Visual Studio")]
 [assembly: AssemblyDescription("Visual Studio Extension for viewing SARIF log files")]
 
-[assembly: AssemblyVersion("2.1.16.0")]
-[assembly: AssemblyFileVersion("2.1.16.0")]
+[assembly: AssemblyVersion("2.1.17.0")]
+[assembly: AssemblyFileVersion("2.1.17.0")]
 
 [assembly: InternalsVisibleTo("Sarif.Viewer.VisualStudio.UnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100433fbf156abe9718142bdbd48a440e779a1b708fd21486ee0ae536f4c548edf8a7185c1e3ac89ceef76c15b8cc2497906798779a59402f9b9e27281fb15e7111566cdc9a9f8326301d45320623c5222089cf4d0013f365ae729fb0a9c9d15138042825cd511a0f3d4887a7b92f4c2749f81b410813d297b73244cf64995effb1")]

--- a/src/Sarif.Viewer.VisualStudio/source.extension.vsixmanifest
+++ b/src/Sarif.Viewer.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Microsoft.Sarif.Viewer.Michael C. Fanning.f17e897a-fd38-4e1f-99db-19fa34a4e184" Version="2.1.16" Language="en-US" Publisher="Microsoft DevLabs" />
+        <Identity Id="Microsoft.Sarif.Viewer.Michael C. Fanning.f17e897a-fd38-4e1f-99db-19fa34a4e184" Version="2.1.17" Language="en-US" Publisher="Microsoft DevLabs" />
         <DisplayName>Microsoft SARIF Viewer</DisplayName>
         <Description xml:space="preserve">Visual Studio Static Analysis Results Interchange Format (SARIF) log file viewer</Description>
         <License>License.txt</License>

--- a/src/build.props
+++ b/src/build.props
@@ -19,7 +19,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF Viewer for Visual Studio</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix Condition=" '$(VersionPrefix)' == ''">2.1.16</VersionPrefix>
+    <VersionPrefix Condition=" '$(VersionPrefix)' == ''">2.1.17</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == ''"></VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
Per discussion in triage meeting, this PR demonstrates existing Model-based unit tests.

Also:
- Removed some dead code.
- Added a comment.
- Changed a non-team-conventional use of `var` to explicit type.
- Avoid multiple creations of a `Run` object used in tests.