### PR TITLE
Fix #230: Provide info bars through file-based APIs

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/TestUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/TestUtilities.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         {
             InitializeTestEnvironment();
 
-            await ErrorListService.ProcessSarifLogAsync(sarifLog, "", showMessageOnNoResults: true, cleanErrors: true, openInEditor: false);
+            await ErrorListService.ProcessSarifLogAsync(sarifLog, "", cleanErrors: true, openInEditor: false);
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/Controls/InfoBar.cs
+++ b/src/Sarif.Viewer.VisualStudio/Controls/InfoBar.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 
@@ -47,7 +48,7 @@ namespace Microsoft.Sarif.Viewer.Controls
         private uint eventCookie;
 
         private static readonly ReaderWriterLockSlimWrapper s_infoBarLock = new ReaderWriterLockSlimWrapper(new ReaderWriterLockSlim());
-        private static readonly IDictionary<InfoBar, ExceptionalConditions> s_infoBarToConditionDictionary = new Dictionary<InfoBar, ExceptionalConditions>();
+        private static readonly IDictionary<InfoBar, ExceptionalConditions> s_infoBarToConditionDictionary = new ConcurrentDictionary<InfoBar, ExceptionalConditions>();
 
         /// <summary>
         /// Display info bars appropriate to the specified set of "exceptional conditions."

--- a/src/Sarif.Viewer.VisualStudio/Controls/InfoBar.cs
+++ b/src/Sarif.Viewer.VisualStudio/Controls/InfoBar.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Sarif.Viewer.Controls
         {
             // It's safe to access and update the dictionary because this method is called inside
             // the write lock.
-            if ((detectedConditions & individualCondition) != 0 && !s_infoBarToConditionDictionary.Values.Contains(individualCondition))
+            if ((detectedConditions & individualCondition) == individualCondition && !s_infoBarToConditionDictionary.Values.Contains(individualCondition))
             {
                 var infoBar = new InfoBar(message, imageMoniker: imageMoniker);
                 await infoBar.ShowAsync();

--- a/src/Sarif.Viewer.VisualStudio/Controls/InfoBar.cs
+++ b/src/Sarif.Viewer.VisualStudio/Controls/InfoBar.cs
@@ -83,8 +83,8 @@ namespace Microsoft.Sarif.Viewer.Controls
                     KnownMonikers.StatusError);
 
                 await AddInfoBarIfRequiredAsync(
-                    ExceptionalConditions.NoResults,
                     conditions,
+                    ExceptionalConditions.NoResults,
                     Resources.InfoNoResultsInLog,
                     KnownMonikers.StatusInformation);
             }

--- a/src/Sarif.Viewer.VisualStudio/Controls/InfoBar.cs
+++ b/src/Sarif.Viewer.VisualStudio/Controls/InfoBar.cs
@@ -48,6 +48,11 @@ namespace Microsoft.Sarif.Viewer.Controls
         private uint eventCookie;
 
         private static readonly ReaderWriterLockSlimWrapper s_infoBarLock = new ReaderWriterLockSlimWrapper(new ReaderWriterLockSlim());
+
+        // It might seem more natural to use the condition as the dictionary key, and the InfoBar
+        // as the value. We wrote it this way because when the user closes an InfoBar, it's easier
+        // to remove it from the dictionary if the InfoBar itself is the key -- rather than having
+        // to look up the KeyValuePair that has that InfoBar as its value. See CloseAsync below.
         private static readonly IDictionary<InfoBar, ExceptionalConditions> s_infoBarToConditionDictionary = new ConcurrentDictionary<InfoBar, ExceptionalConditions>();
 
         /// <summary>

--- a/src/Sarif.Viewer.VisualStudio/Controls/InfoBar.cs
+++ b/src/Sarif.Viewer.VisualStudio/Controls/InfoBar.cs
@@ -177,8 +177,11 @@ namespace Microsoft.Sarif.Viewer.Controls
                 // Close the info bar to correctly send OnClosed() event to the Shell
                 this.uiElement.Close();
 
-                InfoBars.Remove(this.infoBarModel);
-                s_infoBarToConditionDictionary.Remove(this);
+                using (s_infoBarLock.EnterWriteLock())
+                {
+                    InfoBars.Remove(this.infoBarModel);
+                    s_infoBarToConditionDictionary.Remove(this);
+                }
 
                 this.uiElement = null;
             }
