### PR TITLE
Fix #236: Provide an interop API to accept a SARIF log from a stream

### DIFF
--- a/src/Sarif.Sarifer/GenerateTestDataCommand.cs
+++ b/src/Sarif.Sarifer/GenerateTestDataCommand.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
 
         private async Task SendDataToViewerAsync()
         {
-            string testDataFilePath = await CreateTestDataFileAsync().ConfigureAwait(continueOnCapturedContext: true);
+            Stream testDataStream = GetTestDataStream();
 
             // TODO: Why does this never return true?
             if (!viewerInterop.IsViewerExtensionLoaded)
@@ -50,25 +50,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
                 this.viewerInterop.LoadViewerExtension();
             }
 
-            await this.viewerInterop.OpenSarifLogAsync(testDataFilePath).ConfigureAwait(continueOnCapturedContext: false);
+            await this.viewerInterop.OpenSarifLogAsync(testDataStream).ConfigureAwait(continueOnCapturedContext: false);
         }
 
-        private static async Task<string> CreateTestDataFileAsync()
-        {
-            using (Stream testDataResourceStream = Assembly.GetExecutingAssembly().GetManifestResourceStream("TestData.ProofOfConcept.sarif"))
-            using (TextReader reader = new StreamReader(testDataResourceStream))
-            {
-                // No need to continue on the UI thread because we're just doing file I/O.
-                string testDataFileContents = await reader.ReadToEndAsync().ConfigureAwait(continueOnCapturedContext: false);
-
-                string testDataFilePath = Path.GetTempFileName();
-                using (var writer = new StreamWriter(testDataFilePath))
-                {
-                    await writer.WriteAsync(testDataFileContents).ConfigureAwait(continueOnCapturedContext: false);
-                }
-
-                return testDataFilePath;
-            }
-        }
+        private static Stream GetTestDataStream() =>
+            Assembly.GetExecutingAssembly().GetManifestResourceStream("TestData.ProofOfConcept.sarif");
     }
 }

