### PR TITLE
Address Gabe's feedback from previous PR

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 init:
   - git config --global core.autocrlf true

--- a/src/Sarif.Sarifer/GenerateTestDataCommand.cs
+++ b/src/Sarif.Sarifer/GenerateTestDataCommand.cs
@@ -55,7 +55,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
                 string testDataFileContents = await reader.ReadToEndAsync();
 
                 string testDataFilePath = Path.GetTempFileName();
-                File.WriteAllText(testDataFilePath, testDataFileContents); // Pity there's no async version.
+                using (var writer = new StreamWriter(testDataFilePath))
+                {
+                    await writer.WriteAsync(testDataFileContents);
+                }
 
                 return testDataFilePath;
             }

--- a/src/Sarif.Sarifer/GenerateTestDataCommand.cs
+++ b/src/Sarif.Sarifer/GenerateTestDataCommand.cs
@@ -13,8 +13,10 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.CodeAnalysis.Sarif.Sarifer
 {
-    internal class GenerateTestDataCommand
+    internal class GenerateTestDataCommand : SariferCommandBase
     {
+        private const string SendDataToViewerFailureEventName = "SendDataToViewer/Failure";
+
         private readonly SarifViewerInterop viewerInterop;
 
         public GenerateTestDataCommand(IVsShell vsShell, IMenuCommandService menuCommandService)
@@ -35,10 +37,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         /// Since this is a menu item callback, it must return void.
         /// </remarks>
 #pragma warning disable VSTHRD100 // Avoid async void methods
-        private async void MenuCommandCallback(object caller, EventArgs args)
+        private void MenuCommandCallback(object caller, EventArgs args)
 #pragma warning restore VSTHRD100 // Avoid async void methods
         {
-            await SendDataToViewerAsync().ConfigureAwait(continueOnCapturedContext: false);
+            this.SendDataToViewerAsync().FileAndForget(GetFileAndForgetEventName(SendDataToViewerFailureEventName));
         }
 
         private async Task SendDataToViewerAsync()

--- a/src/Sarif.Sarifer/GenerateTestDataCommand.cs
+++ b/src/Sarif.Sarifer/GenerateTestDataCommand.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
 
         private async Task SendDataToViewerAsync()
         {
-            string testDataFilePath = await CreateTestDataFileAsync();
+            string testDataFilePath = await CreateTestDataFileAsync().ConfigureAwait(continueOnCapturedContext: true);
 
             // TODO: Why does this never return true?
             if (!viewerInterop.IsViewerExtensionLoaded)
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
                 this.viewerInterop.LoadViewerExtension();
             }
 
-            await this.viewerInterop.OpenSarifLogAsync(testDataFilePath);
+            await this.viewerInterop.OpenSarifLogAsync(testDataFilePath).ConfigureAwait(continueOnCapturedContext: true);
         }
 
         private static async Task<string> CreateTestDataFileAsync()

--- a/src/Sarif.Sarifer/GenerateTestDataCommand.cs
+++ b/src/Sarif.Sarifer/GenerateTestDataCommand.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
 
         private async Task SendDataToViewerAsync()
         {
-            string testDataFilePath = await CreateTestDataFileAsync().ConfigureAwait(continueOnCapturedContext: true);
+            string testDataFilePath = await CreateTestDataFileAsync().ConfigureAwait(continueOnCapturedContext: false);
 
             // TODO: Why does this never return true?
             if (!viewerInterop.IsViewerExtensionLoaded)
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
                 this.viewerInterop.LoadViewerExtension();
             }
 
-            await this.viewerInterop.OpenSarifLogAsync(testDataFilePath).ConfigureAwait(continueOnCapturedContext: true);
+            await this.viewerInterop.OpenSarifLogAsync(testDataFilePath).ConfigureAwait(continueOnCapturedContext: false);
         }
 
         private static async Task<string> CreateTestDataFileAsync()

--- a/src/Sarif.Sarifer/GenerateTestDataCommand.cs
+++ b/src/Sarif.Sarifer/GenerateTestDataCommand.cs
@@ -33,12 +33,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         /// <summary>
         /// Event handler called when the user selects the Generate SARIF Test Data command.
         /// </summary>