@@ -216,6 +219,8 @@ namespace Microsoft.Sarif.Viewer.Controls
             string message,
             ImageMoniker imageMoniker)
         {
+            // It's safe to access and update the dictionary because this method is called inside
+            // the write lock.
             if ((detectedConditions & individualCondition) != 0 && !s_infoBarToConditionDictionary.Values.Contains(individualCondition))
             {
                 var infoBar = new InfoBar(message, imageMoniker: imageMoniker);

--- a/src/Sarif.Viewer.VisualStudio/Controls/InfoBar.cs
+++ b/src/Sarif.Viewer.VisualStudio/Controls/InfoBar.cs
@@ -178,6 +178,7 @@ namespace Microsoft.Sarif.Viewer.Controls
                 this.uiElement.Close();
 
                 InfoBars.Remove(this.infoBarModel);
+                s_infoBarToConditionDictionary.Remove(this);
 
                 this.uiElement = null;
             }

--- a/src/Sarif.Viewer.VisualStudio/Controls/InfoBar.cs
+++ b/src/Sarif.Viewer.VisualStudio/Controls/InfoBar.cs
@@ -71,8 +71,8 @@ namespace Microsoft.Sarif.Viewer.Controls
                     KnownMonikers.StatusError);
 
                 await AddInfoBarIfRequiredAsync(
-                    ExceptionalConditions.ExecutionError,
                     conditions,
+                    ExceptionalConditions.ExecutionError,
                     Resources.ErrorLogHasErrorLevelToolExecutionNotifications,
                     KnownMonikers.StatusError);
 

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
     {
         public static readonly ErrorListService Instance = new ErrorListService();
 
-        internal static event EventHandler<LogFileProcessedEventArgs> LogFileProcessed;
+        internal static event EventHandler<LogProcessedEventArgs> LogProcessed;
 
         public static void ProcessLogFile(string filePath, string toolFormat, bool promptOnLogConversions, bool cleanErrors, bool openInEditor)
         {
@@ -67,6 +67,18 @@ namespace Microsoft.Sarif.Viewer.ErrorList
         }
 
         public static async Task ProcessLogFileAsync(string filePath, string toolFormat, bool promptOnLogConversions, bool cleanErrors, bool openInEditor)
+        {
+            try
+            {
+                await ProcessLogFileCoreAsync(filePath, toolFormat, promptOnLogConversions, cleanErrors, openInEditor);
+            }
+            catch (JsonReaderException)
+            {
+                RaiseLogProcessed(ExceptionalConditions.InvalidJson);
+            }
+        }
+
+        public static async Task ProcessLogFileCoreAsync(string filePath, string toolFormat, bool promptOnLogConversions, bool cleanErrors, bool openInEditor)
         {
             SarifLog log = null;
             string logText = null;
@@ -352,15 +364,13 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             }
             catch (JsonReaderException)
             {
-                LogFileProcessed?.Invoke(Instance, new LogFileProcessedEventArgs(ExceptionalConditions.InvalidJson));
+                RaiseLogProcessed(ExceptionalConditions.InvalidJson);
             }
 
             if (sarifLog != null)
             {
                 await ProcessSarifLogAsync(sarifLog, logFilePath: logId, showMessageOnNoResults: showMessageOnNoResults, cleanErrors: cleanErrors, openInEditor: openInEditor);
             }
-
-            LogFileProcessed?.Invoke(Instance, new LogFileProcessedEventArgs(ExceptionalConditionsCalculator.Calculate(sarifLog)));
         }
 
         internal static async Task ProcessSarifLogAsync(SarifLog sarifLog, string logFilePath, bool showMessageOnNoResults, bool cleanErrors, bool openInEditor)
@@ -428,6 +438,8 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                                                 OLEMSGBUTTON.OLEMSGBUTTON_OK,
                                                 OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST);
             }
+
+            RaiseLogProcessed(ExceptionalConditionsCalculator.Calculate(sarifLog));
         }
 
         public static void CleanAllErrors()
@@ -551,6 +563,11 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                     }
                 }
             }
