### PR TITLE
Offload log parsing from UI thread

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,6 +1,6 @@
 # SARIF Viewer Visual Studio extension Release History
 ## **v2.1.16** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
-* BUGFIX: Offload file reading and parsing off of Visual Studio's UI thread. [#160](https://github.com/microsoft/sarif-visualstudio-extension/issues/160)
+* BUGFIX: Offload file reading and parsing from Visual Studio's UI thread. [#160](https://github.com/microsoft/sarif-visualstudio-extension/issues/160)
 
 ## **v2.1.15** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
 * BUGFIX: Don't throw exceptions if text buffer has no file name, and properly highlight code analysis flows. [#193](https://github.com/microsoft/sarif-visualstudio-extension/issues/193)

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,4 +1,7 @@
 # SARIF Viewer Visual Studio extension Release History
+## **v2.1.16** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
+* BUGFIX: Offload file reading and parsing off of Visual Studio's UI thread. [#160](https://github.com/microsoft/sarif-visualstudio-extension/issues/160)
+
 ## **v2.1.15** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
 * BUGFIX: Don't throw exceptions if text buffer has no file name, and properly highlight code analysis flows. [#193](https://github.com/microsoft/sarif-visualstudio-extension/issues/193)
 

--- a/src/Sarif.Viewer.VisualStudio.Interop/SarifViewerInterop.cs
+++ b/src/Sarif.Viewer.VisualStudio.Interop/SarifViewerInterop.cs
@@ -8,7 +8,6 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Sarif.Viewer.Interop
 {

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/CallTreeTraversalTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/CallTreeTraversalTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.Models;

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
@@ -181,11 +181,11 @@
     <Reference Include="System.Reflection.TypeExtensions, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reflection.TypeExtensions.4.5.0\lib\net461\System.Reflection.TypeExtensions.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.1\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/SarifViewerPackageUnitTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/SarifViewerPackageUnitTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 
 namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
 {

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/TestUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/TestUtilities.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             InitializeTestEnvironment();
             CodeAnalysisResultManager.Instance.CurrentRunIndex = 0;
 
-            ErrorListService.ProcessSarifLogAsync(sarifLog, "", showMessageOnNoResults: true, cleanErrors: true).RunSynchronously();
+            ErrorListService.ProcessSarifLogAsync(sarifLog, "", showMessageOnNoResults: true, cleanErrors: true).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/TestUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/TestUtilities.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved. 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
-using System;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.ErrorList;
-using Moq;
 
 namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
 {
@@ -20,7 +18,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             InitializeTestEnvironment();
             CodeAnalysisResultManager.Instance.CurrentRunIndex = 0;
 
-            ErrorListService.ProcessSarifLog(sarifLog, "", showMessageOnNoResults: true, cleanErrors: true);
+            ErrorListService.ProcessSarifLogAsync(sarifLog, "", showMessageOnNoResults: true, cleanErrors: true).RunSynchronously();
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/packages.config
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/packages.config
@@ -55,10 +55,10 @@
   <package id="System.Reflection.TypeExtensions" version="4.5.0" targetFramework="net461" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net461" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net461" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.1" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net461" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net461" />
   <package id="System.Threading" version="4.3.0" targetFramework="net461" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
   <package id="xunit" version="2.4.0" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.2" targetFramework="net461" />

--- a/src/Sarif.Viewer.VisualStudio/CloseSarifLogService.cs
+++ b/src/Sarif.Viewer.VisualStudio/CloseSarifLogService.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using Microsoft.CodeAnalysis.Sarif.Converters;
-using Microsoft.Sarif.Viewer.ErrorList; 
+using Microsoft.Sarif.Viewer.ErrorList;
 
 namespace Microsoft.Sarif.Viewer
 {

--- a/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
@@ -98,6 +98,14 @@ namespace Microsoft.Sarif.Viewer
         internal void Register()
         {
             ThreadHelper.ThrowIfNotOnUIThread();
+            // Register this object to listen for IVsUpdateSolutionEvents
+            IVsSolutionBuildManager2 buildManager = ServiceProvider.GlobalProvider.GetService(typeof(SVsSolutionBuildManager)) as IVsSolutionBuildManager2;
+            if (buildManager == null)
+            {
+                throw Marshal.GetExceptionForHR(E_FAIL);
+            }
+            buildManager.AdviseUpdateSolutionEvents(this, out m_updateSolutionEventsCookie);
+
             // Register this object to listen for IVsSolutionEvents
             IVsSolution solution = ServiceProvider.GlobalProvider.GetService(typeof(SVsSolution)) as IVsSolution;
             if (solution == null)

--- a/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
@@ -98,14 +98,6 @@ namespace Microsoft.Sarif.Viewer
         internal void Register()
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            // Register this object to listen for IVsUpdateSolutionEvents
-            IVsSolutionBuildManager2 buildManager = ServiceProvider.GlobalProvider.GetService(typeof(SVsSolutionBuildManager)) as IVsSolutionBuildManager2;
-            if (buildManager == null)
-            {
-                throw Marshal.GetExceptionForHR(E_FAIL);
-            }
-            buildManager.AdviseUpdateSolutionEvents(this, out m_updateSolutionEventsCookie);
-
             // Register this object to listen for IVsSolutionEvents
             IVsSolution solution = ServiceProvider.GlobalProvider.GetService(typeof(SVsSolution)) as IVsSolution;
             if (solution == null)

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -10,7 +10,6 @@ using System.Security;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using EnvDTE;

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -67,8 +67,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
             if (toolFormat.MatchesToolFormat(ToolFormat.None))
             {
-                using (FileStream fileStream = File.OpenRead(filePath))
-                using (StreamReader logStreamReader = new StreamReader(fileStream))
+                using (StreamReader logStreamReader = new StreamReader(filePath, Encoding.UTF8))
                 {
                     logText = await logStreamReader.ReadToEndAsync().ConfigureAwait(continueOnCapturedContext: false);
                 }

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -303,7 +303,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
             try
             {
-                using (StreamWriter streamWriter= File.CreateText(filePath))
+                using (StreamWriter streamWriter = File.CreateText(filePath))
                 {
                     await streamWriter.WriteAsync(logText).ConfigureAwait(continueOnCapturedContext: false);
                 }

--- a/src/Sarif.Viewer.VisualStudio/LoadSarifLogService.cs
+++ b/src/Sarif.Viewer.VisualStudio/LoadSarifLogService.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
-using EnvDTE;
-using EnvDTE80;
 using Microsoft.CodeAnalysis.Sarif.Converters;
 using Microsoft.Sarif.Viewer.ErrorList;
 using Microsoft.VisualStudio.Shell;
@@ -30,6 +28,11 @@ namespace Microsoft.Sarif.Viewer
         /// <inheritdoc/>
         public void LoadSarifLog(string path)
         {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return;
+            }
+
             ErrorListService.ProcessLogFile(path, ToolFormat.None, promptOnLogConversions: true, cleanErrors: true);
         }
 

--- a/src/Sarif.Viewer.VisualStudio/LoadSarifLogService.cs
+++ b/src/Sarif.Viewer.VisualStudio/LoadSarifLogService.cs
@@ -16,12 +16,6 @@ namespace Microsoft.Sarif.Viewer
         /// <inheritdoc/>
         public void LoadSarifLog(string path, bool promptOnSchemaUpgrade = true)
         {
-            // For now this is being done on the UI thread
-            // and is only required due to the message box being shown below.
-            // This will be addressed when https://github.com/microsoft/sarif-visualstudio-extension/issues/160
-            // is fixed.
-            ThreadHelper.ThrowIfNotOnUIThread();
-
             if (string.IsNullOrWhiteSpace(path))
             {
                 return;
@@ -33,36 +27,18 @@ namespace Microsoft.Sarif.Viewer
         /// <inheritdoc/>
         public void LoadSarifLog(string path)
         {
-            // For now this is being done on the UI thread
-            // and is only required due to the message box being shown below.
-            // This will be addressed when https://github.com/microsoft/sarif-visualstudio-extension/issues/160
-            // is fixed.
-            ThreadHelper.ThrowIfNotOnUIThread();
-
             ErrorListService.ProcessLogFile(path, ToolFormat.None, promptOnLogConversions: true, cleanErrors: true);
         }
 
         /// <inheritdoc/>
         public void LoadSarifLogs(IEnumerable<string> paths)
         {
-            // For now this is being done on the UI thread
-            // and is only required due to the message box being shown below.
-            // This will be addressed when https://github.com/microsoft/sarif-visualstudio-extension/issues/160
-            // is fixed.
-            ThreadHelper.ThrowIfNotOnUIThread();
-
             this.LoadSarifLogs(paths, promptOnSchemaUpgrade: false);
         }
 
         /// <inheritdoc/>
         public void LoadSarifLogs(IEnumerable<string> paths, bool promptOnSchemaUpgrade)
         {
-            // For now this is being done on the UI thread
-            // and is only required due to the message box being shown below.
-            // This will be addressed when https://github.com/microsoft/sarif-visualstudio-extension/issues/160
-            // is fixed.
-            ThreadHelper.ThrowIfNotOnUIThread();
-
             foreach (string path in paths.Where((path) => !string.IsNullOrEmpty(path)))
             {
                 // We should not clean errors here, if the user wants to clear errors, they can call the close log service (ICloseSarifLogService::CloseAllSarifLogs)

--- a/src/Sarif.Viewer.VisualStudio/LoadSarifLogService.cs
+++ b/src/Sarif.Viewer.VisualStudio/LoadSarifLogService.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Sarif.Viewer
 
         private async System.Threading.Tasks.Task LoadSarifLogAsync(IEnumerable<string> paths, bool promptOnSchemaUpgrade)
         {
-            List<string> validPaths = paths.Where((path) => !string.IsNullOrEmpty(path)).ToList();
+            List<string> validPaths = paths.Where(path => !string.IsNullOrEmpty(path)).ToList();
             if (validPaths.Count == 0)
             {
                 return;
@@ -92,7 +92,7 @@ namespace Microsoft.Sarif.Viewer
                     taskHandler.Progress.Report(new TaskProgressData
                     {
                         PercentComplete = (validPathIndex + 1 ) * 100 / validPaths.Count,
-                    }); ;
+                    });
                 }
             }
             finally

--- a/src/Sarif.Viewer.VisualStudio/Models/ArtifactChangeModel.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/ArtifactChangeModel.cs
@@ -1,15 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved. 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
-using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.Sarif.Viewer.Models
 {

--- a/src/Sarif.Viewer.VisualStudio/Models/ReplacementModel.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/ReplacementModel.cs
@@ -1,16 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved. 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Microsoft.Sarif.Viewer.Models
 {
     public class ReplacementModel : NotifyPropertyChangedObject

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -13,13 +13,9 @@ using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.Models;
 using Microsoft.Sarif.Viewer.Sarif;
 using Microsoft.Sarif.Viewer.Tags;
-using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Editor;
-using Microsoft.VisualStudio.Text.Tagging;
-using Microsoft.VisualStudio.TextManager.Interop;
 using XamlDoc = System.Windows.Documents;
 
 namespace Microsoft.Sarif.Viewer

--- a/src/Sarif.Viewer.VisualStudio/OpenLogFileCommands.cs
+++ b/src/Sarif.Viewer.VisualStudio/OpenLogFileCommands.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Sarif.Viewer
         /// <param name="e">Event args.</param>
         private void MenuItemCallback(object sender, EventArgs e)
         {
-            this.MenuItemCallbackAsync(sender, e).FileAndForget("SARIF Viewer open log file menu callback failed.");
+            this.MenuItemCallbackAsync(sender, e).FileAndForget("Microsoft/SARIF/Viewer/OpenSARIFLogMenu");
         }
 
         private async System.Threading.Tasks.Task MenuItemCallbackAsync(object sender, EventArgs e)

--- a/src/Sarif.Viewer.VisualStudio/OpenLogFileCommands.cs
+++ b/src/Sarif.Viewer.VisualStudio/OpenLogFileCommands.cs
@@ -126,16 +126,19 @@ namespace Microsoft.Sarif.Viewer
         /// </summary>
         /// <param name="sender">Event sender.</param>
         /// <param name="e">Event args.</param>
-#pragma warning disable VSTHRD100 // Avoid async void methods => This is an async void event handler
-        private async void MenuItemCallback(object sender, EventArgs e)
-#pragma warning restore VSTHRD100 // Avoid async void methods
+        private void MenuItemCallback(object sender, EventArgs e)
+        {
+            this.MenuItemCallbackAsync(sender, e).FileAndForget("SARIF Viewer open log file menu callback failed.");
+        }
+
+        private async System.Threading.Tasks.Task MenuItemCallbackAsync(object sender, EventArgs e)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             OleMenuCommand menuCommand = (OleMenuCommand)sender;
             OleMenuCmdEventArgs menuCmdEventArgs = (OleMenuCmdEventArgs)e;
 
-            string inputFile = menuCmdEventArgs.InValue as String;
+            string inputFile = menuCmdEventArgs.InValue as string;
             string logFile = null;
 
             if (!String.IsNullOrWhiteSpace(inputFile))

--- a/src/Sarif.Viewer.VisualStudio/Properties/AssemblyInfo.cs
+++ b/src/Sarif.Viewer.VisualStudio/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("Microsoft SARIF Viewer for Visual Studio")]
 [assembly: AssemblyDescription("Visual Studio Extension for viewing SARIF log files")]
 
-[assembly: AssemblyVersion("2.1.15.0")]
-[assembly: AssemblyFileVersion("2.1.15.0")]
+[assembly: AssemblyVersion("2.1.16.0")]
+[assembly: AssemblyFileVersion("2.1.16.0")]
 
 [assembly: InternalsVisibleTo("Sarif.Viewer.VisualStudio.UnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100433fbf156abe9718142bdbd48a440e779a1b708fd21486ee0ae536f4c548edf8a7185c1e3ac89ceef76c15b8cc2497906798779a59402f9b9e27281fb15e7111566cdc9a9f8326301d45320623c5222089cf4d0013f365ae729fb0a9c9d15138042825cd511a0f3d4887a7b92f4c2749f81b410813d297b73244cf64995effb1")]

--- a/src/Sarif.Viewer.VisualStudio/Resources.Designer.cs
+++ b/src/Sarif.Viewer.VisualStudio/Resources.Designer.cs
@@ -207,6 +207,24 @@ namespace Microsoft.Sarif.Viewer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Processing SARIF logs..
+        /// </summary>
+        public static string ProcessLogFiles {
+            get {
+                return ResourceManager.GetString("ProcessLogFiles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Processing SARIF logs completed..
+        /// </summary>
+        public static string ProcessLogFilesComplete {
+            get {
+                return ResourceManager.GetString("ProcessLogFilesComplete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Return.
         /// </summary>
         public static string ReturnMessage {

--- a/src/Sarif.Viewer.VisualStudio/Resources.Designer.cs
+++ b/src/Sarif.Viewer.VisualStudio/Resources.Designer.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Sarif.Viewer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Processoing of SARIF log {0} is complete..
+        ///   Looks up a localized string similar to Done processing SARIF log &apos;{0}&apos; is complete..
         /// </summary>
         public static string CompletedProcessingLogFileFormat {
             get {
@@ -198,7 +198,7 @@ namespace Microsoft.Sarif.Viewer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Processing SARIF log {0}..
+        ///   Looks up a localized string similar to Processing SARIF log &apos;{0}&apos;….
         /// </summary>
         public static string ProcessingLogFileFormat {
             get {
@@ -207,7 +207,7 @@ namespace Microsoft.Sarif.Viewer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Processing SARIF logs..
+        ///   Looks up a localized string similar to Processing SARIF logs….
         /// </summary>
         public static string ProcessLogFiles {
             get {
@@ -216,7 +216,7 @@ namespace Microsoft.Sarif.Viewer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Processing SARIF logs completed..
+        ///   Looks up a localized string similar to Completed processing SARIF logs..
         /// </summary>
         public static string ProcessLogFilesComplete {
             get {

--- a/src/Sarif.Viewer.VisualStudio/Resources.Designer.cs
+++ b/src/Sarif.Viewer.VisualStudio/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace Microsoft.Sarif.Viewer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Processoing of SARIF log {0} is complete..
+        /// </summary>
+        public static string CompletedProcessingLogFileFormat {
+            get {
+                return ResourceManager.GetString("CompletedProcessingLogFileFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Always allow downloads from &apos;{0}&apos;.
         /// </summary>
         public static string ConfirmDownloadDialog_CheckboxLabel {
@@ -185,6 +194,15 @@ namespace Microsoft.Sarif.Viewer {
         public static string OpenLogFileFail_DilogMessage {
             get {
                 return ResourceManager.GetString("OpenLogFileFail_DilogMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Processing SARIF log {0}..
+        /// </summary>
+        public static string ProcessingLogFileFormat {
+            get {
+                return ResourceManager.GetString("ProcessingLogFileFormat", resourceCulture);
             }
         }
         

--- a/src/Sarif.Viewer.VisualStudio/Resources.resx
+++ b/src/Sarif.Viewer.VisualStudio/Resources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CompletedProcessingLogFileFormat" xml:space="preserve">
-    <value>Processoing of SARIF log {0} is complete.</value>
+    <value>Done processing SARIF log '{0}' is complete.</value>
     <comment>Used to display processing log file information in VS's task center UI.</comment>
   </data>
   <data name="ConfirmDownloadDialog_CheckboxLabel" xml:space="preserve">
@@ -170,15 +170,15 @@
     <comment>{0} will be the full file path</comment>
   </data>
   <data name="ProcessingLogFileFormat" xml:space="preserve">
-    <value>Processing SARIF log {0}.</value>
+    <value>Processing SARIF log '{0}'&#x2026;</value>
     <comment>Used to display processing log file information in VS's task center UI.</comment>
   </data>
   <data name="ProcessLogFiles" xml:space="preserve">
-    <value>Processing SARIF logs.</value>
+    <value>Processing SARIF logs&#x2026;</value>
     <comment>Used to display processing log file information in VS's task center UI.</comment>
   </data>
   <data name="ProcessLogFilesComplete" xml:space="preserve">
-    <value>Processing SARIF logs completed.</value>
+    <value>Completed processing SARIF logs.</value>
     <comment>Used to display processing log file information in VS's task center UI.</comment>
   </data>
   <data name="ReturnMessage" xml:space="preserve">

--- a/src/Sarif.Viewer.VisualStudio/Resources.resx
+++ b/src/Sarif.Viewer.VisualStudio/Resources.resx
@@ -173,6 +173,14 @@
     <value>Processing SARIF log {0}.</value>
     <comment>Used to display processing log file information in VS's task center UI.</comment>
   </data>
+  <data name="ProcessLogFiles" xml:space="preserve">
+    <value>Processing SARIF logs.</value>
+    <comment>Used to display processing log file information in VS's task center UI.</comment>
+  </data>
+  <data name="ProcessLogFilesComplete" xml:space="preserve">
+    <value>Processing SARIF logs completed.</value>
+    <comment>Used to display processing log file information in VS's task center UI.</comment>
+  </data>
   <data name="ReturnMessage" xml:space="preserve">
     <value>Return</value>
     <comment>Displayed on a call tree "CallReturn" node</comment>

--- a/src/Sarif.Viewer.VisualStudio/Resources.resx
+++ b/src/Sarif.Viewer.VisualStudio/Resources.resx
@@ -117,6 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CompletedProcessingLogFileFormat" xml:space="preserve">
+    <value>Processoing of SARIF log {0} is complete.</value>
+    <comment>Used to display processing log file information in VS's task center UI.</comment>
+  </data>
   <data name="ConfirmDownloadDialog_CheckboxLabel" xml:space="preserve">
     <value>Always allow downloads from '{0}'</value>
   </data>
@@ -164,6 +168,10 @@
   <data name="OpenLogFileFail_DilogMessage" xml:space="preserve">
     <value>The log file '{0}' was not found.</value>
     <comment>{0} will be the full file path</comment>
+  </data>
+  <data name="ProcessingLogFileFormat" xml:space="preserve">
+    <value>Processing SARIF log {0}.</value>
+    <comment>Used to display processing log file information in VS's task center UI.</comment>
   </data>
   <data name="ReturnMessage" xml:space="preserve">
     <value>Return</value>

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -366,10 +366,10 @@
       <HintPath>..\packages\System.Reflection.TypeExtensions.4.1.0-rc2-24027\lib\net46\System.Reflection.TypeExtensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.3\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>

--- a/src/Sarif.Viewer.VisualStudio/packages.config
+++ b/src/Sarif.Viewer.VisualStudio/packages.config
@@ -5,8 +5,8 @@
   <package id="EnvDTE" version="8.0.2" targetFramework="net461" />
   <package id="EnvDTE80" version="8.0.3" targetFramework="net461" />
   <package id="Microsoft.ApplicationInsights" version="2.6.4" targetFramework="net461" />
-  <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="2.9.4" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.ComponentModelHost" version="15.7.27703" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.CoreUtility" version="15.6.27740" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Editor" version="15.6.27740" targetFramework="net461" />
@@ -65,8 +65,8 @@
   <package id="System.Reflection.TypeExtensions" version="4.1.0-rc2-24027" targetFramework="net461" />
   <package id="System.Resources.ResourceManager" version="4.0.1-rc2-24027" targetFramework="net461" />
   <package id="System.Runtime" version="4.1.0-rc2-24027" targetFramework="net461" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net461" />
   <package id="System.Runtime.Extensions" version="4.1.0-rc2-24027" targetFramework="net461" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.3" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/src/Sarif.Viewer.VisualStudio/source.extension.vsixmanifest
+++ b/src/Sarif.Viewer.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Microsoft.Sarif.Viewer.Michael C. Fanning.f17e897a-fd38-4e1f-99db-19fa34a4e184" Version="2.1.15" Language="en-US" Publisher="Microsoft DevLabs" />
+        <Identity Id="Microsoft.Sarif.Viewer.Michael C. Fanning.f17e897a-fd38-4e1f-99db-19fa34a4e184" Version="2.1.16" Language="en-US" Publisher="Microsoft DevLabs" />
         <DisplayName>Microsoft SARIF Viewer</DisplayName>
         <Description xml:space="preserve">Visual Studio Static Analysis Results Interchange Format (SARIF) log file viewer</Description>
         <License>License.txt</License>

--- a/src/build.props
+++ b/src/build.props
@@ -19,7 +19,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF Viewer for Visual Studio</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix Condition=" '$(VersionPrefix)' == ''">2.1.15</VersionPrefix>
+    <VersionPrefix Condition=" '$(VersionPrefix)' == ''">2.1.16</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == ''"></VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
This change partially addresses #160 by parsing SARIF on background tasks as much as possible.

The file reading and conversion (if necessary) are now being done on a background task. This alone makes the UI much more responsive while the log files are loading.

While the log file are being parsed, status is presented in Visual Studio's task center.

There is remaining work that can be done. For example, the data models can indeed be constructed on any thread and modified on any thread IF they are made thread safe and properly send change notifications on the UI thread for WPF/XAML. Also the "ruin data cache" needs to be made thread safe as well.

The error list implementation is already thread safe.

How verified:
Was able to use the editor to edit source code while a code analysis build and log parsing was in progress.
All unit-tests also pass.