### PR TITLE
Send an initial update of the caret position for newly created text views

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -155,6 +155,15 @@ namespace Microsoft.Sarif.Viewer
             }
         }
 
+        /// <summary>
+        /// Fired when this error list item is disposed.
+        /// </summary>
+        /// <remarks>
+        /// An example of the usage of this is making sure that the SARIF explorer window
+        /// doesn't hold on to a disposed object when the error list is cleared.
+        /// </remarks>
+        public event EventHandler Disposed;
+
         private FailureLevel GetEffectiveLevel(Result result)
         {
             FailureLevel effectiveLevel;
@@ -633,6 +642,8 @@ namespace Microsoft.Sarif.Viewer
                     resultTextMarker.Dispose();
                 }
             }
+
+            Disposed?.Invoke(this, new EventArgs());
         }
 
         public void Dispose()

--- a/src/Sarif.Viewer.VisualStudio/Resources.Designer.cs
+++ b/src/Sarif.Viewer.VisualStudio/Resources.Designer.cs
@@ -244,6 +244,15 @@ namespace Microsoft.Sarif.Viewer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to SARIF Explorer.
+        /// </summary>
+        public static string SarifExplorerCaption {
+            get {
+                return ResourceManager.GetString("SarifExplorerCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Save Converted Log File.
         /// </summary>
         public static string SaveConvertedLog_DialogTitle {

--- a/src/Sarif.Viewer.VisualStudio/Resources.resx
+++ b/src/Sarif.Viewer.VisualStudio/Resources.resx
@@ -170,11 +170,11 @@
     <comment>{0} will be the full file path</comment>
   </data>
   <data name="ProcessingLogFileFormat" xml:space="preserve">
-    <value>Processing SARIF log '{0}'&#x2026;</value>
+    <value>Processing SARIF log '{0}'…</value>
     <comment>Used to display processing log file information in VS's task center UI.</comment>
   </data>
   <data name="ProcessLogFiles" xml:space="preserve">
-    <value>Processing SARIF logs&#x2026;</value>
+    <value>Processing SARIF logs…</value>
     <comment>Used to display processing log file information in VS's task center UI.</comment>
   </data>
   <data name="ProcessLogFilesComplete" xml:space="preserve">
@@ -188,6 +188,10 @@
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="RuleLookup" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Data\RuleLookup.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="SarifExplorerCaption" xml:space="preserve">
+    <value>SARIF Explorer</value>
+    <comment>The caption of the SARIF explorer tool window</comment>
   </data>
   <data name="SaveConvertedLog_DialogTitle" xml:space="preserve">
     <value>Save Converted Log File</value>

--- a/src/Sarif.Viewer.VisualStudio/SarifExplorerWindow.cs
+++ b/src/Sarif.Viewer.VisualStudio/SarifExplorerWindow.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Sarif.Viewer
         public SarifExplorerWindow() : base(null)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            this.Caption = "SARIF Explorer";
+            this.Caption = Resources.SarifExplorerCaption;
 
             // This is the user control hosted by the tool window; Note that, even if this class implements IDisposable,
             // we are not calling Dispose on this object. This is because ToolWindowPane calls Dispose on

--- a/src/Sarif.Viewer.VisualStudio/SarifExplorerWindow.cs
+++ b/src/Sarif.Viewer.VisualStudio/SarifExplorerWindow.cs
@@ -171,12 +171,32 @@ namespace Microsoft.Sarif.Viewer
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
+            if (this.Control.DataContext is SarifErrorListItem previousSarifErrorListItem)
+            {
+                previousSarifErrorListItem.Disposed -= SarifErrorListItem_Disposed;
+            }
+
             // Resetting the data context to null causes the correct tab in the SARIF explorer
             // window to be selected when the data context is set back to a non-null value.
             this.Control.DataContext = null;
             this.Control.DataContext = sarifErrorListItem;
 
+            if (sarifErrorListItem != null)
+            {
+                sarifErrorListItem.Disposed += SarifErrorListItem_Disposed;
+            }
+
             UpdateSelectionList(sarifErrorListItem);
+        }
+
+        private void SarifErrorListItem_Disposed(object sender, EventArgs e)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (this.Control.DataContext == sender)
+            {
+                UpdateDataContext(sarifErrorListItem: null);
+            }
         }
 
         /// <summary>

--- a/src/Sarif.Viewer.VisualStudio/Tags/TextViewCaretListener.cs
+++ b/src/Sarif.Viewer.VisualStudio/Tags/TextViewCaretListener.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Sarif.Viewer.Tags
             // is the main UI thread, then it runs this task synchronously.
             // What we want is for the constructor above to return and the consumer
             // of the new object to be able to subscribe to events before the initial
-            // caret position update (and it's corresponding events) are sent.
+            // caret position update (and its corresponding events) are sent.
             // So we yield to allow the constructor call stack to unwind before sending
             // the initial caret position events.
             await System.Threading.Tasks.Task.Yield();
@@ -103,9 +103,11 @@ namespace Microsoft.Sarif.Viewer.Tags
             // Handling the aggregate focus allows tags to have their highlights removed when the focus moves from
             // one document to another rather than having a bunch of views with highlights that don't correspond
             // with what's being selected in the solution explorer.
-            List<ISarifLocationTag> tagsCaretIsCurrentlyIn = (this.textView.HasAggregateFocus ? this.tagger.GetTags(normalizedSnapshotSpanCollection).
-                Where(tag => tag.Tag is ISarifLocationTag).
-                Select(tag => tag.Tag as ISarifLocationTag) : Enumerable.Empty<ISarifLocationTag>()).ToList();
+            List<ISarifLocationTag> tagsCaretIsCurrentlyIn = (this.textView.HasAggregateFocus
+                ? this.tagger.GetTags(normalizedSnapshotSpanCollection).
+                    Where(tag => tag.Tag is ISarifLocationTag).
+                    Select(tag => tag.Tag as ISarifLocationTag)
+                : Enumerable.Empty<ISarifLocationTag>()).ToList();
 
             if (this.previousTagsCaretWasIn != null && tagsCaretIsCurrentlyIn.SequenceEqual(this.previousTagsCaretWasIn, this.textMarkerTagCompaerer))
             {

--- a/src/Sarif.Viewer.VisualStudio/Views/CallTreeView.cs
+++ b/src/Sarif.Viewer.VisualStudio/Views/CallTreeView.cs
@@ -93,14 +93,6 @@ namespace Microsoft.Sarif.Viewer.Views
             {
                 EnsureNodeIsVisibleAndSelected(this, callTree.SelectedItem);
             }
-               
-            // If we still don't have a selection, then select the first item.
-            if (SelectedItem == null &&
-                Items.Count != 0 &&
-                ItemContainerGenerator.ContainerFromIndex(0) is TreeViewItem treeViewItem)
-            {
-                treeViewItem.IsSelected = true;
-            }
         }
 
         private static void EnsureNodeIsVisibleAndSelected(TreeView callTreeView, object newSelectedNode)


### PR DESCRIPTION
This address issue #220 .

When a new text view is created, and a tagger is requested, the extension creates a new text-view listener for it. Consumers of that listener (such as the SARIF explorer window) use the events from the text-view listener to properly show selected items in their views.

During initial creation of the text view (and its corresponding listener), an initial set of events was not being sent for the caret position in the text view. Due to this, the SARIF explorer XAML views could not properly update their initial selection.

The fix was to send an initial events for the starting caret location for the text view.

While testing the fix, I also realized that when you clear the SARIF errors from the list, or do anything else that results in a SARIF result not being valid (such as closing a SARIF log file that was directly opened, etc.), that the SARIF explorer continued to show content for a SARIF result that has been disposed. That's not so good. This was also addressed.