+        }
+
+        private static void RaiseLogProcessed(ExceptionalConditions conditions)
+        {
+            LogProcessed?.Invoke(Instance, new LogProcessedEventArgs(conditions));
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -23,6 +23,7 @@ using Microsoft.CodeAnalysis.Sarif.Readers;
 using Microsoft.CodeAnalysis.Sarif.VersionOne;
 using Microsoft.CodeAnalysis.Sarif.Visitors;
 using Microsoft.CodeAnalysis.Sarif.Writers;
+using Microsoft.Sarif.Viewer.Controls;
 using Microsoft.Sarif.Viewer.Models;
 using Microsoft.Sarif.Viewer.Sarif;
 using Microsoft.Sarif.Viewer.Tags;
@@ -42,6 +43,11 @@ namespace Microsoft.Sarif.Viewer.ErrorList
         public static readonly ErrorListService Instance = new ErrorListService();
 
         internal static event EventHandler<LogProcessedEventArgs> LogProcessed;
+
+        static ErrorListService()
+        {
+            LogProcessed += ErrorListService_LogProcessed;
+        }
 
         public static void ProcessLogFile(string filePath, string toolFormat, bool promptOnLogConversions, bool cleanErrors, bool openInEditor)
         {
@@ -559,6 +565,14 @@ namespace Microsoft.Sarif.Viewer.ErrorList
         private static void RaiseLogProcessed(ExceptionalConditions conditions)
         {
             LogProcessed?.Invoke(Instance, new LogProcessedEventArgs(conditions));
+        }
+
+        private static void ErrorListService_LogProcessed(object sender, LogProcessedEventArgs e)
+        {
+            if (!SarifViewerPackage.IsUnitTesting)
+            {
+                InfoBar.CreateInfoBarsForExceptionalConditionsAsync(e.ExceptionalConditions).FileAndForget(FileAndForgetEventName.InfoBarOpenFailure);
+            }
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                 log = JsonConvert.DeserializeObject<SarifLog>(logText);
             }
 
-            await ProcessSarifLogAsync(log, outputPath, showMessageOnNoResults: promptOnLogConversions, cleanErrors: cleanErrors, openInEditor: openInEditor).ConfigureAwait(continueOnCapturedContext: false);
+            await ProcessSarifLogAsync(log, outputPath, cleanErrors: cleanErrors, openInEditor: openInEditor).ConfigureAwait(continueOnCapturedContext: false);
         }
 
         /// <summary>
@@ -355,7 +355,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             }
         }
 
-        internal static async Task ProcessSarifLogAsync(Stream stream, string logId, bool showMessageOnNoResults, bool cleanErrors, bool openInEditor)
+        internal static async Task ProcessSarifLogAsync(Stream stream, string logId, bool cleanErrors, bool openInEditor)
         {
             SarifLog sarifLog = null;
             try
@@ -369,11 +369,11 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
             if (sarifLog != null)
             {
-                await ProcessSarifLogAsync(sarifLog, logFilePath: logId, showMessageOnNoResults: showMessageOnNoResults, cleanErrors: cleanErrors, openInEditor: openInEditor);
+                await ProcessSarifLogAsync(sarifLog, logFilePath: logId, cleanErrors: cleanErrors, openInEditor: openInEditor);
             }
         }
 
-        internal static async Task ProcessSarifLogAsync(SarifLog sarifLog, string logFilePath, bool showMessageOnNoResults, bool cleanErrors, bool openInEditor)
+        internal static async Task ProcessSarifLogAsync(SarifLog sarifLog, string logFilePath, bool cleanErrors, bool openInEditor)
         {
             // The creation of the data models must be done on the UI thread (for now).
             // VS's table data source constructs are indeed thread safe.
@@ -428,15 +428,6 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                 {
                     SdkUIUtilities.ShowToolWindowAsync(new Guid(ToolWindowGuids80.ErrorList), activate: false).FileAndForget(Constants.FileAndForgetFaultEventNames.ShowErrorList);
                 }
-            }
-            else if (showMessageOnNoResults)
-            {
-                VsShellUtilities.ShowMessageBox(ServiceProvider.GlobalProvider,
-                                                string.Format(Resources.NoResults_DialogMessage, logFilePath),
-                                                null, // title
-                                                OLEMSGICON.OLEMSGICON_INFO,
-                                                OLEMSGBUTTON.OLEMSGBUTTON_OK,
-                                                OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST);
             }
 
             RaiseLogProcessed(ExceptionalConditionsCalculator.Calculate(sarifLog));

