### PR TITLE
Trying to show the error list during unit-testing is not necessary

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -377,7 +377,10 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
             if (hasResults)
             {
-                SdkUIUtilities.ShowToolWindowAsync(new Guid(ToolWindowGuids80.ErrorList), activate: false).FileAndForget(Constants.FileAndForgetFaultEventNames.ShowErrorList);
+                if (!SarifViewerPackage.IsUnitTesting) // We cannot show UI during unit-tests.
+                {
+                    SdkUIUtilities.ShowToolWindowAsync(new Guid(ToolWindowGuids80.ErrorList), activate: false).FileAndForget(Constants.FileAndForgetFaultEventNames.ShowErrorList);
+                }
             }
             else if (showMessageOnNoResults)
             {


### PR DESCRIPTION
And causes a null-deref since we have no joinable task factory and no VS shell.