### PR TITLE
Stop storing tagger as property

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,6 +1,6 @@
 # SARIF Viewer Visual Studio extension Release History
 ## **v2.1.17** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
-* BUGFIX: Fix crash when closing and re-opening the a file with tagged SARIF results. [#205](https://github.com/microsoft/sarif-visualstudio-extension/issues/205)
+* BUGFIX: Fix crash when closing and re-opening a file with tagged SARIF results. [#205](https://github.com/microsoft/sarif-visualstudio-extension/issues/205)
 
 ## **v2.1.16** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
 * BUGFIX: Offload file reading and parsing from Visual Studio's UI thread. [#160](https://github.com/microsoft/sarif-visualstudio-extension/issues/160)

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,4 +1,7 @@
 # SARIF Viewer Visual Studio extension Release History
+## **v2.1.17** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
+* BUGFIX: Fix crash when closing and re-opening the a file with tagged SARIF results. [#205](https://github.com/microsoft/sarif-visualstudio-extension/issues/205)
+
 ## **v2.1.16** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
 * BUGFIX: Offload file reading and parsing from Visual Studio's UI thread. [#160](https://github.com/microsoft/sarif-visualstudio-extension/issues/160)
 

--- a/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
@@ -711,17 +711,14 @@ namespace Microsoft.Sarif.Viewer
             }
 
             ITextBuffer textBuffer = editorAdapterFactoryService.GetDataBuffer(vsTextLines);
-            foreach (KeyValuePair<int, RunDataCache> runIndexToRunDataCacheKVP in RunIndexToRunDataCache)
-            {
-                IEnumerable<SarifErrorListItem> sarifErrorsForDocument = runIndexToRunDataCacheKVP.
-                    Value.
-                    SarifErrors.
-                    Where(sarifError => string.Compare(documentName, sarifError.FileName, StringComparison.OrdinalIgnoreCase) == 0);
 
-                foreach (SarifErrorListItem sarifError in sarifErrorsForDocument)
-                {
-                    sarifError.TryTagDocument(textBuffer);
-                }
+            foreach (SarifErrorListItem sarifErrorListItem in 
+                RunIndexToRunDataCache.
+                Values.
+                SelectMany(runDataCache => runDataCache.SarifErrors).
+                Where(sarifListItem => string.Compare(documentName, sarifListItem.FileName, StringComparison.OrdinalIgnoreCase) == 0))
+            {
+                sarifErrorListItem.TryTagDocument(textBuffer);
             }
         }
 

--- a/src/Sarif.Viewer.VisualStudio/CodeLocationObject.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeLocationObject.cs
@@ -6,11 +6,10 @@ using System.ComponentModel;
 using System.IO;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.Sarif.Viewer
 {
-    public abstract class CodeLocationObject : NotifyPropertyChangedObject
+    internal abstract class CodeLocationObject : NotifyPropertyChangedObject
     {
         private Region _region;
         protected ResultTextMarker _lineMarker;
@@ -27,7 +26,7 @@ namespace Microsoft.Sarif.Viewer
                 // without a region.
                 if (_lineMarker == null && Region != null)
                 {
-                    _lineMarker = new ResultTextMarker(RunId, Region, FilePath);
+                    _lineMarker = new ResultTextMarker(RunId, Region, FilePath, DefaultSourceHighlightColor);
                 }
 
                 // If the UriBaseId was populated before the marker was available, set the
@@ -195,13 +194,7 @@ namespace Microsoft.Sarif.Viewer
 
         public void ApplyDefaultSourceFileHighlighting()
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            // Remove hover marker
             LineMarker?.RemoveTagHighlight();
-
-            // Add default marker instead
-            LineMarker?.AddTagHighlight(DefaultSourceHighlightColor);
         }
 
         /// <summary>
@@ -209,22 +202,7 @@ namespace Microsoft.Sarif.Viewer
         /// </summary>
         public void ApplySelectionSourceFileHighlighting()
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            // Remove previous highlighting and replace with hover color
-            LineMarker?.RemoveTagHighlight();
             LineMarker?.AddTagHighlight(SelectedSourceHighlightColor);
-        }
-
-        /// <summary>
-        /// An overridden method for reacting to the event of a document window
-        /// being opened
-        /// </summary>
-        internal void AttachToDocument(ITextBuffer textBuffer)
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            LineMarker?.TryTagDocument(textBuffer);
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/CodeLocationObject.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeLocationObject.cs
@@ -183,6 +183,8 @@ namespace Microsoft.Sarif.Viewer
 
         public void ApplyDefaultSourceFileHighlighting()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             // Remove hover marker
             LineMarker?.RemoveTagHighlight();
 
@@ -195,6 +197,8 @@ namespace Microsoft.Sarif.Viewer
         /// </summary>
         public void ApplySelectionSourceFileHighlighting()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             // Remove previous highlighting and replace with hover color
             LineMarker?.RemoveTagHighlight();
             LineMarker?.AddTagHighlight(SelectedSourceHighlightColor);

--- a/src/Sarif.Viewer.VisualStudio/CodeLocationObjectTypeDescriptor.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeLocationObjectTypeDescriptor.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Sarif.Viewer
     /// A custom type descriptor which enables the SARIF properties to be displayed
     /// in the Properties window.
     /// </summary>
-    public class CodeLocationObjectTypeDescriptor : ICustomTypeDescriptor
+    internal class CodeLocationObjectTypeDescriptor : ICustomTypeDescriptor
     {
         CodeLocationObject _item;
 

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -452,6 +452,8 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
             (dataCache.SarifErrors as List<SarifErrorListItem>).AddRange(sarifErrors);
             SarifTableDataSource.Instance.AddErrors(sarifErrors);
+            SarifLocationTagger.NotifyAllTagsChanged();
+
             return sarifErrors.Count;
         }
 

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/SarifTableControlEventProcessorProvider.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/SarifTableControlEventProcessorProvider.cs
@@ -46,6 +46,8 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             /// </summary>
             public override void PreprocessSelectionChanged(TableSelectionChangedEventArgs e)
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
                 // We only support single selection.
                 // So if there is no selection, or more than one, clear
                 // the SARIF explorer pane (set it's data context to null) and return.

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/SarifTableControlEventProcessorProvider.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/SarifTableControlEventProcessorProvider.cs
@@ -4,8 +4,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
-using System.Windows.Controls;
-using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.Models;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Shell;

--- a/src/Sarif.Viewer.VisualStudio/Models/CallTree.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/CallTree.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.Sarif.Viewer.Models
 {
-    public class CallTree : NotifyPropertyChangedObject
+    internal class CallTree : NotifyPropertyChangedObject
     {
         CallTreeNode _selectedItem;
         DelegateCommand<TreeView> _selectPreviousCommand;

--- a/src/Sarif.Viewer.VisualStudio/Models/CallTreeCollection.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/CallTreeCollection.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.Sarif.Viewer.Models
 {
-    public class CallTreeCollection : ObservableCollection<CallTree>
+    internal class CallTreeCollection : ObservableCollection<CallTree>
     {
         private int _verbosity;
         private DelegateCommand _expandAllCommand;

--- a/src/Sarif.Viewer.VisualStudio/Models/CallTreeNode.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/CallTreeNode.cs
@@ -9,11 +9,10 @@ using System.Windows;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.Sarif;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Text.Adornments;
 
 namespace Microsoft.Sarif.Viewer.Models
 {
-    public class CallTreeNode : CodeLocationObject
+    internal class CallTreeNode : CodeLocationObject
     {
         private ThreadFlowLocation _location;
         private CallTree _callTree;
@@ -119,7 +118,11 @@ namespace Microsoft.Sarif.Viewer.Models
                 if (_lineMarker == null
                     && Region != null)
                 {
-                    _lineMarker = new ResultTextMarker(RunId, Region, FilePath, PredefinedErrorTypeNames.Suggestion, this.Message);
+                    // Note that we could add tool-tips here as well but that results in super confusing UI
+                    // as the same thread flow locations can (and often do) show up in multiple SARIF results.
+                    // If we attempt to "remove duplicates" and only add one, then it gets even more confusing
+                    // as then it could "show up" for a result that isn't relevant at all.
+                    _lineMarker = new ResultTextMarker(RunId, Region, FilePath, DefaultSourceHighlightColor);
                     _lineMarker.RaiseRegionSelected += RegionSelected;
                 }
 

--- a/src/Sarif.Viewer.VisualStudio/Models/CallTreeNode.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/CallTreeNode.cs
@@ -9,6 +9,7 @@ using System.Windows;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.Sarif;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text.Adornments;
 
 namespace Microsoft.Sarif.Viewer.Models
 {
@@ -118,7 +119,7 @@ namespace Microsoft.Sarif.Viewer.Models
                 if (_lineMarker == null
                     && Region != null)
                 {
-                    _lineMarker = new ResultTextMarker(RunId, Region, FilePath);
+                    _lineMarker = new ResultTextMarker(RunId, Region, FilePath, PredefinedErrorTypeNames.Suggestion, this.Message);
                     _lineMarker.RaiseRegionSelected += RegionSelected;
                 }
 

--- a/src/Sarif.Viewer.VisualStudio/Models/LocationCollection.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/LocationCollection.cs
@@ -7,7 +7,7 @@ using System.ComponentModel;
 
 namespace Microsoft.Sarif.Viewer.Models
 {
-    public class LocationCollection : ObservableCollection<LocationModel>
+    internal class LocationCollection : ObservableCollection<LocationModel>
     {
         private string _message;
         private LocationModel _selectedItem;

--- a/src/Sarif.Viewer.VisualStudio/Models/LocationModel.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/LocationModel.cs
@@ -5,7 +5,7 @@ using System.IO;
 
 namespace Microsoft.Sarif.Viewer.Models
 {
-    public class LocationModel : CodeLocationObject
+    internal class LocationModel : CodeLocationObject
     {
         private string _message;
         private string _logicalLocation;

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -399,6 +399,8 @@ namespace Microsoft.Sarif.Viewer
 
         internal void RemoveTagHighlights()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             LineMarker?.RemoveTagHighlight();
 
             foreach (LocationModel location in Locations)

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -32,6 +32,13 @@ namespace Microsoft.Sarif.Viewer
         private ObservableCollection<XamlDoc.Inline> _messageInlines;
         private ResultTextMarker _lineMarker;
 
+        private static readonly Dictionary<FailureLevel, string> FailureLevelToPredefinedErrorTypes = new Dictionary<FailureLevel, string>
+        {
+            { FailureLevel.Error, Microsoft.VisualStudio.Text.Adornments.PredefinedErrorTypeNames.OtherError },
+            { FailureLevel.Warning, Microsoft.VisualStudio.Text.Adornments.PredefinedErrorTypeNames.Warning },
+            { FailureLevel.Note, Microsoft.VisualStudio.Text.Adornments.PredefinedErrorTypeNames.HintedSuggestion },
+        };
+
         internal SarifErrorListItem()
         {
             Locations = new LocationCollection(string.Empty);
@@ -517,7 +524,9 @@ namespace Microsoft.Sarif.Viewer
             {
                 if (_lineMarker == null && Region != null && Region.StartLine > 0)
                 {
-                    _lineMarker = new ResultTextMarker(_runId, Region, FileName)
+                    FailureLevelToPredefinedErrorTypes.TryGetValue(this.Level, out string predefinedErrorType);
+
+                    _lineMarker = new ResultTextMarker(_runId, Region, FileName, predefinedErrorType, this.Message)
                     {
                         UriBaseId = Locations?.FirstOrDefault()?.UriBaseId
                     };

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -597,7 +597,7 @@ namespace Microsoft.Sarif.Viewer
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            if (!textBuffer.Properties.TryGetProperty(typeof(SarifLocationTagger), out SarifLocationTagger tagger))
+            if (!SarifLocationTagger.TryFindTaggerForBuffer(textBuffer, out SarifLocationTagger tagger))
             {
                 return false;
             }

--- a/src/Sarif.Viewer.VisualStudio/Models/StackCollection.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/StackCollection.cs
@@ -6,7 +6,7 @@ using System.ComponentModel;
 
 namespace Microsoft.Sarif.Viewer.Models
 {
-    public class StackCollection : ObservableCollection<StackFrameModel>
+    internal class StackCollection : ObservableCollection<StackFrameModel>
     {
         private string _message;
 

--- a/src/Sarif.Viewer.VisualStudio/Models/StackFrameModel.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/StackFrameModel.cs
@@ -6,7 +6,7 @@ using System.IO;
 
 namespace Microsoft.Sarif.Viewer.Models
 {
-    public class StackFrameModel : CodeLocationObject
+    internal class StackFrameModel : CodeLocationObject
     {
         private string _message;
         private int _line;

--- a/src/Sarif.Viewer.VisualStudio/Properties/AssemblyInfo.cs
+++ b/src/Sarif.Viewer.VisualStudio/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("Microsoft SARIF Viewer for Visual Studio")]
 [assembly: AssemblyDescription("Visual Studio Extension for viewing SARIF log files")]
 
-[assembly: AssemblyVersion("2.1.16.0")]
-[assembly: AssemblyFileVersion("2.1.16.0")]
+[assembly: AssemblyVersion("2.1.17.0")]
+[assembly: AssemblyFileVersion("2.1.17.0")]
 
 [assembly: InternalsVisibleTo("Sarif.Viewer.VisualStudio.UnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100433fbf156abe9718142bdbd48a440e779a1b708fd21486ee0ae536f4c548edf8a7185c1e3ac89ceef76c15b8cc2497906798779a59402f9b9e27281fb15e7111566cdc9a9f8326301d45320623c5222089cf4d0013f365ae729fb0a9c9d15138042825cd511a0f3d4887a7b92f4c2749f81b410813d297b73244cf64995effb1")]

--- a/src/Sarif.Viewer.VisualStudio/ResultTextMarker.cs
+++ b/src/Sarif.Viewer.VisualStudio/ResultTextMarker.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Sarif.Viewer
                 return false;
             }
 
-            if (!textBuffer.Properties.TryGetProperty(typeof(SarifLocationTagger), out ISarifLocationTagger tagger))
+            if (!SarifLocationTagger.TryFindTaggerForBuffer(textBuffer, out SarifLocationTagger tagger))
             {
                 return false;
             }

--- a/src/Sarif.Viewer.VisualStudio/RunDataCache.cs
+++ b/src/Sarif.Viewer.VisualStudio/RunDataCache.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.Sarif.Viewer
 {
-    public class RunDataCache
+    internal class RunDataCache
     {
         private IList<SarifErrorListItem> _sarifErrors = new List<SarifErrorListItem>();
 

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -85,7 +85,7 @@
     <Compile Include="SLoadSarifLogService.cs" />
     <Compile Include="Tags\ISarifLocationTag.cs" />
     <Compile Include="Tags\ISarifLocationTagger.cs" />
-    <Compile Include="Tags\SarifLocationTag.cs" />
+    <Compile Include="Tags\SarifLocationTextMarkerTag.cs" />
     <Compile Include="Tags\SarifLocationTagger.cs" />
     <Compile Include="TelemetryEvent.cs" />
     <Compile Include="TelemetryProvider.cs" />

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -85,6 +85,7 @@
     <Compile Include="SLoadSarifLogService.cs" />
     <Compile Include="Tags\ISarifLocationTag.cs" />
     <Compile Include="Tags\ISarifLocationTagger.cs" />
+    <Compile Include="Tags\SarifLocationErrorTag.cs" />
     <Compile Include="Tags\SarifLocationTextMarkerTag.cs" />
     <Compile Include="Tags\SarifLocationTagger.cs" />
     <Compile Include="TelemetryEvent.cs" />

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -83,6 +83,8 @@
     <Compile Include="SarifToolWindowCommand.cs" />
     <Compile Include="SCloseSarifLogService.cs" />
     <Compile Include="SLoadSarifLogService.cs" />
+    <Compile Include="Tags\ISarifLocationErrorTag.cs" />
+    <Compile Include="Tags\ISarifLocationTextMarkerTag.cs" />
     <Compile Include="Tags\ISarifLocationTag.cs" />
     <Compile Include="Tags\ISarifLocationTagger.cs" />
     <Compile Include="Tags\SarifLocationErrorTag.cs" />

--- a/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
@@ -879,7 +879,9 @@ namespace Microsoft.Sarif.Viewer
                 return false;
             }
 
-            return persistFileFormat.GetCurFile(out filename, out uint formatIndex) == VSConstants.S_OK;
+            // IPersistFileFormat::GetCurFile clearly documents that the filename can be null (with an S_OK return value) if the document is in the "untitled" state.
+            // For our uses, we require a non-empty, non-null file name.
+            return persistFileFormat.GetCurFile(out filename, out uint formatIndex) == VSConstants.S_OK && !string.IsNullOrWhiteSpace(filename);
         }
 
         /// <summary>

--- a/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
@@ -802,6 +802,30 @@ namespace Microsoft.Sarif.Viewer
             return true;
         }
 
+        public static bool TryGetTextViewFromFrame(IVsWindowFrame frame, out ITextView textView)
+        {
+            IVsTextView vsTextView = VsShellUtilities.GetTextView(frame);
+
+            if (vsTextView == null)
+            {
+                textView = null;
+                return false;
+            }
+
+            object textViewHost;
+            Guid guidTextViewHost = Microsoft.VisualStudio.Editor.DefGuidList.guidIWpfTextViewHost;
+            if (ErrorHandler.Succeeded(((IVsUserData)vsTextView).GetData(ref guidTextViewHost, out textViewHost)) &&
+                textViewHost != null)
+            {
+                textView = ((IWpfTextViewHost)textViewHost).TextView;
+                return true;
+            }
+
+            textView = null;
+
+            return false;
+        }
+
         public static bool TryGetTextViewFromFrame(IVsWindowFrame frame, out IVsTextView vsTextView)
         {
             ThreadHelper.ThrowIfNotOnUIThread();

--- a/src/Sarif.Viewer.VisualStudio/Tags/ISarifLocationErrorTag.cs
+++ b/src/Sarif.Viewer.VisualStudio/Tags/ISarifLocationErrorTag.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+namespace Microsoft.Sarif.Viewer.Tags
+{
+    using Microsoft.VisualStudio.Text.Tagging;
+
+    internal interface ISarifLocationErrorTag : ISarifLocationTag, IErrorTag
+    {
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/Tags/ISarifLocationTag.cs
+++ b/src/Sarif.Viewer.VisualStudio/Tags/ISarifLocationTag.cs
@@ -5,10 +5,10 @@ namespace Microsoft.Sarif.Viewer.Tags
 {
     using Microsoft.CodeAnalysis.Sarif;
     using Microsoft.VisualStudio.Text;
+    using Microsoft.VisualStudio.Text.Tagging;
     using System;
-    using System.ComponentModel;
 
-    internal interface ISarifLocationTag: INotifyPropertyChanged
+    internal interface ISarifLocationTag : ITag, IDisposable
     {
         /// <summary>
         /// Gets the persistent span for a document.
@@ -21,6 +21,11 @@ namespace Microsoft.Sarif.Viewer.Tags
         IPersistentSpan DocumentPersistentSpan { get; }
 
         /// <summary>
+        /// The Visual Studio buffer this tag is associated with.
+        /// </summary>
+        ITextBuffer TextBuffer { get; }
+
+        /// <summary>
         /// Gets the original span (SAIRF region) that was present in the SARIF log.
         /// </summary>
         Region SourceRegion { get; }
@@ -29,11 +34,6 @@ namespace Microsoft.Sarif.Viewer.Tags
         /// Gets the SARIF run index associated with this tag.
         /// </summary>
         int RunIndex { get; }
-
-        /// <summary>
-        /// Gets the current text tag used for this tag.
-        /// </summary>
-        string TextMarkerTagType { get; set; }
 
         /// <summary>
         /// Fired when the caret enters a tag.

--- a/src/Sarif.Viewer.VisualStudio/Tags/ISarifLocationTag.cs
+++ b/src/Sarif.Viewer.VisualStudio/Tags/ISarifLocationTag.cs
@@ -33,5 +33,10 @@ namespace Microsoft.Sarif.Viewer.Tags
         /// Fired when the caret enters a tag.
         /// </summary>
         event EventHandler CaretEnteredTag;
+
+        /// <summary>
+        /// Causes the object to raise a <see cref="CaretEnteredTag"/> event its consumers.
+        /// </summary>
+        void NotifyCaretWithin();
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/Tags/ISarifLocationTag.cs
+++ b/src/Sarif.Viewer.VisualStudio/Tags/ISarifLocationTag.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Sarif.Viewer.Tags
 {
     using Microsoft.CodeAnalysis.Sarif;
     using Microsoft.VisualStudio.Text;
-    using Microsoft.VisualStudio.Text.Tagging;
     using System;
     using System.ComponentModel;
 
@@ -34,7 +33,7 @@ namespace Microsoft.Sarif.Viewer.Tags
         /// <summary>
         /// Gets the current text tag used for this tag.
         /// </summary>
-        TextMarkerTag Tag { get; set; }
+        string TextMarkerTagType { get; set; }
 
         /// <summary>
         /// Fired when the caret enters a tag.

--- a/src/Sarif.Viewer.VisualStudio/Tags/ISarifLocationTag.cs
+++ b/src/Sarif.Viewer.VisualStudio/Tags/ISarifLocationTag.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Sarif.Viewer.Tags
 {
-    using Microsoft.CodeAnalysis.Sarif;
     using Microsoft.VisualStudio.Text;
     using Microsoft.VisualStudio.Text.Tagging;
     using System;
@@ -24,11 +23,6 @@ namespace Microsoft.Sarif.Viewer.Tags
         /// The Visual Studio buffer this tag is associated with.
         /// </summary>
         ITextBuffer TextBuffer { get; }
-
-        /// <summary>
-        /// Gets the original span (SAIRF region) that was present in the SARIF log.
-        /// </summary>
-        Region SourceRegion { get; }
 
         /// <summary>
         /// Gets the SARIF run index associated with this tag.

--- a/src/Sarif.Viewer.VisualStudio/Tags/ISarifLocationTagger.cs
+++ b/src/Sarif.Viewer.VisualStudio/Tags/ISarifLocationTagger.cs
@@ -15,14 +15,30 @@ namespace Microsoft.Sarif.Viewer.Tags
         /// <param name="sourceRegion">The original span from the region in the SARIF log.</param>
         /// <param name="documentSpan">The span to use to create the tag relative to an open document.</param>
         /// <param name="runIndex">The SARIF run index associated with this tag.</param>
-        /// <param name="TextMarkerTagType">The text marker tag to display for this tag.</param>
+        /// <param name="textMarkerTagType">The text marker tag to display for this tag.</param>
         /// <returns>Returns a new instance of <see cref="ISarifLocationTag"/></returns>
         /// <remarks>
         /// This <paramref name="documentSpan"/>is not necessarily the same as <paramref name="sourceRegion"/>.
         /// It may have been modified to fix up column and line numbers from the region
         /// present in the SARIF log.
         /// </remarks>
-        ISarifLocationTag AddTag(Region sourceRegion, TextSpan documentSpan, int runIndex, string TextMarkerTagType);
+        ISarifLocationTag AddTextMarkerTag(Region sourceRegion, TextSpan documentSpan, int runIndex, string textMarkerTagType);
+
+        /// <summary>
+        /// Adds a tag to report to visual studio.
+        /// </summary>
+        /// <param name="sourceRegion">The original span from the region in the SARIF log.</param>
+        /// <param name="documentSpan">The span to use to create the tag relative to an open document.</param>
+        /// <param name="runIndex">The SARIF run index associated with this tag.</param>
+        /// <param name="errorType">The error type as defined by <see cref="Microsoft.VisualStudio.Text.Adornments.PredefinedErrorTypeNames"/>.</param>
+        /// <param name="tooltipContent">The tool tip content to display in Visual studio.</param>
+        /// <returns>Returns a new instance of <see cref="ISarifLocationTag"/></returns>
+        /// <remarks>
+        /// This <paramref name="documentSpan"/>is not necessarily the same as <paramref name="sourceRegion"/>.
+        /// It may have been modified to fix up column and line numbers from the region
+        /// present in the SARIF log.
+        /// </remarks>
+        ISarifLocationTag AddErrorTag(Region sourceRegion, TextSpan documentSpan, int runIndex, string errorType, object tooltipContent);
 
         /// <summary>
         /// Determines if the tagger already knows about the given source span.

--- a/src/Sarif.Viewer.VisualStudio/Tags/ISarifLocationTagger.cs
+++ b/src/Sarif.Viewer.VisualStudio/Tags/ISarifLocationTagger.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using Microsoft.CodeAnalysis.Sarif;
-using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.TextManager.Interop;
 using System;
 
@@ -16,14 +15,14 @@ namespace Microsoft.Sarif.Viewer.Tags
         /// <param name="sourceRegion">The original span from the region in the SARIF log.</param>
         /// <param name="documentSpan">The span to use to create the tag relative to an open document.</param>
         /// <param name="runIndex">The SARIF run index associated with this tag.</param>
-        /// <param name="textMarkerTag">The text marker tag to display for this tag.</param>
+        /// <param name="TextMarkerTagType">The text marker tag to display for this tag.</param>
         /// <returns>Returns a new instance of <see cref="ISarifLocationTag"/></returns>
         /// <remarks>
         /// This <paramref name="documentSpan"/>is not necessarily the same as <paramref name="sourceRegion"/>.
         /// It may have been modified to fix up column and line numbers from the region
         /// present in the SARIF log.
         /// </remarks>
-        ISarifLocationTag AddTag(Region sourceRegion, TextSpan documentSpan, int runIndex, TextMarkerTag textMarkerTag);
+        ISarifLocationTag AddTag(Region sourceRegion, TextSpan documentSpan, int runIndex, string TextMarkerTagType);
 
         /// <summary>
         /// Determines if the tagger already knows about the given source span.

--- a/src/Sarif.Viewer.VisualStudio/Tags/ISarifLocationTagger.cs
+++ b/src/Sarif.Viewer.VisualStudio/Tags/ISarifLocationTagger.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved. 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
-using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.VisualStudio.TextManager.Interop;
 using System;
 
@@ -12,7 +11,6 @@ namespace Microsoft.Sarif.Viewer.Tags
         /// <summary>
         /// Adds a tag to report to visual studio.
         /// </summary>
-        /// <param name="sourceRegion">The original span from the region in the SARIF log.</param>
         /// <param name="documentSpan">The span to use to create the tag relative to an open document.</param>
         /// <param name="runIndex">The SARIF run index associated with this tag.</param>
         /// <param name="textMarkerTagType">The text marker tag to display for this tag.</param>
@@ -22,12 +20,11 @@ namespace Microsoft.Sarif.Viewer.Tags
         /// It may have been modified to fix up column and line numbers from the region
         /// present in the SARIF log.
         /// </remarks>
-        ISarifLocationTag AddTextMarkerTag(Region sourceRegion, TextSpan documentSpan, int runIndex, string textMarkerTagType);
+        ISarifLocationTextMarkerTag AddTextMarkerTag(TextSpan documentSpan, int runIndex, string textMarkerTagType);
 
         /// <summary>
         /// Adds a tag to report to visual studio.
         /// </summary>
-        /// <param name="sourceRegion">The original span from the region in the SARIF log.</param>
         /// <param name="documentSpan">The span to use to create the tag relative to an open document.</param>
         /// <param name="runIndex">The SARIF run index associated with this tag.</param>
         /// <param name="errorType">The error type as defined by <see cref="Microsoft.VisualStudio.Text.Adornments.PredefinedErrorTypeNames"/>.</param>
@@ -38,16 +35,7 @@ namespace Microsoft.Sarif.Viewer.Tags
         /// It may have been modified to fix up column and line numbers from the region
         /// present in the SARIF log.
         /// </remarks>
-        ISarifLocationTag AddErrorTag(Region sourceRegion, TextSpan documentSpan, int runIndex, string errorType, object tooltipContent);
-
-        /// <summary>
-        /// Determines if the tagger already knows about the given source span.
-        /// </summary>
-        /// <param name="sourceRegion">The original span from the region in the SARIF log.</param>
-        /// <param name="runIndex">The SARIF run index associated with this tag.</param>
-        /// <param name="existingTag">On successful return, contains existing tag</param>
-        /// <returns>Returns true if the tagger already has a span for the given source span.</returns>
-        bool TryGetTag(Region sourceRegion, int runIndex, out ISarifLocationTag existingTag);
+        ISarifLocationErrorTag AddErrorTag(TextSpan documentSpan, int runIndex, string errorType, object tooltipContent);
 
         /// <summary>
         /// Removes the tag from the tagger.

--- a/src/Sarif.Viewer.VisualStudio/Tags/ISarifLocationTextMarkerTag.cs
+++ b/src/Sarif.Viewer.VisualStudio/Tags/ISarifLocationTextMarkerTag.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+namespace Microsoft.Sarif.Viewer.Tags
+{
+    using Microsoft.VisualStudio.Text.Tagging;
+
+    internal interface ISarifLocationTextMarkerTag : ISarifLocationTag, ITextMarkerTag
+    {
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/Tags/ISarifLocationTextMarkerTag.cs
+++ b/src/Sarif.Viewer.VisualStudio/Tags/ISarifLocationTextMarkerTag.cs
@@ -7,5 +7,10 @@ namespace Microsoft.Sarif.Viewer.Tags
 
     internal interface ISarifLocationTextMarkerTag : ISarifLocationTag, ITextMarkerTag
     {
+        /// <summary>
+        /// Changes the "highlight" color for the tag.
+        /// </summary>
+        /// <param name="textMarkerTagType">The new tag type color.</param>
+        void UpdateTextMarkerTagType(string textMarkerTagType);
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/Tags/SarifLocationErrorTag.cs
+++ b/src/Sarif.Viewer.VisualStudio/Tags/SarifLocationErrorTag.cs
@@ -49,10 +49,8 @@ namespace Microsoft.Sarif.Viewer.Tags
         /// <inheritdoc/>
         public event EventHandler CaretEnteredTag;
 
-        /// <summary>
-        /// Called by the tagger to when it detects that the caret for a text view has entered a tag.
-        /// </summary>
-        public void RaiseCaretEnteredTag()
+        /// <inheritdoc/>
+        public void NotifyCaretWithin()
         {
             this.CaretEnteredTag?.Invoke(this, new EventArgs());
         }

--- a/src/Sarif.Viewer.VisualStudio/Tags/SarifLocationErrorTag.cs
+++ b/src/Sarif.Viewer.VisualStudio/Tags/SarifLocationErrorTag.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.Text.Tagging;
 
 namespace Microsoft.Sarif.Viewer.Tags
 {
-    internal class SarifLocationTextMarkerTag : ISarifLocationTag, ITextMarkerTag
+    internal class SarifLocationErrorTag : ISarifLocationTag, IErrorTag
     {
         private bool disposed;
 
@@ -16,16 +16,18 @@ namespace Microsoft.Sarif.Viewer.Tags
         /// Initialize a new instance of <see cref="SarifLocationTextMarkerTag"/>.
         /// </summary>
         /// <param name="documentPersistentSpan">The persistent span for the tag within a document.</param>
+        /// <param name="textBuffer">The Visual Studio <see cref="ITextBuffer"/> this tag is associated with.</param>
         /// <param name="sourceRegion">The original span from the region present in the SARIF log.</param>
         /// <param name="runIndex">The SARIF run index associated with this tag.</param>
-        /// <param name="textMarkerTagType">The text marker tag to display for this tag.</param>
-        public SarifLocationTextMarkerTag(IPersistentSpan documentPersistentSpan, ITextBuffer textBuffer, Region sourceRegion, int runIndex, string textMarkerTagType)
+        /// <param name="errorType">The Visual Studio error type to display.</param>
+        public SarifLocationErrorTag(IPersistentSpan documentPersistentSpan, ITextBuffer textBuffer, Region sourceRegion, int runIndex, string errorType, object toolTipContet)
         {
             this.DocumentPersistentSpan = documentPersistentSpan;
             this.TextBuffer = textBuffer;
             this.SourceRegion = sourceRegion;
             this.RunIndex = runIndex;
-            this.Type = textMarkerTagType;
+            this.ErrorType = errorType;
+            this.ToolTipContent = toolTipContet;
         }
 
         /// <inheritdoc/>
@@ -38,7 +40,10 @@ namespace Microsoft.Sarif.Viewer.Tags
         public int RunIndex { get; }
 
         /// <inheritdoc/>
-        public string Type { get ; }
+        public string ErrorType { get; }
+
+        /// <inheritdoc/>
+        public object ToolTipContent { get; }
 
         /// <inheritdoc/>
         public ITextBuffer TextBuffer { get; }

--- a/src/Sarif.Viewer.VisualStudio/Tags/SarifLocationErrorTag.cs
+++ b/src/Sarif.Viewer.VisualStudio/Tags/SarifLocationErrorTag.cs
@@ -2,29 +2,30 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using System;
-using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Tagging;
 
 namespace Microsoft.Sarif.Viewer.Tags
 {
-    internal class SarifLocationErrorTag : ISarifLocationTag, IErrorTag
+    /// <summary>
+    /// Contains the data necessary to display a error tag (a underlined squiggle with a tool tip)
+    /// inside Visual Studio's text views.
+    /// </summary>
+    internal class SarifLocationErrorTag : ISarifLocationErrorTag
     {
         private bool disposed;
 
         /// <summary>
-        /// Initialize a new instance of <see cref="SarifLocationTextMarkerTag"/>.
+        /// Initialize a new instance of <see cref="SarifLocationErrorTag"/>.
         /// </summary>
         /// <param name="documentPersistentSpan">The persistent span for the tag within a document.</param>
         /// <param name="textBuffer">The Visual Studio <see cref="ITextBuffer"/> this tag is associated with.</param>
-        /// <param name="sourceRegion">The original span from the region present in the SARIF log.</param>
         /// <param name="runIndex">The SARIF run index associated with this tag.</param>
         /// <param name="errorType">The Visual Studio error type to display.</param>
-        public SarifLocationErrorTag(IPersistentSpan documentPersistentSpan, ITextBuffer textBuffer, Region sourceRegion, int runIndex, string errorType, object toolTipContet)
+        /// <param name="toolTipContet">The content to use when displaying a tool tip for this error. This parameter may be null.</param>
+        public SarifLocationErrorTag(IPersistentSpan documentPersistentSpan, ITextBuffer textBuffer, int runIndex, string errorType, object toolTipContet)
         {
             this.DocumentPersistentSpan = documentPersistentSpan;
             this.TextBuffer = textBuffer;
-            this.SourceRegion = sourceRegion;
             this.RunIndex = runIndex;
             this.ErrorType = errorType;
             this.ToolTipContent = toolTipContet;
@@ -32,10 +33,7 @@ namespace Microsoft.Sarif.Viewer.Tags
 
         /// <inheritdoc/>
         public IPersistentSpan DocumentPersistentSpan { get; }
-
-        /// <inheritdoc/>
-        public Region SourceRegion { get; }
-
+ 
         /// <inheritdoc/>
         public int RunIndex { get; }
 

--- a/src/Sarif.Viewer.VisualStudio/Tags/SarifLocationTaggerProvider.cs
+++ b/src/Sarif.Viewer.VisualStudio/Tags/SarifLocationTaggerProvider.cs
@@ -66,14 +66,7 @@ namespace Microsoft.Sarif.Viewer.Tags
                 return null;
             }
 
-            SarifLocationTagger tagger = new SarifLocationTagger(textView, textBuffer, this.PersistentSpanFactory);
-
-            // Text view creation comes before the ask to create a tagger.
-            // So at the time we are asked for a tagger for this view and buffer
-            // we likely have no running taggers.
-            tagger.TextViewCreated(textView);
-
-            return tagger as ITagger<T>;
+            return new SarifLocationTagger(textView, textBuffer, this.PersistentSpanFactory) as ITagger<T>;
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/Tags/SarifLocationTaggerProvider.cs
+++ b/src/Sarif.Viewer.VisualStudio/Tags/SarifLocationTaggerProvider.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Sarif.Viewer.Tags
     /// </remarks>
     [Export(typeof(IViewTaggerProvider))]
     [TagType(typeof(SarifLocationTextMarkerTag))]
+    [TagType(typeof(SarifLocationErrorTag))]
     [Export(typeof(ITextViewCreationListener))]
     [TextViewRole(PredefinedTextViewRoles.Document)]
     [ContentType("any")]
@@ -52,11 +53,6 @@ namespace Microsoft.Sarif.Viewer.Tags
             if (textBuffer == null)
             {
                 throw new ArgumentNullException(nameof(textBuffer));
-            }
-
-            if (typeof(T) != typeof(SarifLocationTextMarkerTag) && typeof(T) != typeof(ITextMarkerTag))
-            {
-                return null;
             }
 
             // If for some reason the text buffer doesn't belong to the text view, then skip this.

--- a/src/Sarif.Viewer.VisualStudio/Tags/SarifLocationTextMarkerTag.cs
+++ b/src/Sarif.Viewer.VisualStudio/Tags/SarifLocationTextMarkerTag.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using System;
+using System.ComponentModel;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.Sarif.Viewer.Tags
@@ -10,9 +11,10 @@ namespace Microsoft.Sarif.Viewer.Tags
     /// Contains the data necessary to display a text marker tag (a highlight)
     /// inside Visual Studio's text views.
     /// </summary>
-    internal class SarifLocationTextMarkerTag : ISarifLocationTextMarkerTag
+    internal class SarifLocationTextMarkerTag : ISarifLocationTextMarkerTag, INotifyPropertyChanged
     {
         private bool disposed;
+        private string textMarkerTagType;
 
         /// <summary>
         /// Initialize a new instance of <see cref="SarifLocationTextMarkerTag"/>.
@@ -25,7 +27,7 @@ namespace Microsoft.Sarif.Viewer.Tags
             this.DocumentPersistentSpan = documentPersistentSpan;
             this.TextBuffer = textBuffer;
             this.RunIndex = runIndex;
-            this.Type = textMarkerTagType;
+            this.textMarkerTagType = textMarkerTagType;
         }
 
         /// <inheritdoc/>
@@ -35,7 +37,10 @@ namespace Microsoft.Sarif.Viewer.Tags
         public int RunIndex { get; }
 
         /// <inheritdoc/>
-        public string Type { get ; }
+        public string Type
+        {
+            get => this.textMarkerTagType;
+        }
 
         /// <inheritdoc/>
         public ITextBuffer TextBuffer { get; }
@@ -43,10 +48,21 @@ namespace Microsoft.Sarif.Viewer.Tags
         /// <inheritdoc/>
         public event EventHandler CaretEnteredTag;
 
-        /// <summary>
-        /// Called by the tagger to when it detects that the caret for a text view has entered a tag.
-        /// </summary>
-        public void RaiseCaretEnteredTag()
+        /// <inheritdoc/>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <inheritdoc/>
+        public void UpdateTextMarkerTagType(string textMarkerTagType)
+        {
+            if (textMarkerTagType != this.textMarkerTagType)
+            {
+                this.textMarkerTagType = textMarkerTagType;
+                this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(this.Type)));
+            }
+        }
+
+        /// <inheritdoc/>
+        public void NotifyCaretWithin()
         {
             this.CaretEnteredTag?.Invoke(this, new EventArgs());
         }

--- a/src/Sarif.Viewer.VisualStudio/Tags/SarifLocationTextMarkerTag.cs
+++ b/src/Sarif.Viewer.VisualStudio/Tags/SarifLocationTextMarkerTag.cs
@@ -9,24 +9,24 @@ using Microsoft.VisualStudio.Text.Tagging;
 
 namespace Microsoft.Sarif.Viewer.Tags
 {
-    internal class SarifLocationTag : ISarifLocationTag, IDisposable
+    internal class SarifLocationTextMarkerTag : ITextMarkerTag, ISarifLocationTag, IDisposable
     {
-        private TextMarkerTag textMarkerTag;
+        private string textMarkerTagType;
         private bool disposed;
 
         /// <summary>
-        /// Initialize a new instance of <see cref="SarifLocationTag"/>.
+        /// Initialize a new instance of <see cref="SarifLocationTextMarkerTag"/>.
         /// </summary>
         /// <param name="documentPersistentSpan">The persistent span for the tag within a document.</param>
         /// <param name="sourceRegion">The original span from the region present in the SARIF log.</param>
         /// <param name="runIndex">The SARIF run index associated with this tag.</param>
-        /// <param name="textMarkerTag">The text marker tag to display for this tag.</param>
-        public SarifLocationTag(IPersistentSpan documentPersistentSpan, Region sourceRegion, int runIndex, TextMarkerTag textMarkerTag)
+        /// <param name="textMarkerTagType">The text marker tag to display for this tag.</param>
+        public SarifLocationTextMarkerTag(IPersistentSpan documentPersistentSpan, Region sourceRegion, int runIndex, string textMarkerTagType)
         {
             this.DocumentPersistentSpan = documentPersistentSpan;
             this.SourceRegion = sourceRegion;
             this.RunIndex = runIndex;
-            this.textMarkerTag = textMarkerTag;
+            this.textMarkerTagType = textMarkerTagType;
         }
 
         /// <inheritdoc/>
@@ -39,19 +39,22 @@ namespace Microsoft.Sarif.Viewer.Tags
         public int RunIndex { get; }
 
         /// <inheritdoc/>
-        public TextMarkerTag Tag
+        public string TextMarkerTagType
         {
-            get => this.textMarkerTag;
+            get => this.textMarkerTagType;
 
             set
             {
-                if (value != this.textMarkerTag)
+                if (value != this.textMarkerTagType)
                 {
-                    this.textMarkerTag = value;
-                    this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(this.Tag)));
+                    this.textMarkerTagType = value;
+                    this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(this.TextMarkerTagType)));
                 }
             }
         }
+
+        /// <inheritdoc/>
+        public string Type { get => this.textMarkerTagType; }
 
         /// <inheritdoc/>
         public event PropertyChangedEventHandler PropertyChanged;

--- a/src/Sarif.Viewer.VisualStudio/Tags/SarifLocationTextMarkerTag.cs
+++ b/src/Sarif.Viewer.VisualStudio/Tags/SarifLocationTextMarkerTag.cs
@@ -2,13 +2,15 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using System;
-using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Tagging;
 
 namespace Microsoft.Sarif.Viewer.Tags
 {
-    internal class SarifLocationTextMarkerTag : ISarifLocationTag, ITextMarkerTag
+    /// <summary>
+    /// Contains the data necessary to display a text marker tag (a highlight)
+    /// inside Visual Studio's text views.
+    /// </summary>
+    internal class SarifLocationTextMarkerTag : ISarifLocationTextMarkerTag
     {
         private bool disposed;
 
@@ -16,23 +18,18 @@ namespace Microsoft.Sarif.Viewer.Tags
         /// Initialize a new instance of <see cref="SarifLocationTextMarkerTag"/>.
         /// </summary>
         /// <param name="documentPersistentSpan">The persistent span for the tag within a document.</param>
-        /// <param name="sourceRegion">The original span from the region present in the SARIF log.</param>
         /// <param name="runIndex">The SARIF run index associated with this tag.</param>
         /// <param name="textMarkerTagType">The text marker tag to display for this tag.</param>
-        public SarifLocationTextMarkerTag(IPersistentSpan documentPersistentSpan, ITextBuffer textBuffer, Region sourceRegion, int runIndex, string textMarkerTagType)
+        public SarifLocationTextMarkerTag(IPersistentSpan documentPersistentSpan, ITextBuffer textBuffer, int runIndex, string textMarkerTagType)
         {
             this.DocumentPersistentSpan = documentPersistentSpan;
             this.TextBuffer = textBuffer;
-            this.SourceRegion = sourceRegion;
             this.RunIndex = runIndex;
             this.Type = textMarkerTagType;
         }
 
         /// <inheritdoc/>
         public IPersistentSpan DocumentPersistentSpan { get; }
-
-        /// <inheritdoc/>
-        public Region SourceRegion { get; }
 
         /// <inheritdoc/>
         public int RunIndex { get; }

--- a/src/Sarif.Viewer.VisualStudio/ViewModels/ViewModelLocator.cs
+++ b/src/Sarif.Viewer.VisualStudio/ViewModels/ViewModelLocator.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Sarif.Viewer.ViewModels
     /// This type is only used by the VS designer. It provides the data which is 
     /// displayed in the designer. 
     /// </summary>
-    public static class ViewModelLocator
+    internal static class ViewModelLocator
     {
         static object _syncroot = new object();
         static SarifErrorListItem _designTime = null;

--- a/src/Sarif.Viewer.VisualStudio/source.extension.vsixmanifest
+++ b/src/Sarif.Viewer.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Microsoft.Sarif.Viewer.Michael C. Fanning.f17e897a-fd38-4e1f-99db-19fa34a4e184" Version="2.1.16" Language="en-US" Publisher="Microsoft DevLabs" />
+        <Identity Id="Microsoft.Sarif.Viewer.Michael C. Fanning.f17e897a-fd38-4e1f-99db-19fa34a4e184" Version="2.1.17" Language="en-US" Publisher="Microsoft DevLabs" />
         <DisplayName>Microsoft SARIF Viewer</DisplayName>
         <Description xml:space="preserve">Visual Studio Static Analysis Results Interchange Format (SARIF) log file viewer</Description>
         <License>License.txt</License>

--- a/src/build.props
+++ b/src/build.props
@@ -19,7 +19,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF Viewer for Visual Studio</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix Condition=" '$(VersionPrefix)' == ''">2.1.16</VersionPrefix>
+    <VersionPrefix Condition=" '$(VersionPrefix)' == ''">2.1.17</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == ''"></VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
This addresses issue #205.

A "tagger" in Visual Studio is related to both a text view and a text buffer. Multiple text views can be associated with the same text buffer.

When a view is closed in Visual Studio, it disposes the tagger. (This is key to this fix).

Our tagger implementation maintains static lists of "tags" that are shared between all tagger instances. So every time a new view is created a new tagger instance is created and it attaches itself to the set of tags that are appropriate for it.

All that was fine.

However, what we were doing is storing a singleton tagger instance associated with a property bag given to each Visual Studio text buffer. This was the key to the bug. When a view is closed, Visual Studio disposes the tagger BUT the disposed instance still remained as a value in the text buffer's property bag. (oops).

So this change simply stops associating tagger instances with the text buffer.

There are also minor changes to how the events from the error list table are handled. The previous code was finding the list-box control and asking it for the selected items rather than just using the data that was already present in the event. Our extension shouldn't be "assuming" the XAML implementation of the error table in the first place.

Also, due to the change in the implementation, we can remove one of the "text view creation listeners" thereby increasing VS performance a tiny bit.