### PR TITLE
Remove references to unused NuGet package CsvHelper.

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
@@ -20,9 +20,6 @@
     <Reference Include="CommandLine, Version=2.7.82.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
       <HintPath>..\packages\CommandLineParser.2.7.82\lib\net461\CommandLine.dll</HintPath>
     </Reference>
-    <Reference Include="CsvHelper, Version=7.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
-      <HintPath>..\packages\CsvHelper.7.1.1\lib\net45\CsvHelper.dll</HintPath>
-    </Reference>
     <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/packages.config
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/packages.config
@@ -2,7 +2,6 @@
 <packages>
   <package id="Castle.Core" version="4.3.1" targetFramework="net461" />
   <package id="CommandLineParser" version="2.7.82" targetFramework="net461" />
-  <package id="CsvHelper" version="7.1.1" targetFramework="net461" />
   <package id="FluentAssertions" version="5.4.1" targetFramework="net461" />
   <package id="Microsoft.ApplicationInsights" version="2.6.4" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.CoreUtility" version="15.6.27740" targetFramework="net461" />

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -174,9 +174,6 @@
     <Reference Include="CommandLine, Version=2.7.82.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
       <HintPath>..\packages\CommandLineParser.2.7.82\lib\net461\CommandLine.dll</HintPath>
     </Reference>
-    <Reference Include="CsvHelper, Version=7.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
-      <HintPath>..\packages\CsvHelper.7.1.1\lib\net45\CsvHelper.dll</HintPath>
-    </Reference>
     <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
       <HintPath>..\packages\EnvDTE.8.0.2\lib\net10\EnvDTE.dll</HintPath>

--- a/src/Sarif.Viewer.VisualStudio/packages.config
+++ b/src/Sarif.Viewer.VisualStudio/packages.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommandLineParser" version="2.7.82" targetFramework="net461" />
-  <package id="CsvHelper" version="7.1.1" targetFramework="net461" />
   <package id="EnvDTE" version="8.0.2" targetFramework="net461" />
   <package id="EnvDTE80" version="8.0.3" targetFramework="net461" />
   <package id="Microsoft.ApplicationInsights" version="2.6.4" targetFramework="net461" />


### PR DESCRIPTION
I noticed that two projects refer to NuGet package CsvHelper, but it's not used anywhere.

(I came across this in the context of implementing a FlawFinder CSV converter, while investigating how our various code bases handle CSV files.)