-        /// <remarks>
-        /// Since this is a menu item callback, it must return void.
-        /// </remarks>
-#pragma warning disable VSTHRD100 // Avoid async void methods
         private void MenuCommandCallback(object caller, EventArgs args)
-#pragma warning restore VSTHRD100 // Avoid async void methods
         {
             this.SendDataToViewerAsync().FileAndForget(GetFileAndForgetEventName(SendDataToViewerFailureEventName));
         }

--- a/src/Sarif.Sarifer/Properties/AssemblyInfo.cs
+++ b/src/Sarif.Sarifer/Properties/AssemblyInfo.cs
@@ -2,10 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
+using System.Resources;
 using Microsoft.CodeAnalysis.Sarif.Sarifer;
 
 [assembly: AssemblyTitle("Sarifer test data producer extension for Visual Studio")]
 [assembly: AssemblyDescription("Generates test data in SARIF format and provides it to the SARIF viewer extension, upon which it depends.")]
+
+[assembly: NeutralResourcesLanguage("en")]
 
 [assembly: AssemblyVersion(VersionConstants.FileVersion)]
 [assembly: AssemblyFileVersion(VersionConstants.FileVersion)]

--- a/src/Sarif.Sarifer/Sarif.Sarifer.csproj
+++ b/src/Sarif.Sarifer/Sarif.Sarifer.csproj
@@ -25,12 +25,14 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., build.props))\build.props" />
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="15.0.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.7.27703" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GenerateTestDataCommand.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\VersionConstants.cs" />
     <Compile Include="Guids.cs" />
+    <Compile Include="SariferCommandBase.cs" />
     <Compile Include="SariferPackageCommandIds.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="VSPackage.Designer.cs">

--- a/src/Sarif.Sarifer/Sarif.Sarifer.csproj
+++ b/src/Sarif.Sarifer/Sarif.Sarifer.csproj
@@ -24,6 +24,11 @@
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., build.props))\build.props" />
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
+      <Version>3.3.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="15.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.7.27703" />
   </ItemGroup>

--- a/src/Sarif.Sarifer/SariferCommandBase.cs
+++ b/src/Sarif.Sarifer/SariferCommandBase.cs
@@ -7,6 +7,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
     {
         private const string FileAndForgetEventNamePrefix = "Microsoft/Sarifer/";
 
-        protected string GetFileAndForgetEventName(string suffix) => $"{FileAndForgetEventNamePrefix}{suffix}";
+        protected static string GetFileAndForgetEventName(string suffix) => $"{FileAndForgetEventNamePrefix}{suffix}";
     }
 }

--- a/src/Sarif.Sarifer/SariferCommandBase.cs
+++ b/src/Sarif.Sarifer/SariferCommandBase.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.CodeAnalysis.Sarif.Sarifer
+{
+    internal abstract class SariferCommandBase
+    {
+        private const string FileAndForgetEventNamePrefix = "Microsoft/Sarifer/";
+
+        protected string GetFileAndForgetEventName(string suffix) => $"{FileAndForgetEventNamePrefix}{suffix}";
+    }
+}

--- a/src/Sarif.Sarifer/SariferPackage.cs
+++ b/src/Sarif.Sarifer/SariferPackage.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         /// </summary>
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
-            await base.InitializeAsync(cancellationToken, progress);
+            await base.InitializeAsync(cancellationToken, progress).ConfigureAwait(continueOnCapturedContext: true);
 
             // When initialized asynchronously, we *may* be on a background thread at this point.
             // Do any initialization that requires the UI thread after switching to the UI thread.
@@ -53,8 +53,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
 
             // The OleCommandService object provided by the MPF is responsible for managing the set
             // of commands implemented by the package.
-            if (await GetServiceAsync(typeof(IMenuCommandService)) is OleMenuCommandService mcs &&
-                await GetServiceAsync(typeof(SVsShell)) is IVsShell vsShell)
+            if (await GetServiceAsync(typeof(IMenuCommandService)).ConfigureAwait(continueOnCapturedContext: true) is OleMenuCommandService mcs &&
+                await GetServiceAsync(typeof(SVsShell)).ConfigureAwait(continueOnCapturedContext: true) is IVsShell vsShell)
             {
                 _ = new GenerateTestDataCommand(vsShell, mcs);
             }

