### PR TITLE
Fix #201: Double-clicking result does not navigate to source file

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/CodeLocationObject.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeLocationObject.cs
@@ -22,9 +22,21 @@ namespace Microsoft.Sarif.Viewer
             get
             {
                 // Not all locations have regions. Don't try to mark the locations that don't.
+                //
+                // PROBLEM: This means we can't double-click to open a file containing a result
+                // without a region.
                 if (_lineMarker == null && Region != null)
                 {
                     _lineMarker = new ResultTextMarker(RunId, Region, FilePath);
+                }
+
+                // If the UriBaseId was populated before the marker was available, set the
+                // marker's UriBaseId property now. The marker's UriBaseId is used to resolve
+                // relative paths to absolute paths when the user double-clicks a result in
+                // the Error List window.
+                if (_lineMarker != null && UriBaseId != null)
+                {
+                    _lineMarker.UriBaseId = UriBaseId;
                 }
 
                 return _lineMarker;
@@ -94,7 +106,7 @@ namespace Microsoft.Sarif.Viewer
             }
             set
             {
-                if (string.Equals(value, this._uriBaseId))
+                if (!string.Equals(value, this._uriBaseId))
                 {
                     this._uriBaseId = value;
 

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -282,12 +282,13 @@ namespace Microsoft.Sarif.Viewer.ErrorList
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            var saveFileDialog = new SaveFileDialog();
-
-            saveFileDialog.Title = dialogTitle;
-            saveFileDialog.Filter = Resources.SaveDialogFileFilter;
-            saveFileDialog.RestoreDirectory = true;
-            saveFileDialog.InitialDirectory = Path.GetDirectoryName(inputFilePath);
+            var saveFileDialog = new SaveFileDialog
+            {
+                Title = dialogTitle,
+                Filter = Resources.SaveDialogFileFilter,
+                RestoreDirectory = true,
+                InitialDirectory = Path.GetDirectoryName(inputFilePath)
+            };
 
             inputFilePath = Path.GetFileNameWithoutExtension(inputFilePath) + ".v2.sarif";
             saveFileDialog.FileName = Path.GetFileName(inputFilePath);

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Sarif.Viewer
 {
     public class SarifErrorListItem : NotifyPropertyChangedObject
     {
-        private int _runId;
+        private readonly int _runId;
         private string _fileName;
         private ToolModel _tool;
         private RuleModel _rule;
@@ -138,7 +138,6 @@ namespace Microsoft.Sarif.Viewer
         {
             ThreadHelper.ThrowIfNotOnUIThread();
             _runId = CodeAnalysisResultManager.Instance.CurrentRunIndex;
-            ReportingDescriptor rule;
             string ruleId = null;
 
             if (notification.AssociatedRule != null)
@@ -150,7 +149,7 @@ namespace Microsoft.Sarif.Viewer
                 ruleId = notification.Descriptor.Id;
             }
 
-            run.TryGetRule(ruleId, out rule);
+            run.TryGetRule(ruleId, out ReportingDescriptor rule);
             Message = notification.Message.Text?.Trim() ?? string.Empty;
             ShortMessage = ExtensionMethods.GetFirstSentence(Message);
 
@@ -490,6 +489,10 @@ namespace Microsoft.Sarif.Viewer
                 if (_lineMarker == null && Region != null && Region.StartLine > 0)
                 {
                     _lineMarker = new ResultTextMarker(_runId, Region, FileName);
+                    if (Locations.Count > 0)
+                    {
+                        _lineMarker.UriBaseId = Locations[0].UriBaseId;
+                    }
                 }
 
                 return _lineMarker;

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -488,11 +488,10 @@ namespace Microsoft.Sarif.Viewer
             {
                 if (_lineMarker == null && Region != null && Region.StartLine > 0)
                 {
-                    _lineMarker = new ResultTextMarker(_runId, Region, FileName);
-                    if (Locations.Count > 0)
+                    _lineMarker = new ResultTextMarker(_runId, Region, FileName)
                     {
-                        _lineMarker.UriBaseId = Locations[0].UriBaseId;
-                    }
+                        UriBaseId = Locations?.FirstOrDefault()?.UriBaseId
+                    };
                 }
 
                 return _lineMarker;


### PR DESCRIPTION
The proximate cause is that `uriBaseId` was null in a call to `CodeAnalysisResultManager.TryRebaselineAllSarifErrors`. I don't know the root cause (that is, I don't know the last time this feature worked, or which code change broke it). But it's straightforward to supply the `uriBaseId`.

Also:
- Fix a backwards logical condition that prevented `CodeLocationObject.UriBaseId` from being set. That bug didn't seem to cause any observable problems (in particular, it was not the cause of _this_ bug). I don't know if that property used to percolate down to the `CodeAnalysisResultManager`, but as the code stands today, it does not.
- Clean up a few IDE suggestions.