--- a/src/Sarif.Viewer.VisualStudio/LogFileProcessedEventArgs.cs
+++ b/src/Sarif.Viewer.VisualStudio/LogFileProcessedEventArgs.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sarif.Viewer
+{
+    // Provides data for the event handler invoked when the ErrorListService finishes
+    // finishes processing a SARIF log.
+    internal class LogFileProcessedEventArgs
+    {
+        internal LogFileProcessedEventArgs(ExceptionalConditions exceptionalConditions)
+        {
+            ExceptionalConditions = exceptionalConditions;
+        }
+
+        // Gets any exceptional conditions (for example, an error-level tool execution
+        // failure) that occurred during the processing of the log file.
+        internal ExceptionalConditions ExceptionalConditions { get; }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/LogProcessedEventArgs.cs
+++ b/src/Sarif.Viewer.VisualStudio/LogProcessedEventArgs.cs
@@ -7,13 +7,13 @@ namespace Microsoft.Sarif.Viewer
     // processing a SARIF log.
     internal class LogProcessedEventArgs
     {
-        internal LogProcessedEventArgs(ExceptionalConditions exceptionalConditions)
+        public LogProcessedEventArgs(ExceptionalConditions exceptionalConditions)
         {
             ExceptionalConditions = exceptionalConditions;
         }
 
         // Gets any exceptional conditions (for example, an error-level tool execution
         // failure) that occurred during the processing of the log file.
-        internal ExceptionalConditions ExceptionalConditions { get; }
+        public ExceptionalConditions ExceptionalConditions { get; }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/LogProcessedEventArgs.cs
+++ b/src/Sarif.Viewer.VisualStudio/LogProcessedEventArgs.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.Sarif.Viewer
 {
     // Provides data for the event handler invoked when the ErrorListService finishes
-    // finishes processing a SARIF log.
+    // processing a SARIF log.
     internal class LogProcessedEventArgs
     {
         internal LogProcessedEventArgs(ExceptionalConditions exceptionalConditions)

--- a/src/Sarif.Viewer.VisualStudio/LogProcessedEventArgs.cs
+++ b/src/Sarif.Viewer.VisualStudio/LogProcessedEventArgs.cs
@@ -5,9 +5,9 @@ namespace Microsoft.Sarif.Viewer
 {
     // Provides data for the event handler invoked when the ErrorListService finishes
     // finishes processing a SARIF log.
-    internal class LogFileProcessedEventArgs
+    internal class LogProcessedEventArgs
     {
-        internal LogFileProcessedEventArgs(ExceptionalConditions exceptionalConditions)
+        internal LogProcessedEventArgs(ExceptionalConditions exceptionalConditions)
         {
             ExceptionalConditions = exceptionalConditions;
         }

--- a/src/Sarif.Viewer.VisualStudio/Resources.Designer.cs
+++ b/src/Sarif.Viewer.VisualStudio/Resources.Designer.cs
@@ -351,15 +351,6 @@ namespace Microsoft.Sarif.Viewer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SARIF Explorer found no results in analysis log &apos;{0}&apos;..
-        /// </summary>
-        public static string NoResults_DialogMessage {
-            get {
-                return ResourceManager.GetString("NoResults_DialogMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The log file &apos;{0}&apos; was not found..
         /// </summary>
         public static string OpenLogFileFail_DilogMessage {

--- a/src/Sarif.Viewer.VisualStudio/Resources.Designer.cs
+++ b/src/Sarif.Viewer.VisualStudio/Resources.Designer.cs
@@ -126,6 +126,15 @@ namespace Microsoft.Sarif.Viewer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The InfoBar for condition &apos;{0}&apos; is already present in the dictionary..
+        /// </summary>
+        public static string ErrorInfoBarAlreadyPresent {
+            get {
+                return ResourceManager.GetString("ErrorInfoBarAlreadyPresent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The SARIF viewer received one or more corrupted SARIF logs, and they were ignored..
         /// </summary>
         public static string ErrorInvalidSarifStream {

--- a/src/Sarif.Viewer.VisualStudio/Resources.resx
+++ b/src/Sarif.Viewer.VisualStudio/Resources.resx
@@ -298,4 +298,7 @@
   <data name="ErrorLogHasErrorLevelToolExecutionNotifications" xml:space="preserve">
     <value>The SARIF viewer received one or more SARIF logs containing a run that failed due to a tool execution error. These logs might contain incomplete results.</value>
   </data>
+  <data name="ErrorInfoBarAlreadyPresent" xml:space="preserve">
+    <value>The InfoBar for condition '{0}' is already present in the dictionary.</value>
+  </data>
 </root>

--- a/src/Sarif.Viewer.VisualStudio/Resources.resx
+++ b/src/Sarif.Viewer.VisualStudio/Resources.resx
@@ -161,10 +161,6 @@
     <value>The log file '{0}' is invalid and couldn't be opened.</value>
     <comment>{0} will be the name of the invalid file that couldn't be opened</comment>
   </data>
-  <data name="NoResults_DialogMessage" xml:space="preserve">
-    <value>SARIF Explorer found no results in analysis log '{0}'.</value>
-    <comment>{0} will be the name of the file that was opened</comment>
-  </data>
   <data name="OpenLogFileFail_DilogMessage" xml:space="preserve">
     <value>The log file '{0}' was not found.</value>
     <comment>{0} will be the full file path</comment>

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Fixes\FixSuggestedAction.cs" />
     <Compile Include="Fixes\FixSuggestedActionsSource.cs" />
     <Compile Include="Fixes\FixSuggestedActionsSourceProvider.cs" />
+    <Compile Include="LogFileProcessedEventArgs.cs" />
     <Compile Include="Sarif\SarifLog.extensions.cs" />
     <Compile Include="Services\ICloseSarifLogService.cs" />
     <Compile Include="Services\ILoadSarifLogService.cs" />

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -86,7 +86,7 @@
     <Compile Include="Fixes\FixSuggestedAction.cs" />
     <Compile Include="Fixes\FixSuggestedActionsSource.cs" />
     <Compile Include="Fixes\FixSuggestedActionsSourceProvider.cs" />
-    <Compile Include="LogFileProcessedEventArgs.cs" />
+    <Compile Include="LogProcessedEventArgs.cs" />
     <Compile Include="Sarif\SarifLog.extensions.cs" />
     <Compile Include="Services\ICloseSarifLogService.cs" />
     <Compile Include="Services\ILoadSarifLogService.cs" />

--- a/src/Sarif.Viewer.VisualStudio/Services/LoadSarifLogService.cs
+++ b/src/Sarif.Viewer.VisualStudio/Services/LoadSarifLogService.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Sarif.Viewer.Services
 
         private void ErrorListService_LogProcessed(object sender, LogProcessedEventArgs e)
         {
-            InfoBar.CreateInfoBarsForExceptionalConditions(e.ExceptionalConditions);
+            InfoBar.CreateInfoBarsForExceptionalConditionsAsync(e.ExceptionalConditions).FileAndForget(FileAndForgetEventName.InfoBarOpenFailure);
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/Services/LoadSarifLogService.cs
+++ b/src/Sarif.Viewer.VisualStudio/Services/LoadSarifLogService.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis.Sarif.Converters;
-using Microsoft.Sarif.Viewer.Controls;
 using Microsoft.Sarif.Viewer.ErrorList;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.TaskStatusCenter;
@@ -23,14 +22,6 @@ namespace Microsoft.Sarif.Viewer.Services
     /// </summary>
     public class LoadSarifLogService : SLoadSarifLogService, ILoadSarifLogService
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LoadSarifLogService"/> class.
-        /// </summary>
-        public LoadSarifLogService()
-        {
-            ErrorListService.LogProcessed += this.ErrorListService_LogProcessed;
-        }
-
         /// <inheritdoc/>
         public void LoadSarifLog(string path, bool promptOnLogConversions = true, bool cleanErrors = true, bool openInEditor = false)
         {
@@ -124,11 +115,6 @@ namespace Microsoft.Sarif.Viewer.Services
             {
                 await ErrorListService.ProcessSarifLogAsync(stream, logId: null, cleanErrors: false, openInEditor: false).ConfigureAwait(continueOnCapturedContext: false);
             }
-        }
-
-        private void ErrorListService_LogProcessed(object sender, LogProcessedEventArgs e)
-        {
-            InfoBar.CreateInfoBarsForExceptionalConditionsAsync(e.ExceptionalConditions).FileAndForget(FileAndForgetEventName.InfoBarOpenFailure);
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/Services/LoadSarifLogService.cs
+++ b/src/Sarif.Viewer.VisualStudio/Services/LoadSarifLogService.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Sarif.Viewer.Services
         /// </summary>
         public LoadSarifLogService()
         {
-            ErrorListService.LogFileProcessed += this.ErrorListService_LogFileProcessed;
+            ErrorListService.LogProcessed += this.ErrorListService_LogProcessed;
         }
 
         /// <inheritdoc/>
@@ -126,7 +126,7 @@ namespace Microsoft.Sarif.Viewer.Services
             }
         }
 
-        private void ErrorListService_LogFileProcessed(object sender, LogFileProcessedEventArgs e)
+        private void ErrorListService_LogProcessed(object sender, LogProcessedEventArgs e)
         {
             InfoBar.CreateInfoBarsForExceptionalConditions(e.ExceptionalConditions);
         }

--- a/src/Sarif.Viewer.VisualStudio/Services/LoadSarifLogService.cs
+++ b/src/Sarif.Viewer.VisualStudio/Services/LoadSarifLogService.cs
@@ -23,6 +23,14 @@ namespace Microsoft.Sarif.Viewer.Services
     /// </summary>
     public class LoadSarifLogService : SLoadSarifLogService, ILoadSarifLogService
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoadSarifLogService"/> class.
+        /// </summary>
+        public LoadSarifLogService()
+        {
+            ErrorListService.LogFileProcessed += this.ErrorListService_LogFileProcessed;
+        }
+
         /// <inheritdoc/>
         public void LoadSarifLog(string path, bool promptOnLogConversions = true, bool cleanErrors = true, bool openInEditor = false)
         {
@@ -107,20 +115,20 @@ namespace Microsoft.Sarif.Viewer.Services
 
         private async Task LoadSarifLogAsync(Stream stream, string logId)
         {
-            ExceptionalConditions conditions = await ErrorListService.ProcessSarifLogAsync(stream, logId: logId, showMessageOnNoResults: false, cleanErrors: false, openInEditor: false).ConfigureAwait(continueOnCapturedContext: false);
-
-            InfoBar.CreateInfoBarsForExceptionalConditions(conditions);
+            await ErrorListService.ProcessSarifLogAsync(stream, logId: logId, showMessageOnNoResults: false, cleanErrors: false, openInEditor: false).ConfigureAwait(continueOnCapturedContext: false);
         }
 
         public async Task LoadSarifLogAsync(IEnumerable<Stream> streams)
         {
-            ExceptionalConditions conditions = ExceptionalConditions.None;
             foreach (Stream stream in streams)
             {
-                conditions |= await ErrorListService.ProcessSarifLogAsync(stream, logId: null, showMessageOnNoResults: false, cleanErrors: false, openInEditor: false).ConfigureAwait(continueOnCapturedContext: false);
+                await ErrorListService.ProcessSarifLogAsync(stream, logId: null, showMessageOnNoResults: false, cleanErrors: false, openInEditor: false).ConfigureAwait(continueOnCapturedContext: false);
             }
+        }
 
-            InfoBar.CreateInfoBarsForExceptionalConditions(conditions);
+        private void ErrorListService_LogFileProcessed(object sender, LogFileProcessedEventArgs e)
+        {
+            InfoBar.CreateInfoBarsForExceptionalConditions(e.ExceptionalConditions);
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/Services/LoadSarifLogService.cs
+++ b/src/Sarif.Viewer.VisualStudio/Services/LoadSarifLogService.cs
@@ -115,14 +115,14 @@ namespace Microsoft.Sarif.Viewer.Services
 
         private async Task LoadSarifLogAsync(Stream stream, string logId)
         {
-            await ErrorListService.ProcessSarifLogAsync(stream, logId: logId, showMessageOnNoResults: false, cleanErrors: false, openInEditor: false).ConfigureAwait(continueOnCapturedContext: false);
+            await ErrorListService.ProcessSarifLogAsync(stream, logId: logId, cleanErrors: false, openInEditor: false).ConfigureAwait(continueOnCapturedContext: false);
         }
 
         public async Task LoadSarifLogAsync(IEnumerable<Stream> streams)
         {
             foreach (Stream stream in streams)
             {
-                await ErrorListService.ProcessSarifLogAsync(stream, logId: null, showMessageOnNoResults: false, cleanErrors: false, openInEditor: false).ConfigureAwait(continueOnCapturedContext: false);
+                await ErrorListService.ProcessSarifLogAsync(stream, logId: null, cleanErrors: false, openInEditor: false).ConfigureAwait(continueOnCapturedContext: false);
             }
         }
 


### PR DESCRIPTION
Clients of the file-based viewer interop API now see info bars now appear for the same "exceptional conditions" as clients of the stream-based API.

The basic change that makes this possible is to have the `ErrorListService` raise an event when it finishes processing a log, rather than for `ErrorListService` APIs to _return_ the set of exceptional conditions. This is necessary because the file-based APIs are run in the background with "file and forget", so we never get a chance to see a return value.

Also:
- Fix #167: Opening multiple SARIF files will prompt user to select "ok" for every empty SARIF file.
    This actually no longer happened, because there was no code path that popped the dialog. But the code to show the dialog was still there, and I removed it.