--- a/src/Sarif.Sarifer/GenerateTestDataCommand.cs
+++ b/src/Sarif.Sarifer/GenerateTestDataCommand.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
 {
     internal class GenerateTestDataCommand
     {
+        private const string ProofOfConceptResourceName = "TestData.ProofOfConcept.sarif";
         private const string SendDataToViewerFailureEventName = "SendDataToViewer/Failure";
 
         private readonly SarifViewerInterop viewerInterop;
@@ -37,13 +38,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         /// </summary>
         private void MenuCommandCallback(object caller, EventArgs args)
         {
-            this.SendDataToViewerAsync().FileAndForget(FileAndForget.EventName(SendDataToViewerFailureEventName));
+            Stream testDataStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(ProofOfConceptResourceName);
+
+            this.SendDataToViewerAsync(testDataStream).FileAndForget(FileAndForget.EventName(SendDataToViewerFailureEventName));
         }
 
-        private async Task SendDataToViewerAsync()
+        private async Task SendDataToViewerAsync(Stream testDataStream)
         {
-            Stream testDataStream = GetTestDataStream();
-
             // TODO: Why does this never return true?
             if (!viewerInterop.IsViewerExtensionLoaded)
             {
@@ -52,8 +53,5 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
 
             await this.viewerInterop.OpenSarifLogAsync(testDataStream).ConfigureAwait(continueOnCapturedContext: false);
         }
-
-        private static Stream GetTestDataStream() =>
-            Assembly.GetExecutingAssembly().GetManifestResourceStream("TestData.ProofOfConcept.sarif");
     }
 }

--- a/src/Sarif.Sarifer/GenerateTestDataCommand.cs
+++ b/src/Sarif.Sarifer/GenerateTestDataCommand.cs
@@ -5,13 +5,10 @@ using System;
 using System.ComponentModel.Design;
 using System.IO;
 using System.Reflection;
-using System.Threading.Tasks;
 
 using Microsoft.Sarif.Viewer.Interop;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-
-using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.CodeAnalysis.Sarif.Sarifer
 {
@@ -26,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         {
             this.viewerInterop = new SarifViewerInterop(vsShell);
 
-            MenuCommand menuCommand = new MenuCommand(
+            var menuCommand = new MenuCommand(
                 new EventHandler(this.MenuCommandCallback),
                 new CommandID(Guids.SariferCommandSet, SariferPackageCommandIds.GenerateTestData));
 
@@ -40,18 +37,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         {
             Stream testDataStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(ProofOfConceptResourceName);
 
-            this.SendDataToViewerAsync(testDataStream).FileAndForget(FileAndForget.EventName(SendDataToViewerFailureEventName));
-        }
-
-        private async Task SendDataToViewerAsync(Stream testDataStream)
-        {
             // TODO: Why does this never return true?
             if (!viewerInterop.IsViewerExtensionLoaded)
             {
                 this.viewerInterop.LoadViewerExtension();
             }
 
-            await this.viewerInterop.OpenSarifLogAsync(testDataStream).ConfigureAwait(continueOnCapturedContext: false);
+            this.viewerInterop.OpenSarifLogAsync(testDataStream).FileAndForget(FileAndForget.EventName(SendDataToViewerFailureEventName));
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.Interop/SarifViewerInterop.cs
+++ b/src/Sarif.Viewer.VisualStudio.Interop/SarifViewerInterop.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -97,6 +98,26 @@ namespace Microsoft.Sarif.Viewer.Interop
 
                 return _isViewerExtensionLoaded ?? (bool)(_isViewerExtensionLoaded = IsExtensionLoaded());
             }
+        }
+
+        /// <summary>
+        /// Open the SARIF log file read from the specified stream in the SARIF Viewer extension.
+        /// </summary>
+        /// <param name="stream">
+        /// The <see cref="Stream"/> from which the SARIF log file is to be read.
+        /// </param>
+        /// <returns>
+        /// <code>true</code> if a SARIF log file was successfully read from the <paramref name="stream"/>,
+        /// otherwise <code>false</code>.
+        /// </returns>
+        public Task<bool> OpenSarifLogAsync(Stream stream)
+        {
+            stream = stream ?? throw new ArgumentNullException(nameof(stream));
+
+            return this.CallServiceApiAsync(ViewerLoadServiceInterfaceName, (service) =>
+            {
+                return true;
+            });
         }
 
         /// <summary>

--- a/src/Sarif.Viewer.VisualStudio.Interop/SarifViewerInterop.cs
+++ b/src/Sarif.Viewer.VisualStudio.Interop/SarifViewerInterop.cs
@@ -107,8 +107,8 @@ namespace Microsoft.Sarif.Viewer.Interop
         /// The <see cref="Stream"/> from which the SARIF log file is to be read.
         /// </param>
         /// <returns>
-        /// <code>true</code> if a SARIF log file was successfully read from the <paramref name="stream"/>,
-        /// otherwise <code>false</code>.
+        /// <code>true</code> if the extensions service was successfully invoked (regardless of the
+        /// outcome), otherwise <code>false</code>.
         /// </returns>
         public Task<bool> OpenSarifLogAsync(Stream stream)
         {
@@ -116,6 +116,7 @@ namespace Microsoft.Sarif.Viewer.Interop
 
             return this.CallServiceApiAsync(ViewerLoadServiceInterfaceName, (service) =>
             {
+                service.LoadSarifLog(stream);
                 return true;
             });
         }

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListCommand.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListCommand.cs
@@ -18,11 +18,6 @@ namespace Microsoft.Sarif.Viewer.ErrorList
         /// </summary>
         public const int ClearSarifResultsCommandId = 0x0300;
 
-        private static int[] s_commands = new int[]
-        {
-            ClearSarifResultsCommandId
-        };
-
         /// <summary>
         /// Command menu group (command set GUID).
         /// </summary>

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
             if (toolFormat.MatchesToolFormat(ToolFormat.None))
             {
-                using (StreamReader logStreamReader = new StreamReader(filePath, Encoding.UTF8))
+                using (var logStreamReader = new StreamReader(filePath, Encoding.UTF8))
                 {
                     logText = await logStreamReader.ReadToEndAsync().ConfigureAwait(continueOnCapturedContext: false);
                 }
@@ -434,7 +434,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
             if (run.Invocations != null)
             {
-                foreach (var invocation in run.Invocations)
+                foreach (Invocation invocation in run.Invocations)
                 {
                     if (invocation.ToolConfigurationNotifications != null)
                     {
@@ -509,7 +509,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                 return;
             }
 
-            foreach (var file in artifacts)
+            foreach (Artifact file in artifacts)
             {
                 Uri uri = file.Location?.Uri;
                 if (uri != null)

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -339,9 +339,8 @@ namespace Microsoft.Sarif.Viewer.ErrorList
         internal static async Task ProcessSarifLogAsync(Stream stream, bool showMessageOnNoResults, bool cleanErrors, bool openInEditor)
         {
             SarifLog sarifLog = SarifLog.Load(stream);
-            string logFilePath = Path.GetTempFileName();
 
-            await ProcessSarifLogAsync(sarifLog, logFilePath, showMessageOnNoResults, cleanErrors, openInEditor);
+            await ProcessSarifLogAsync(sarifLog, logFilePath: null, showMessageOnNoResults: showMessageOnNoResults, cleanErrors: cleanErrors, openInEditor: openInEditor);
         }
 
         internal static async Task ProcessSarifLogAsync(SarifLog sarifLog, string logFilePath, bool showMessageOnNoResults, bool cleanErrors, bool openInEditor)

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -33,6 +33,8 @@ using Microsoft.VisualStudio.TaskStatusCenter;
 
 using Newtonsoft.Json;
 
+using Task = System.Threading.Tasks.Task;
+
 namespace Microsoft.Sarif.Viewer.ErrorList
 {
     public class ErrorListService
@@ -62,7 +64,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             taskHandler.RegisterTask(ProcessLogFileAsync(filePath, toolFormat, promptOnLogConversions, cleanErrors, openInEditor));
         }
 
-        public static async System.Threading.Tasks.Task ProcessLogFileAsync(string filePath, string toolFormat, bool promptOnLogConversions, bool cleanErrors, bool openInEditor)
+        public static async Task ProcessLogFileAsync(string filePath, string toolFormat, bool promptOnLogConversions, bool cleanErrors, bool openInEditor)
         {
             SarifLog log = null;
             string logText = null;
@@ -334,7 +336,15 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             }
         }
 
-        internal static async System.Threading.Tasks.Task ProcessSarifLogAsync(SarifLog sarifLog, string logFilePath, bool showMessageOnNoResults, bool cleanErrors, bool openInEditor)
+        internal static async Task ProcessSarifLogAsync(Stream stream, bool showMessageOnNoResults, bool cleanErrors, bool openInEditor)
+        {
+            SarifLog sarifLog = SarifLog.Load(stream);
+            string logFilePath = Path.GetTempFileName();
+
+            await ProcessSarifLogAsync(sarifLog, logFilePath, showMessageOnNoResults, cleanErrors, openInEditor);
+        }
+
+        internal static async Task ProcessSarifLogAsync(SarifLog sarifLog, string logFilePath, bool showMessageOnNoResults, bool cleanErrors, bool openInEditor)
         {
             // The creation of the data models must be done on the UI thread (for now).
             // VS's table data source constructs are indeed thread safe.

--- a/src/Sarif.Viewer.VisualStudio/OpenLogFileCommands.cs
+++ b/src/Sarif.Viewer.VisualStudio/OpenLogFileCommands.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Sarif.Viewer
             }
         }
 
-        private string ConvertSarifProtocol(string inputUrl)
+        private static string ConvertSarifProtocol(string inputUrl)
         {
             int sarifProtocolLength;
             string replacementProtocol;
@@ -298,12 +298,12 @@ namespace Microsoft.Sarif.Viewer
             return newUrl;
         }
 
-        private bool TryDownloadFile(string inputUrl, out string downloadedFilePath)
+        private static bool TryDownloadFile(string inputUrl, out string downloadedFilePath)
         {
-            Uri inputUri = new Uri(inputUrl, UriKind.Absolute);
+            var inputUri = new Uri(inputUrl, UriKind.Absolute);
             downloadedFilePath = Path.GetTempFileName();
-            string downloadUrl = null;
 
+            string downloadUrl;
             if (inputUri.Scheme.Equals("sarif", StringComparison.OrdinalIgnoreCase))
             {
                 downloadUrl = ConvertSarifProtocol(inputUrl);
@@ -321,7 +321,7 @@ namespace Microsoft.Sarif.Viewer
             {
                 try
                 {
-                    using (WebClient webClient = new WebClient())
+                    using (var webClient = new WebClient())
                     {
                         webClient.UseDefaultCredentials = true;
                         webClient.DownloadFile(downloadUrl, downloadedFilePath);

--- a/src/Sarif.Viewer.VisualStudio/OpenLogFileCommands.cs
+++ b/src/Sarif.Viewer.VisualStudio/OpenLogFileCommands.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Sarif.Viewer
             string inputFile = menuCmdEventArgs.InValue as string;
             string logFile = null;
 
-            if (!String.IsNullOrWhiteSpace(inputFile))
+            if (!string.IsNullOrWhiteSpace(inputFile))
             {
                 // If the input file is a URL, download the file.
                 if (Uri.IsWellFormedUriString(inputFile, UriKind.Absolute))
@@ -197,7 +197,7 @@ namespace Microsoft.Sarif.Viewer
                     Multiselect = false
                 };
 
-                if (!String.IsNullOrWhiteSpace(inputFile))
+                if (!string.IsNullOrWhiteSpace(inputFile))
                 {
                     openFileDialog.FileName = Path.GetFileName(inputFile);
                     openFileDialog.InitialDirectory = Path.GetDirectoryName(inputFile);
@@ -271,7 +271,7 @@ namespace Microsoft.Sarif.Viewer
             }
         }
 
-        string ConvertSarifProtocol(string inputUrl)
+        private string ConvertSarifProtocol(string inputUrl)
         {
             int sarifProtocolLength;
             string replacementProtocol;
@@ -298,7 +298,7 @@ namespace Microsoft.Sarif.Viewer
             return newUrl;
         }
 
-        bool TryDownloadFile(string inputUrl, out string downloadedFilePath)
+        private bool TryDownloadFile(string inputUrl, out string downloadedFilePath)
         {
             Uri inputUri = new Uri(inputUrl, UriKind.Absolute);
             downloadedFilePath = Path.GetTempFileName();

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -83,6 +83,7 @@
     <Compile Include="KeyValuePairPropertyDescriptor.cs" />
     <Compile Include="Controls\BindableTextBlock.cs" />
     <Compile Include="Services\CloseSarifLogService.cs" />
+    <Compile Include="Services\ILoadSarifLogService3.cs" />
     <Compile Include="Services\LoadSarifLogService.cs" />
     <Compile Include="Models\CallTreeCollection.cs" />
     <Compile Include="Models\CallTree.cs" />

--- a/src/Sarif.Viewer.VisualStudio/Sarif/Replacement.extensions.cs
+++ b/src/Sarif.Viewer.VisualStudio/Sarif/Replacement.extensions.cs
@@ -8,7 +8,7 @@ using Microsoft.Sarif.Viewer.Models;
 
 namespace Microsoft.Sarif.Viewer.Sarif
 {
-    static class ReplacementExtensions
+    internal static class ReplacementExtensions
     {
         public static ReplacementModel ToReplacementModel(this Replacement replacement, FileRegionsCache fileRegionsCache, Uri uri)
         {

--- a/src/Sarif.Viewer.VisualStudio/Services/ILoadSarifLogService.cs
+++ b/src/Sarif.Viewer.VisualStudio/Services/ILoadSarifLogService.cs
@@ -3,8 +3,17 @@
 
 namespace Microsoft.Sarif.Viewer.Services
 {
+    /// <summary>
+    /// Interface for loading a SARIF log from a file.
+    /// </summary>
     internal interface ILoadSarifLogService
     {
+        /// <summary>
+        /// Loads a SARIF log from the specified file.
+        /// </summary>
+        /// <param name="path">
+        /// The path to the file from which the SARIF log should be loaded.
+        /// </param>
         void LoadSarifLog(string path);
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/Services/ILoadSarifLogService2.cs
+++ b/src/Sarif.Viewer.VisualStudio/Services/ILoadSarifLogService2.cs
@@ -5,6 +5,9 @@ using System.Collections.Generic;
 
 namespace Microsoft.Sarif.Viewer.Services
 {
+    /// <summary>
+    /// Interface for loading SARIF logs from multiple files into the viewer.
+    /// </summary>
     internal interface ILoadSarifLogService2
     {
         /// <summary>

--- a/src/Sarif.Viewer.VisualStudio/Services/ILoadSarifLogService3.cs
+++ b/src/Sarif.Viewer.VisualStudio/Services/ILoadSarifLogService3.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+
+namespace Microsoft.Sarif.Viewer.Services
+{
+    /// <summary>
+    /// Interface for loading SARIF logs from streams into the viewer.
+    /// </summary>
+    internal interface ILoadSarifLogService3
+    {
+        /// <summary>
+        /// Loads a SARIF log from the specified stream into the viewer.
+        /// </summary>
+        /// <param name="stream">
+        /// The stream from which the SARIF log should be loaded.
+        /// </param>
+        void LoadSarifLog(Stream stream);
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/Services/LoadSarifLogService.cs
+++ b/src/Sarif.Viewer.VisualStudio/Services/LoadSarifLogService.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Sarif.Viewer.Services
                 Title = Resources.ProcessLogFiles,
             };
 
-            TaskCompletionSource<bool> taskCompletionSource = new TaskCompletionSource<bool>();
+            var taskCompletionSource = new TaskCompletionSource<bool>();
             ITaskHandler taskHandler = taskStatusCenterService.PreRegister(taskHandlerOptions, taskProgressData);
             taskHandler.RegisterTask(taskCompletionSource.Task);
 
@@ -91,7 +91,7 @@ namespace Microsoft.Sarif.Viewer.Services
                         ProgressText = string.Format(CultureInfo.CurrentCulture, Resources.ProcessingLogFileFormat, validPaths[validPathIndex])
                     }); ;
 
-                    // We should not clean errors here, if the user wants to clear errors, they can call the close log service (ICloseSarifLogService::CloseAllSarifLogs)
+                    // We should not clean errors here. If the user wants to clear errors, they can call ICloseSarifLogService.CloseAllSarifLogs.
                     await ErrorListService.ProcessLogFileAsync(validPaths[validPathIndex], ToolFormat.None, promptOnLogConversions: false, cleanErrors: false, openInEditor: false).ConfigureAwait(continueOnCapturedContext: false);
 
                     taskHandler.Progress.Report(new TaskProgressData

--- a/src/Sarif.Viewer.VisualStudio/Services/LoadSarifLogService.cs
+++ b/src/Sarif.Viewer.VisualStudio/Services/LoadSarifLogService.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -11,13 +12,15 @@ using Microsoft.Sarif.Viewer.ErrorList;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.TaskStatusCenter;
 
+using Task = System.Threading.Tasks.Task;
+
 namespace Microsoft.Sarif.Viewer.Services
 {
     /// <summary>
     /// Provides an interface through which other extensions can interact with the this extension,
     /// in particular, to ask this extension to load a log file.
     /// </summary>
-    public class LoadSarifLogService : SLoadSarifLogService, ILoadSarifLogService, ILoadSarifLogService2
+    public class LoadSarifLogService : SLoadSarifLogService, ILoadSarifLogService, ILoadSarifLogService2, ILoadSarifLogService3
     {
         /// <inheritdoc/>
         public void LoadSarifLog(string path, bool promptOnSchemaUpgrade = true)
@@ -53,7 +56,13 @@ namespace Microsoft.Sarif.Viewer.Services
             LoadSarifLogAsync(paths).FileAndForget(Constants.FileAndForgetFaultEventNames.LoadSarifLogs);
         }
 
-        private async System.Threading.Tasks.Task LoadSarifLogAsync(IEnumerable<string> paths)
+        /// <inheritdoc/>
+        public void LoadSarifLog(Stream stream)
+        {
+            LoadSarifLogAsync(stream).FileAndForget(Constants.FileAndForgetFaultEventNames.LoadSarifLogs);
+        }
+
+        private async Task LoadSarifLogAsync(IEnumerable<string> paths)
         {
             List<string> validPaths = paths.Where(path => !string.IsNullOrEmpty(path)).ToList();
             if (validPaths.Count == 0)
@@ -104,6 +113,11 @@ namespace Microsoft.Sarif.Viewer.Services
             {
                 taskCompletionSource.SetResult(true);
             }
+        }
+
+        private async Task LoadSarifLogAsync(Stream stream)
+        {
+            await ErrorListService.ProcessSarifLogAsync(stream, showMessageOnNoResults: false, cleanErrors: false, openInEditor: false).ConfigureAwait(continueOnCapturedContext: false);
         }
     }
 }


### PR DESCRIPTION
This turns out to require only a small change to `ErrorListService`. We introduce a "shim" API `ErrorListService.ProcessSarifLogAsync(Stream)`, which deserializes the stream into a `SarifLog` and then calls an existing private API `ErrorListService.ProcessSarifLogAsync(SarifLog)`.

The fact that there is no file name available turns out not to matter:
- The file name never appears in the UI.
- At the moment, there is no gesture to re-read the file, or to re-persist it, so the lack of a backing file is moot.
- The extension does use the log file path, when prompting the user to resolve a source file path, as the "initial directory" in the File Open dialog. But if the path is null, it just starts in the current working directory.

The only other thing the extension uses the log file path for is as a key into a dictionary that associates sets of results with log files. This allows the extension to remove those results from the Error List when the user closes a log file. Without a file name, the results from a streamed in file can't be collectively removed from the error list.

But the scenario for using the stream-based APIs is background analysis, and there's no gesture today to remove (for example) all IDE warnings from the error list, or all warnings from the StyleCop or FxCop analyzer. So our proposed SARIF-based background analysis is no worse off in this regard than existing background analyses.

In fact, the stream-based API is no worse off than the file-based API in this regard. When another extension sends a SARIF file to the viewer through the file-based API, the viewer does _not_ display the file -- so again, there is no "close the file and remove its results from the Error List" gesture.

Because this turns out to "just work", we don't need to refactor, so we will close #254, "Refactors in preparation for stream-driven SARIF transfer API", as `resolved-wont-fix`.
