### PR TITLE
Don't activate the error list when parsing error logs, only show it. …

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/Constants.cs
+++ b/src/Sarif.Viewer.VisualStudio/Constants.cs
@@ -3,8 +3,26 @@
 
 namespace Microsoft.Sarif.Viewer
 {
-    class Constants
+    internal static class Constants
     {
         public const string VSIX_NAME = "SARIF Viewer";
+
+        public static class FileAndForgetFaultEventNames
+        {
+            /// <summary>
+            /// Used when showing the error list fails.
+            /// </summary>
+            public const string ShowErrorList = "Microsoft/SARIF/Viewer/ShowErrorList";
+
+            /// <summary>
+            /// Used when the open SARIF log menu fails.
+            /// </summary>
+            public const string OpenSarifLogMenu = "Microsoft/SARIF/Viewer/OpenSARIFLogMenu";
+
+            /// <summary>
+            /// Used when loading a SARIF log through the load SARIF log service files.
+            /// </summary>
+            public const string LoadSarifLogs = "Microsoft/SARIF/Viewer/LoadSarifLogs";
+        }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -377,7 +377,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
             if (hasResults)
             {
-                SdkUIUtilities.ShowToolWindowAsync(new Guid(ToolWindowGuids80.ErrorList), activate: false).FileAndForget("Microsoft/SARIF/Viewer/ShowErrorList");
+                SdkUIUtilities.ShowToolWindowAsync(new Guid(ToolWindowGuids80.ErrorList), activate: false).FileAndForget(Constants.FileAndForgetFaultEventNames.ShowErrorList);
             }
             else if (showMessageOnNoResults)
             {

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -215,12 +215,6 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             }
 
             await ProcessSarifLogAsync(log, outputPath, showMessageOnNoResults: promptOnLogConversions, cleanErrors: cleanErrors).ConfigureAwait(continueOnCapturedContext: false);
-
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            if (AsyncPackage.GetGlobalService(typeof(DTE)) is DTE2 dte)
-            {
-                dte.ExecuteCommand("View.ErrorList");
-            }
         }
 
         /// <summary>
@@ -381,9 +375,12 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                 }
             }
 
-            if (!hasResults && showMessageOnNoResults)
+            if (hasResults)
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                SdkUIUtilities.ShowToolWindowAsync(new Guid(ToolWindowGuids80.ErrorList), activate: false).FileAndForget("Microsoft/SARIF/Viewer/ShowErrorList");
+            }
+            else if (showMessageOnNoResults)
+            {
                 VsShellUtilities.ShowMessageBox(ServiceProvider.GlobalProvider,
                                                 string.Format(Resources.NoResults_DialogMessage, logFilePath),
                                                 null, // title

--- a/src/Sarif.Viewer.VisualStudio/OpenLogFileCommands.cs
+++ b/src/Sarif.Viewer.VisualStudio/OpenLogFileCommands.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Sarif.Viewer
         /// <param name="e">Event args.</param>
         private void MenuItemCallback(object sender, EventArgs e)
         {
-            this.MenuItemCallbackAsync(sender, e).FileAndForget("Microsoft/SARIF/Viewer/OpenSARIFLogMenu");
+            this.MenuItemCallbackAsync(sender, e).FileAndForget(Constants.FileAndForgetFaultEventNames.OpenSarifLogMenu);
         }
 
         private async System.Threading.Tasks.Task MenuItemCallbackAsync(object sender, EventArgs e)

--- a/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
@@ -397,26 +397,22 @@ namespace Microsoft.Sarif.Viewer
         public static async System.Threading.Tasks.Task<bool> ShowToolWindowAsync(Guid toolWindowGuid, bool activate)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            IVsUIShell uiShell = Microsoft.VisualStudio.Shell.Package.GetGlobalService(typeof(SVsUIShell)) as IVsUIShell;
-            if (uiShell == null)
+            if (Package.GetGlobalService(typeof(SVsUIShell)) is IVsUIShell uiShell)
             {
-                return false;
-            }
-
-            IVsWindowFrame toolWindowFrame = null;
-            uiShell.FindToolWindow((uint)__VSFINDTOOLWIN.FTW_fForceCreate, ref toolWindowGuid, out toolWindowFrame);
-            if (toolWindowFrame != null)
-            {
-                if (activate)
+                if (uiShell.FindToolWindow((uint)__VSFINDTOOLWIN.FTW_fForceCreate, ref toolWindowGuid, out IVsWindowFrame toolWindowFrame) == VSConstants.S_OK &&
+                    toolWindowFrame != null)
                 {
-                    toolWindowFrame.Show();
-                }
-                else
-                {
-                    toolWindowFrame.ShowNoActivate();
-                }
+                    if (activate)
+                    {
+                        toolWindowFrame.Show();
+                    }
+                    else
+                    {
+                        toolWindowFrame.ShowNoActivate();
+                    }
 
-                return true;
+                    return true;
+                }
             }
 
             return false;

--- a/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
@@ -388,6 +388,40 @@ namespace Microsoft.Sarif.Viewer
             return true;
         }
 
+        /// <summary>
+        /// Locates a tool window and request that it be shown.
+        /// </summary>
+        /// <param name="toolWindowGuid">A tool window identifier, typically one from <see cref="ToolWindowGuids80"/> such as the error list.</param>
+        /// <param name="activate">Indicates whether to activate (take keyboard focus) when showing the tool window.</param>
+        /// <returns>Returns a task that when completed indicates if the tool window was shown.</returns>
+        public static async System.Threading.Tasks.Task<bool> ShowToolWindowAsync(Guid toolWindowGuid, bool activate)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            IVsUIShell uiShell = Microsoft.VisualStudio.Shell.Package.GetGlobalService(typeof(SVsUIShell)) as IVsUIShell;
+            if (uiShell == null)
+            {
+                return false;
+            }
+
+            IVsWindowFrame toolWindowFrame = null;
+            uiShell.FindToolWindow((uint)__VSFINDTOOLWIN.FTW_fForceCreate, ref toolWindowGuid, out toolWindowFrame);
+            if (toolWindowFrame != null)
+            {
+                if (activate)
+                {
+                    toolWindowFrame.Show();
+                }
+                else
+                {
+                    toolWindowFrame.ShowNoActivate();
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
         private static char[] s_directorySeparatorArray = new char[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
 
         /// <summary>

--- a/src/Sarif.Viewer.VisualStudio/Services/LoadSarifLogService.cs
+++ b/src/Sarif.Viewer.VisualStudio/Services/LoadSarifLogService.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Sarif.Viewer.Services
         /// <inheritdoc/>
         public void LoadSarifLogs(IEnumerable<string> paths, bool promptOnSchemaUpgrade)
         {
-            LoadSarifLogAsync(paths, promptOnSchemaUpgrade).FileAndForget("Microsoft/SARIF/Viewer/LoadSarifLogs");
+            LoadSarifLogAsync(paths, promptOnSchemaUpgrade).FileAndForget(Constants.FileAndForgetFaultEventNames.LoadSarifLogs);
         }
 
         private async System.Threading.Tasks.Task LoadSarifLogAsync(IEnumerable<string> paths, bool promptOnSchemaUpgrade)


### PR DESCRIPTION
This fix address issue #222 which was causing keyboard focus to be taken away from the user when an extension called the open log APIs.

…It is annoying to have keyboard focus yanked away from you while log files are processing in the background.