### PR TITLE
Allow exceptions to escape from task status center so tests can see them

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             Task task = ProcessLogFileAsync(filePath, toolFormat, promptOnLogConversions, cleanErrors, openInEditor);
             taskHandler.RegisterTask(task);
 
-            await task;
+            await task.ConfigureAwait(continueOnCapturedContext: false);
         }
 
         public static async Task ProcessLogFileAsync(string filePath, string toolFormat, bool promptOnLogConversions, bool cleanErrors, bool openInEditor)

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -51,6 +51,11 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
         public static void ProcessLogFile(string filePath, string toolFormat, bool promptOnLogConversions, bool cleanErrors, bool openInEditor)
         {
+            ThreadHelper.JoinableTaskFactory.Run(() => ProcessLogFileWrapperAsync(filePath, toolFormat, promptOnLogConversions, cleanErrors, openInEditor));
+        }
+
+        public static async Task ProcessLogFileWrapperAsync(string filePath, string toolFormat, bool promptOnLogConversions, bool cleanErrors, bool openInEditor)
+        {
             var taskStatusCenterService = (IVsTaskStatusCenterService)Package.GetGlobalService(typeof(SVsTaskStatusCenterService));
             var taskProgressData = new TaskProgressData
             {
@@ -69,7 +74,10 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
             ITaskHandler taskHandler = taskStatusCenterService.PreRegister(taskHandlerOptions, taskProgressData);
 
-            taskHandler.RegisterTask(ProcessLogFileAsync(filePath, toolFormat, promptOnLogConversions, cleanErrors, openInEditor));
+            Task task = ProcessLogFileAsync(filePath, toolFormat, promptOnLogConversions, cleanErrors, openInEditor);
+            taskHandler.RegisterTask(task);
+
+            await task;
         }
 
         public static async Task ProcessLogFileAsync(string filePath, string toolFormat, bool promptOnLogConversions, bool cleanErrors, bool openInEditor)


### PR DESCRIPTION
In the file-based API code path, the log file handling was being done in a background task in the Task Status Center. If that background task threw an exception, it was lost. The affected test would fail with an verification failure, but the stack trace did not reveal the exception that caused the failure.

In this PR, we refactor to assign the background task to a temporary variable, pass the task variable to the Task Status Center, and then await the task ourselves. Now if the task throws an exception, the viewer will rethrow it, and Apex will detect and report it.

I've tested this by intentionally introducing an exception into the error list service's log file handling and watching Apex report it.