### PR TITLE
Run tests for the correct Configuration.

### DIFF
--- a/scripts/BuildAndTest.ps1
+++ b/scripts/BuildAndTest.ps1
@@ -173,7 +173,7 @@ if (-not $NoBuild) {
 }
 
 if (-not $NoTest) {
-    & $PSScriptRoot\Run-Tests.ps1
+    & $PSScriptRoot\Run-Tests.ps1 -Configuration $Configuration
     if (-not $?) {
         Exit-WithFailureMessage $ScriptName "RunTests failed."
     }


### PR DESCRIPTION
`BuildAndTest.ps1` wasn't passing its `-Configuration` option to `Run-Tests.ps1`, so `BuildAndTest -Configuration Debug` was failing since `Run-Tests` always ran the (default) `Release`-flavored tests.