--- a/src/Sarif.Sarifer/SariferPackage.cs
+++ b/src/Sarif.Sarifer/SariferPackage.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.ComponentModel.Design;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.CodeAnalysis.Sarif.Sarifer
@@ -56,10 +56,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
             if (await GetServiceAsync(typeof(IMenuCommandService)) is OleMenuCommandService mcs &&
                 await GetServiceAsync(typeof(SVsShell)) is IVsShell vsShell)
             {
-                var command = new GenerateTestDataCommand(vsShell);
-
-                // Add the command to the command service.
-                mcs.AddCommand(command);
+                _ = new GenerateTestDataCommand(vsShell, mcs);
             }
         }
     }

--- a/src/Sarif.Viewer.VisualStudio.Interop/Sarif.Viewer.VisualStudio.Interop.csproj
+++ b/src/Sarif.Viewer.VisualStudio.Interop/Sarif.Viewer.VisualStudio.Interop.csproj
@@ -17,6 +17,11 @@
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., build.props))\build.props" />
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
+      <Version>3.3.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="15.0.1" />
     <!-- Necessary to resolve version conflict on Newtonsoft.Json: -->
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/src/Sarif.Viewer.VisualStudio.Interop/SarifViewerInterop.cs
+++ b/src/Sarif.Viewer.VisualStudio.Interop/SarifViewerInterop.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.CodeDom;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -13,9 +14,9 @@ namespace Microsoft.Sarif.Viewer.Interop
 {
     public class SarifViewerInterop
     {
-        private static readonly string ViewerAssemblyFileName = "Microsoft.Sarif.Viewer";
-        private static readonly string ViewerLoadServiceInterfaceName = "SLoadSarifLogService";
-        private static readonly string ViewerCloseServiceInterfaceName = "SCloseSarifLogService";
+        private const string ViewerAssemblyFileName = "Microsoft.Sarif.Viewer";
+        private const string ViewerLoadServiceInterfaceName = "SLoadSarifLogService";
+        private const string ViewerCloseServiceInterfaceName = "SCloseSarifLogService";
         private bool? _isViewerExtensionInstalled;
         private bool? _isViewerExtensionLoaded;
         private Assembly _viewerExtensionAssembly;
@@ -184,7 +185,7 @@ namespace Microsoft.Sarif.Viewer.Interop
             }
 
             // Get a service reference
-            dynamic serviceInterface = await ServiceProvider.GetGlobalServiceAsync(serviceType);
+            dynamic serviceInterface = await ServiceProvider.GetGlobalServiceAsync(serviceType).ConfigureAwait(continueOnCapturedContext: true);
 
             if (serviceInterface == null)
             {

--- a/src/Sarif.Viewer.VisualStudio.Interop/SarifViewerInterop.cs
+++ b/src/Sarif.Viewer.VisualStudio.Interop/SarifViewerInterop.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.CodeDom;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/src/Sarif.Viewer.VisualStudio/Properties/AssemblyInfo.cs
+++ b/src/Sarif.Viewer.VisualStudio/Properties/AssemblyInfo.cs
@@ -2,11 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.Sarif.Viewer.VisualStudio;
 
 [assembly: AssemblyTitle("Microsoft SARIF Viewer for Visual Studio")]
 [assembly: AssemblyDescription("Visual Studio Extension for viewing SARIF log files")]
+
+[assembly: NeutralResourcesLanguage("en")]
 
 [assembly: AssemblyVersion(VersionConstants.FileVersion)]
 [assembly: AssemblyFileVersion(VersionConstants.FileVersion)]


### PR DESCRIPTION
- Use `StreamWriter.WriteAsync` instead of `File.WriteAllText`.
- Aggregate, don't inherit from, `MenuCommand`. This avoids the need for static methods and data.
- `MenuItemCallback` doesn't need to be `async`: use `FileAndForget` instead of `await`.
- Add FxCop analyzers to Sarifer and Interop projects.

Gabe had also asked to add StyleCop analyzers to the new project while it was still small. I'll do that in a separate PR. I filed #237.