### PR TITLE
Remove deep clone on call to `PopulateTextRegionProperties`

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/Sarif/Replacement.Extensions.cs
+++ b/src/Sarif.Viewer.VisualStudio/Sarif/Replacement.Extensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Sarif.Viewer.Sarif
             ReplacementModel model = new ReplacementModel
             {
                 Region = uri.IsAbsoluteUri
-                    ? fileRegionsCache.PopulateTextRegionProperties(replacement.DeletedRegion.DeepClone(), uri, populateSnippet: false)
+                    ? fileRegionsCache.PopulateTextRegionProperties(replacement.DeletedRegion, uri, populateSnippet: false)
                     : replacement.DeletedRegion
             };
 


### PR DESCRIPTION
The `PopulateTextRegionProperties` already clones its input argument before injecting other region properties to it (and returning). It is therefore unnecessary to clone the region before calling.

>            Region region = inputRegion.DeepClone();