### PR TITLE
Enable symbols for interop project

### DIFF
--- a/scripts/ScriptUtilities.psm1
+++ b/scripts/ScriptUtilities.psm1
@@ -39,6 +39,7 @@ function New-NuGetPackageFromNuspecFile($configuration, $project, $version, $fra
     $arguments=
         "pack", $nuspecFile,
         "-Symbols",
+        "-SymbolPackageFormat", "snupkg",
         "-Properties", "platform=$Platform;configuration=$configuration;project=$project;version=$version;framework=$framework",
         "-Verbosity", "Quiet",
         "-BasePath", ".\",

--- a/src/Sarif.Viewer.VisualStudio.Interop/Sarif.Viewer.VisualStudio.Interop.nuspec
+++ b/src/Sarif.Viewer.VisualStudio.Interop/Sarif.Viewer.VisualStudio.Interop.nuspec
@@ -23,7 +23,7 @@
   <files>
     <file src="bld\bin\Signing\$framework$\$project$.dll"
           target="lib\$framework$" />
-    <file src="bld\bin\AnyCPU_Release\$project$\$project$.pdb"
+    <file src="bld\bin\$Platform$_$configuration$\$project$\$project$.pdb"
           target="lib\$framework$" />
     <file src="triskelion.png" />
     <file src="src\ReleaseHistory.md" />

--- a/src/Sarif.Viewer.VisualStudio.Interop/Sarif.Viewer.VisualStudio.Interop.nuspec
+++ b/src/Sarif.Viewer.VisualStudio.Interop/Sarif.Viewer.VisualStudio.Interop.nuspec
@@ -13,7 +13,6 @@
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/microsoft/sarif-visualstudio-extension</projectUrl>
     <icon>triskelion.png</icon>
-    <iconUrl>https://go.microsoft.com/fwlink/?linkid=2008860</iconUrl>
     <tags>SARIF viewer static analysis</tags>
     <packageTypes>
       <packageType name="Dependency" />
@@ -23,6 +22,8 @@
     </dependencies>  </metadata>
   <files>
     <file src="bld\bin\Signing\$framework$\$project$.dll"
+          target="lib\$framework$" />
+    <file src="bld\bin\AnyCPU_Release\$project$\$project$.pdb"
           target="lib\$framework$" />
     <file src="triskelion.png" />
     <file src="src\ReleaseHistory.md" />

--- a/src/build.props
+++ b/src/build.props
@@ -44,9 +44,11 @@
     <DefineConstants>DEBUG;TRACE;CODE_ANALYSIS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' " Label="Release build">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <DefineConstants>TRACE</DefineConstants>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'x86'" Label="x86 build">
     <PlatformTarget>x86</PlatformTarget>


### PR DESCRIPTION
## Changes
- enabling symbols
- fixing warning while packing (`iconurl` is deprecated)