### PR TITLE
Clear results before analyze + fixes

### DIFF
--- a/src/Sarif.Sarifer/AnalyzeProjectCommand.cs
+++ b/src/Sarif.Sarifer/AnalyzeProjectCommand.cs
@@ -38,6 +38,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         /// </summary>
         public void Cancel()
         {
+            this.backgroundAnalysisService.ClearAsync()
+                .FileAndForget(FileAndForgetEventName.BackgroundAnalysisFailure);
             this.cancellationTokenSource?.Cancel();
         }
 

--- a/src/Sarif.Sarifer/AnalyzeProjectCommand.cs
+++ b/src/Sarif.Sarifer/AnalyzeProjectCommand.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         /// </summary>
         public void Cancel()
         {
-            this.backgroundAnalysisService.ClearAsync()
+            this.backgroundAnalysisService.ClearResultsAsync()
                 .FileAndForget(FileAndForgetEventName.BackgroundAnalysisFailure);
             this.cancellationTokenSource?.Cancel();
         }

--- a/src/Sarif.Sarifer/AnalyzeProjectCommand.cs
+++ b/src/Sarif.Sarifer/AnalyzeProjectCommand.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         /// </summary>
         public void Cancel()
         {
-            this.backgroundAnalysisService.ClearResultsAsync()
+            this.backgroundAnalysisService?.ClearResultsAsync()
                 .FileAndForget(FileAndForgetEventName.BackgroundAnalysisFailure);
             this.cancellationTokenSource?.Cancel();
         }

--- a/src/Sarif.Sarifer/AnalyzeSolutionCommand.cs
+++ b/src/Sarif.Sarifer/AnalyzeSolutionCommand.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         /// </summary>
         public void Cancel()
         {
-            this.backgroundAnalysisService.ClearResultsAsync()
+            this.backgroundAnalysisService?.ClearResultsAsync()
                 .FileAndForget(FileAndForgetEventName.BackgroundAnalysisFailure);
             this.cancellationTokenSource?.Cancel();
         }

--- a/src/Sarif.Sarifer/AnalyzeSolutionCommand.cs
+++ b/src/Sarif.Sarifer/AnalyzeSolutionCommand.cs
@@ -37,6 +37,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         /// </summary>
         public void Cancel()
         {
+            this.backgroundAnalysisService.ClearAsync()
+                .FileAndForget(FileAndForgetEventName.BackgroundAnalysisFailure);
             this.cancellationTokenSource?.Cancel();
         }
 

--- a/src/Sarif.Sarifer/AnalyzeSolutionCommand.cs
+++ b/src/Sarif.Sarifer/AnalyzeSolutionCommand.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         /// </summary>
         public void Cancel()
         {
-            this.backgroundAnalysisService.ClearAsync()
+            this.backgroundAnalysisService.ClearResultsAsync()
                 .FileAndForget(FileAndForgetEventName.BackgroundAnalysisFailure);
             this.cancellationTokenSource?.Cancel();
         }

--- a/src/Sarif.Sarifer/BackgroundAnalysisService.cs
+++ b/src/Sarif.Sarifer/BackgroundAnalysisService.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
     [Export(typeof(IBackgroundAnalysisService))]
     internal class BackgroundAnalysisService : IBackgroundAnalysisService
     {
-#pragma warning disable IDE0044, CS0649 // Assigned,Filled in by MEF
+#pragma warning disable IDE0044, CS0649 // Provided by MEF
         [ImportMany]
         private IEnumerable<IBackgroundAnalyzer> analyzers;
 #pragma warning restore IDE0044, CS0649

--- a/src/Sarif.Sarifer/BackgroundAnalysisService.cs
+++ b/src/Sarif.Sarifer/BackgroundAnalysisService.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,32 +21,39 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
 #pragma warning disable IDE0044, CS0649 // Provided by MEF
         [ImportMany]
         private IEnumerable<IBackgroundAnalyzer> analyzers;
+
+        [ImportMany]
+        private IEnumerable<IBackgroundAnalysisSink> sinks;
 #pragma warning restore IDE0044, CS0649
 
         /// <inheritdoc/>
         public async Task AnalyzeAsync(string path, string text, CancellationToken cancellationToken)
         {
-            var tasks = new List<Task>(this.analyzers.Count());
+            var tasks = new List<Task<Stream>>(this.analyzers.Count());
 
             foreach (IBackgroundAnalyzer analyzer in this.analyzers)
             {
                 tasks.Add(analyzer.AnalyzeAsync(path, text, cancellationToken));
             }
 
-            await Task.WhenAll(tasks).ConfigureAwait(continueOnCapturedContext: false);
+            Stream[] streams = await Task.WhenAll(tasks).ConfigureAwait(continueOnCapturedContext: false);
+            await this.WriteStreamsToSinksAsync(path, streams, cleanAll: false).ConfigureAwait(continueOnCapturedContext: false);
+            DisposeStreams(streams);
         }
 
         /// <inheritdoc/>
         public async Task AnalyzeAsync(string logId, IEnumerable<string> targetFiles, CancellationToken cancellationToken)
         {
-            var tasks = new List<Task>(this.analyzers.Count());
+            var tasks = new List<Task<Stream>>(this.analyzers.Count());
 
             foreach (IBackgroundAnalyzer analyzer in this.analyzers)
             {
                 tasks.Add(analyzer.AnalyzeAsync(logId, targetFiles, cancellationToken));
             }
 
-            await Task.WhenAll(tasks).ConfigureAwait(continueOnCapturedContext: false);
+            Stream[] streams = await Task.WhenAll(tasks).ConfigureAwait(continueOnCapturedContext: false);
+            await this.WriteStreamsToSinksAsync(logId, streams, cleanAll: true).ConfigureAwait(continueOnCapturedContext: false);
+            DisposeStreams(streams);
         }
 
         /// <inheritdoc/>
@@ -53,12 +61,50 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         {
             var tasks = new List<Task>(this.analyzers.Count());
 
-            foreach (IBackgroundAnalyzer analyzer in this.analyzers)
+            foreach (IBackgroundAnalysisSink sink in this.sinks)
             {
-                tasks.Add(analyzer.ClearResultsAsync());
+                tasks.Add(sink.CloseAsync());
             }
 
             await Task.WhenAll(tasks).ConfigureAwait(continueOnCapturedContext: false);
+        }
+
+        private Task WriteStreamsToSinksAsync(string logId, Stream[] streams, bool cleanAll)
+        {
+            var sinkTasks = new List<Task>(this.analyzers.Count());
+            foreach (Stream stream in streams)
+            {
+                sinkTasks.Add(this.WriteToSinksAsync(logId, stream, cleanAll));
+            }
+
+            return Task.WhenAll(sinkTasks);
+        }
+
+        private async Task WriteToSinksAsync(string logId, Stream stream, bool cleanAll)
+        {
+            foreach (IBackgroundAnalysisSink sink in this.sinks)
+            {
+                stream.Seek(0L, SeekOrigin.Begin);
+
+                if (cleanAll)
+                {
+                    await sink.CloseAsync().ConfigureAwait(false);
+                }
+                else
+                {
+                    await sink.CloseAsync(new[] { logId }).ConfigureAwait(false);
+                }
+
+                await sink.ReceiveAsync(stream, logId).ConfigureAwait(false);
+            }
+        }
+
+        private static void DisposeStreams(Stream[] streams)
+        {
+            foreach (Stream stream in streams)
+            {
+                stream.Dispose();
+            }
         }
     }
 }

--- a/src/Sarif.Sarifer/BackgroundAnalysisService.cs
+++ b/src/Sarif.Sarifer/BackgroundAnalysisService.cs
@@ -49,13 +49,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         }
 
         /// <inheritdoc/>
-        public async Task ClearAsync()
+        public async Task ClearResultsAsync()
         {
             var tasks = new List<Task>(this.analyzers.Count());
 
             foreach (IBackgroundAnalyzer analyzer in this.analyzers)
             {
-                tasks.Add(analyzer.ClearAsync());
+                tasks.Add(analyzer.ClearResultsAsync());
             }
 
             await Task.WhenAll(tasks).ConfigureAwait(continueOnCapturedContext: false);

--- a/src/Sarif.Sarifer/BackgroundAnalysisService.cs
+++ b/src/Sarif.Sarifer/BackgroundAnalysisService.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
 
             foreach (IBackgroundAnalyzer analyzer in this.analyzers)
             {
-                tasks.Add(analyzer.AnalyzeAsync(logId, targetFiles, cancellationToken));
+                tasks.Add(analyzer.AnalyzeAsync(targetFiles, cancellationToken));
             }
 
             Stream[] streams = await Task.WhenAll(tasks).ConfigureAwait(continueOnCapturedContext: false);

--- a/src/Sarif.Sarifer/BackgroundAnalysisService.cs
+++ b/src/Sarif.Sarifer/BackgroundAnalysisService.cs
@@ -87,6 +87,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
             var sinkTasks = new List<Task>(this.analyzers.Count());
             foreach (Stream stream in streams)
             {
+                if (stream == Stream.Null)
+                {
+                    continue;
+                }
+
                 sinkTasks.Add(this.WriteToSinksAsync(logId, stream, cleanAll));
             }
 

--- a/src/Sarif.Sarifer/BackgroundAnalysisService.cs
+++ b/src/Sarif.Sarifer/BackgroundAnalysisService.cs
@@ -17,12 +17,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
     [Export(typeof(IBackgroundAnalysisService))]
     internal class BackgroundAnalysisService : IBackgroundAnalysisService
     {
-#pragma warning disable CS0649 // Filled in by MEF
-#pragma warning disable IDE0044 // Assigned by MEF
+#pragma warning disable IDE0044, CS0649 // Assigned,Filled in by MEF
         [ImportMany]
         private IEnumerable<IBackgroundAnalyzer> analyzers;
-#pragma warning restore IDE0044
-#pragma warning restore CS0649
+#pragma warning restore IDE0044, CS0649
 
         /// <inheritdoc/>
         public async Task AnalyzeAsync(string path, string text, CancellationToken cancellationToken)
@@ -45,6 +43,19 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
             foreach (IBackgroundAnalyzer analyzer in this.analyzers)
             {
                 tasks.Add(analyzer.AnalyzeAsync(logId, targetFiles, cancellationToken));
+            }
+
+            await Task.WhenAll(tasks).ConfigureAwait(continueOnCapturedContext: false);
+        }
+
+        /// <inheritdoc/>
+        public async Task ClearAsync()
+        {
+            var tasks = new List<Task>(this.analyzers.Count());
+
+            foreach (IBackgroundAnalyzer analyzer in this.analyzers)
+            {
+                tasks.Add(analyzer.ClearAsync());
             }
 
             await Task.WhenAll(tasks).ConfigureAwait(continueOnCapturedContext: false);

--- a/src/Sarif.Sarifer/BackgroundAnalysisService.cs
+++ b/src/Sarif.Sarifer/BackgroundAnalysisService.cs
@@ -37,8 +37,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
             }
 
             Stream[] streams = await Task.WhenAll(tasks).ConfigureAwait(continueOnCapturedContext: false);
-            await this.WriteStreamsToSinksAsync(path, streams, cleanAll: false).ConfigureAwait(continueOnCapturedContext: false);
-            DisposeStreams(streams);
+
+            try
+            {
+                await this.WriteStreamsToSinksAsync(path, streams, cleanAll: false).ConfigureAwait(continueOnCapturedContext: false);
+            }
+            finally
+            {
+                DisposeStreams(streams);
+            }
         }
 
         /// <inheritdoc/>
@@ -52,8 +59,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
             }
 
             Stream[] streams = await Task.WhenAll(tasks).ConfigureAwait(continueOnCapturedContext: false);
-            await this.WriteStreamsToSinksAsync(logId, streams, cleanAll: true).ConfigureAwait(continueOnCapturedContext: false);
-            DisposeStreams(streams);
+            try
+            {
+                await this.WriteStreamsToSinksAsync(logId, streams, cleanAll: true).ConfigureAwait(continueOnCapturedContext: false);
+            }
+            finally
+            {
+                DisposeStreams(streams);
+            }
         }
 
         /// <inheritdoc/>

--- a/src/Sarif.Sarifer/BackgroundAnalysisTextViewCreationListener.cs
+++ b/src/Sarif.Sarifer/BackgroundAnalysisTextViewCreationListener.cs
@@ -30,8 +30,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         private bool disposed;
         private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
 
-#pragma warning disable CS0649 // Filled in by MEF
-#pragma warning disable IDE0044 // Assigned by MEF
+#pragma warning disable IDE0044, CS0649 // Assigned,Filled in by MEF
         [Import]
         private Lazy<IBackgroundAnalysisService> backgroundAnalysisService;
 
@@ -40,8 +39,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
 
         [Import]
         private ITextBufferViewTracker textBufferViewTracker;
-#pragma warning restore IDE0044
-#pragma warning restore CS0649
+#pragma warning restore IDE0044, CS0649
 
         /// <inheritdoc/>
         public void TextViewCreated(ITextView textView)

--- a/src/Sarif.Sarifer/BackgroundAnalysisTextViewCreationListener.cs
+++ b/src/Sarif.Sarifer/BackgroundAnalysisTextViewCreationListener.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         private bool disposed;
         private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
 
-#pragma warning disable IDE0044, CS0649 // Assigned,Filled in by MEF
+#pragma warning disable IDE0044, CS0649 // Provided by MEF
         [Import]
         private Lazy<IBackgroundAnalysisService> backgroundAnalysisService;
 

--- a/src/Sarif.Sarifer/BackgroundAnalyzerBase.cs
+++ b/src/Sarif.Sarifer/BackgroundAnalyzerBase.cs
@@ -54,31 +54,39 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
                 return Stream.Null;
             }
 
-            var stream = new MemoryStream();
-            using (var writer = new StreamWriter(stream, Encoding.UTF8, DefaultBufferSize, leaveOpen: true))
+            try
             {
-                using (SarifLogger sarifLogger = this.MakeSarifLogger(writer))
+                var stream = new MemoryStream();
+                using (var writer = new StreamWriter(stream, Encoding.UTF8, DefaultBufferSize, leaveOpen: true))
                 {
-                    sarifLogger.AnalysisStarted();
+                    using (SarifLogger sarifLogger = this.MakeSarifLogger(writer))
+                    {
+                        sarifLogger.AnalysisStarted();
 
-                    // TODO: What do we do when path is null (text buffer with no backing file)?
-                    Uri uri = path != null ? new Uri(path, UriKind.Absolute) : null;
+                        // TODO: What do we do when path is null (text buffer with no backing file)?
+                        Uri uri = path != null ? new Uri(path, UriKind.Absolute) : null;
 
-                    this.AnalyzeCore(uri, text, solutionDirectory, sarifLogger, cancellationToken);
+                        this.AnalyzeCore(uri, text, solutionDirectory, sarifLogger, cancellationToken);
 
-                    sarifLogger.AnalysisStopped(RuntimeConditions.None);
+                        sarifLogger.AnalysisStopped(RuntimeConditions.None);
+                    }
+
+                    await writer.FlushAsync().ConfigureAwait(continueOnCapturedContext: false);
                 }
 
-                await writer.FlushAsync().ConfigureAwait(continueOnCapturedContext: false);
+                return stream;
             }
-
-            return stream;
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                return Stream.Null;
+            }
         }
 
         /// <inheritdoc/>
-        public async Task<Stream> AnalyzeAsync(string logId, IEnumerable<string> targetFiles, CancellationToken cancellationToken)
+        public async Task<Stream> AnalyzeAsync(IEnumerable<string> targetFiles, CancellationToken cancellationToken)
         {
-            logId = logId ?? throw new ArgumentNullException(nameof(logId));
             targetFiles = targetFiles ?? throw new ArgumentNullException(nameof(targetFiles));
 
             if (!targetFiles.Any())
@@ -88,28 +96,37 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
 
             string solutionDirectory = await GetSolutionDirectoryAsync().ConfigureAwait(continueOnCapturedContext: false);
 
-            var stream = new MemoryStream();
-            using (var writer = new StreamWriter(stream, Encoding.UTF8, DefaultBufferSize, leaveOpen: true))
+            try
             {
-                using (SarifLogger sarifLogger = this.MakeSarifLogger(writer))
+                var stream = new MemoryStream();
+                using (var writer = new StreamWriter(stream, Encoding.UTF8, DefaultBufferSize, leaveOpen: true))
                 {
-                    sarifLogger.AnalysisStarted();
-
-                    foreach (string targetFile in targetFiles)
+                    using (SarifLogger sarifLogger = this.MakeSarifLogger(writer))
                     {
-                        var uri = new Uri(targetFile, UriKind.Absolute);
-                        string text = File.ReadAllText(targetFile);
+                        sarifLogger.AnalysisStarted();
 
-                        this.AnalyzeCore(uri, text, solutionDirectory, sarifLogger, cancellationToken);
+                        foreach (string targetFile in targetFiles)
+                        {
+                            var uri = new Uri(targetFile, UriKind.Absolute);
+                            string text = File.ReadAllText(targetFile);
+
+                            this.AnalyzeCore(uri, text, solutionDirectory, sarifLogger, cancellationToken);
+                        }
+
+                        sarifLogger.AnalysisStopped(RuntimeConditions.None);
                     }
 
-                    sarifLogger.AnalysisStopped(RuntimeConditions.None);
+                    await writer.FlushAsync().ConfigureAwait(continueOnCapturedContext: false);
                 }
 
-                await writer.FlushAsync().ConfigureAwait(continueOnCapturedContext: false);
+                return stream;
             }
-
-            return stream;
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                return Stream.Null;
+            }
         }
 
         /// <summary>

--- a/src/Sarif.Sarifer/BackgroundAnalyzerBase.cs
+++ b/src/Sarif.Sarifer/BackgroundAnalyzerBase.cs
@@ -54,6 +54,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
 
             string solutionDirectory = await GetSolutionDirectoryAsync().ConfigureAwait(continueOnCapturedContext: false);
 
+            // If we don't have a solutionDirectory, then, we don't need to analyze.
+            if (string.IsNullOrEmpty(solutionDirectory))
+            {
+                return;
+            }
+
             using (Stream stream = new MemoryStream())
             using (TextWriter writer = new StreamWriter(stream, Encoding.UTF8))
             {

--- a/src/Sarif.Sarifer/BackgroundAnalyzerBase.cs
+++ b/src/Sarif.Sarifer/BackgroundAnalyzerBase.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
     /// </remarks>
     public abstract class BackgroundAnalyzerBase : IBackgroundAnalyzer
     {
-#pragma warning disable IDE0044, CS0649 // Assigned,Filled by MEF
+#pragma warning disable IDE0044, CS0649 // Provided by MEF
         [ImportMany]
         private IEnumerable<IBackgroundAnalysisSink> sinks;
 #pragma warning restore IDE0044, CS0649
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
 
                 await writer.FlushAsync().ConfigureAwait(continueOnCapturedContext: false);
 
-                await this.WriteToSinksAsync(path, stream, false).ConfigureAwait(false);
+                await this.WriteToSinksAsync(path, stream, cleanAll: false).ConfigureAwait(continueOnCapturedContext: false);
             }
         }
 
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
 
                 await writer.FlushAsync().ConfigureAwait(continueOnCapturedContext: false);
 
-                await this.WriteToSinksAsync(logId, stream, true).ConfigureAwait(false);
+                await this.WriteToSinksAsync(logId, stream, cleanAll: true).ConfigureAwait(continueOnCapturedContext: false);
             }
         }
 

--- a/src/Sarif.Sarifer/BackgroundAnalyzerBase.cs
+++ b/src/Sarif.Sarifer/BackgroundAnalyzerBase.cs
@@ -54,9 +54,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
                 return Stream.Null;
             }
 
+            var stream = new MemoryStream();
             try
             {
-                var stream = new MemoryStream();
                 using (var writer = new StreamWriter(stream, Encoding.UTF8, DefaultBufferSize, leaveOpen: true))
                 {
                     using (SarifLogger sarifLogger = this.MakeSarifLogger(writer))
@@ -80,6 +80,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
             catch (Exception)
 #pragma warning restore CA1031 // Do not catch general exception types
             {
+                stream.Dispose();
                 return Stream.Null;
             }
         }
@@ -96,9 +97,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
 
             string solutionDirectory = await GetSolutionDirectoryAsync().ConfigureAwait(continueOnCapturedContext: false);
 
+            var stream = new MemoryStream();
             try
             {
-                var stream = new MemoryStream();
                 using (var writer = new StreamWriter(stream, Encoding.UTF8, DefaultBufferSize, leaveOpen: true))
                 {
                     using (SarifLogger sarifLogger = this.MakeSarifLogger(writer))
@@ -125,6 +126,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
             catch (Exception)
 #pragma warning restore CA1031 // Do not catch general exception types
             {
+                stream.Dispose();
                 return Stream.Null;
             }
         }

--- a/src/Sarif.Sarifer/BackgroundAnalyzerBase.cs
+++ b/src/Sarif.Sarifer/BackgroundAnalyzerBase.cs
@@ -118,7 +118,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
             }
         }
 
-        public async Task ClearAsync()
+        /// <inheritdoc/>
+        public async Task ClearResultsAsync()
         {
             foreach (IBackgroundAnalysisSink sink in this.sinks)
             {

--- a/src/Sarif.Sarifer/FirstViewAddedEventArgs.cs
+++ b/src/Sarif.Sarifer/FirstViewAddedEventArgs.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         /// Initializes a new instance of the <see cref="FirstViewAddedEventArgs"/> class.
         /// </summary>
         /// <param name="path">
-        /// The path to the file whose contents are being viewed, or <code>null</code> if
+        /// The path to the file whose contents are being viewed, or <c>null</c> if
         /// <paramref name="textBuffer"/> is not associated with a file.
         /// </param>
         /// <param name="text">
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         }
 
         /// <summary>
-        /// Gets the path to the file whose contents are being viewed, or <code>null</code> if
+        /// Gets the path to the file whose contents are being viewed, or <c>null</c> if
         /// <see cref="TextBuffer"/> is not associated with a file.
         /// </summary>
         public string Path { get; }

--- a/src/Sarif.Sarifer/IBackgroundAnalysisService.cs
+++ b/src/Sarif.Sarifer/IBackgroundAnalysisService.cs
@@ -50,6 +50,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         /// <summary>
         /// Clear all results.
         /// </summary>
-        Task ClearAsync();
+        Task ClearResultsAsync();
     }
 }

--- a/src/Sarif.Sarifer/IBackgroundAnalysisService.cs
+++ b/src/Sarif.Sarifer/IBackgroundAnalysisService.cs
@@ -46,5 +46,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         /// A <see cref="Task"/> that represents the completion of the analysis.
         /// </returns>
         Task AnalyzeAsync(string logId, IEnumerable<string> targetFiles, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Clear all results.
+        /// </summary>
+        Task ClearAsync();
     }
 }

--- a/src/Sarif.Sarifer/IBackgroundAnalysisSink.cs
+++ b/src/Sarif.Sarifer/IBackgroundAnalysisSink.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -31,5 +32,16 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         /// <paramref name="logStream"/>.
         /// </returns>
         Task ReceiveAsync(Stream logStream, string logId);
+
+        /// <summary>
+        /// Closes all SARIF logs opened in the viewer.
+        /// </summary>
+        Task CloseAsync();
+
+        /// <summary>
+        /// Closes the specified SARIF log files in the SARIF Viewer extension.
+        /// </summary>
+        /// <param name="paths">The paths to the log files.</param>
+        Task CloseAsync(IEnumerable<string> paths);
     }
 }

--- a/src/Sarif.Sarifer/IBackgroundAnalyzer.cs
+++ b/src/Sarif.Sarifer/IBackgroundAnalyzer.cs
@@ -49,9 +49,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         /// <summary>
         /// Analyzes the specified files.
         /// </summary>
-        /// <param name="logId">
-        /// A unique identifier for this analysis.
-        /// </param>
         /// <param name="targetFiles">
         /// The absolute paths of the files to analyze.
         /// </param>
@@ -61,6 +58,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         /// <returns>
         /// A <see cref="Task{Stream}"/> that represents the result of the background analysis.
         /// </returns>
-        Task<Stream> AnalyzeAsync(string logId, IEnumerable<string> targetFiles, CancellationToken cancellationToken);
+        Task<Stream> AnalyzeAsync(IEnumerable<string> targetFiles, CancellationToken cancellationToken);
     }
 }

--- a/src/Sarif.Sarifer/IBackgroundAnalyzer.cs
+++ b/src/Sarif.Sarifer/IBackgroundAnalyzer.cs
@@ -65,6 +65,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         /// <summary>
         /// Clear all results.
         /// </summary>
-        Task ClearAsync();
+        Task ClearResultsAsync();
     }
 }

--- a/src/Sarif.Sarifer/IBackgroundAnalyzer.cs
+++ b/src/Sarif.Sarifer/IBackgroundAnalyzer.cs
@@ -61,5 +61,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         /// A <see cref="Task"/> that represents the completion of the background analysis.
         /// </returns>
         Task AnalyzeAsync(string logId, IEnumerable<string> targetFiles, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Clear all results.
+        /// </summary>
+        Task ClearAsync();
     }
 }

--- a/src/Sarif.Sarifer/IBackgroundAnalyzer.cs
+++ b/src/Sarif.Sarifer/IBackgroundAnalyzer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -41,9 +42,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         /// A <see cref="CancellationToken"/> that can be used to cancel the background analysis.
         /// </param>
         /// <returns>
-        /// A <see cref="Task"/> that represents the completion of the background analysis.
+        /// A <see cref="Task{Stream}"/> that represents the result of the background analysis.
         /// </returns>
-        Task AnalyzeAsync(string path, string text, CancellationToken cancellationToken);
+        Task<Stream> AnalyzeAsync(string path, string text, CancellationToken cancellationToken);
 
         /// <summary>
         /// Analyzes the specified files.
@@ -58,13 +59,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         /// A <see cref="CancellationToken"/> that can be used to cancel the background analysis.
         /// </param>
         /// <returns>
-        /// A <see cref="Task"/> that represents the completion of the background analysis.
+        /// A <see cref="Task{Stream}"/> that represents the result of the background analysis.
         /// </returns>
-        Task AnalyzeAsync(string logId, IEnumerable<string> targetFiles, CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Clear all results.
-        /// </summary>
-        Task ClearResultsAsync();
+        Task<Stream> AnalyzeAsync(string logId, IEnumerable<string> targetFiles, CancellationToken cancellationToken);
     }
 }

--- a/src/Sarif.Sarifer/SarifViewerBackgroundAnalysisSink.cs
+++ b/src/Sarif.Sarifer/SarifViewerBackgroundAnalysisSink.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Threading;
@@ -32,6 +33,26 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
             SarifViewerInterop sarifViewerInterop = await this.GetInteropObjectAsync().ConfigureAwait(continueOnCapturedContext: true);
 
             await sarifViewerInterop.OpenSarifLogAsync(logStream, logId).ConfigureAwait(continueOnCapturedContext: false);
+        }
+
+        /// <inheritdoc/>
+        public async Task CloseAsync()
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            SarifViewerInterop sarifViewerInterop = await this.GetInteropObjectAsync().ConfigureAwait(continueOnCapturedContext: true);
+
+            await sarifViewerInterop.CloseAllSarifLogsAsync().ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task CloseAsync(IEnumerable<string> paths)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            SarifViewerInterop sarifViewerInterop = await this.GetInteropObjectAsync().ConfigureAwait(continueOnCapturedContext: true);
+
+            await sarifViewerInterop.CloseSarifLogAsync(paths).ConfigureAwait(false);
         }
 
         private async System.Threading.Tasks.Task<SarifViewerInterop> GetInteropObjectAsync()

--- a/src/Sarif.Sarifer/SpamBackgroundAnalyzer.cs
+++ b/src/Sarif.Sarifer/SpamBackgroundAnalyzer.cs
@@ -32,7 +32,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         public SpamBackgroundAnalyzer()
         {
             this.fileSystem = FileSystem.Instance;
-            this.rules = new HashSet<Skimmer<AnalyzeContext>>();
         }
 
         protected override void AnalyzeCore(Uri uri, string text, string solutionDirectory, SarifLogger sarifLogger, CancellationToken cancellationToken)
@@ -41,13 +40,18 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
                 || (this.currentSolutionDirectory?.Equals(solutionDirectory, StringComparison.OrdinalIgnoreCase) != true))
             {
                 // clear older rules
-                this.rules.Clear();
+                this.rules?.Clear();
                 this.currentSolutionDirectory = solutionDirectory;
 
                 if (this.currentSolutionDirectory != null)
                 {
                     this.rules = LoadSearchDefinitionsFiles(this.fileSystem, this.currentSolutionDirectory);
                 }
+            }
+
+            if (this.rules == null)
+            {
+                return;
             }
 
             var disabledSkimmers = new HashSet<string>();

--- a/src/Sarif.Sarifer/SpamBackgroundAnalyzer.cs
+++ b/src/Sarif.Sarifer/SpamBackgroundAnalyzer.cs
@@ -32,6 +32,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         public SpamBackgroundAnalyzer()
         {
             this.fileSystem = FileSystem.Instance;
+            this.rules = new HashSet<Skimmer<AnalyzeContext>>();
         }
 
         protected override void AnalyzeCore(Uri uri, string text, string solutionDirectory, SarifLogger sarifLogger, CancellationToken cancellationToken)
@@ -40,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
                 || (this.currentSolutionDirectory?.Equals(solutionDirectory, StringComparison.OrdinalIgnoreCase) != true))
             {
                 // clear older rules
-                this.rules?.Clear();
+                this.rules.Clear();
                 this.currentSolutionDirectory = solutionDirectory;
 
                 if (this.currentSolutionDirectory != null)

--- a/src/Sarif.Viewer.VisualStudio.Interop/SarifViewerInterop.cs
+++ b/src/Sarif.Viewer.VisualStudio.Interop/SarifViewerInterop.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Sarif.Viewer.Interop
                 if (this._viewerExtensionAssembly == null)
                 {
                     Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
-                    this._viewerExtensionAssembly = assemblies.Where(a => a.GetName().Name == ViewerAssemblyFileName).FirstOrDefault();
+                    this._viewerExtensionAssembly = assemblies.FirstOrDefault(a => a.GetName().Name == ViewerAssemblyFileName);
                 }
 
                 return this._viewerExtensionAssembly;
@@ -110,8 +110,8 @@ namespace Microsoft.Sarif.Viewer.Interop
         /// A unique identifier for this stream that can be used to close the log later.
         /// </param>
         /// <returns>
-        /// <code>true</code> if the extensions service was successfully invoked (regardless of the
-        /// outcome), otherwise <code>false</code>.
+        /// <c>true</c> if the extensions service was successfully invoked (regardless of the
+        /// outcome), otherwise <c>false</c>.
         /// </returns>
         public Task<bool> OpenSarifLogAsync(Stream stream, string logId = null)
         {
@@ -131,8 +131,8 @@ namespace Microsoft.Sarif.Viewer.Interop
         /// The <see cref="Stream"/>s from which the SARIF log files are to be read.
         /// </param>
         /// <returns>
-        /// <code>true</code> if the extensions service was successfully invoked (regardless of the
-        /// outcome), otherwise <code>false</code>.
+        /// <c>true</c> if the extensions service was successfully invoked (regardless of the
+        /// outcome), otherwise <c>false</c>.
         /// </returns>
         public Task<bool> OpenSarifLogAsync(IEnumerable<Stream> streams)
         {
@@ -223,9 +223,9 @@ namespace Microsoft.Sarif.Viewer.Interop
 
             // Get the service interface type
             Type[] types = this.ViewerExtensionAssembly.GetTypes();
-            Type serviceType = types.Where(t => t.Name == serviceInterfaceName).FirstOrDefault();
+            Type serviceType = types.FirstOrDefault(t => t.Name == serviceInterfaceName);
 
-            if (serviceType == default(Type))
+            if (serviceType == default)
             {
                 return false;
             }
@@ -252,7 +252,7 @@ namespace Microsoft.Sarif.Viewer.Interop
             ThreadHelper.ThrowIfNotOnUIThread();
 
             Guid serviceGuid = ViewerExtensionGuid;
-            IVsPackage package = null; ;
+            IVsPackage package = null;
 
             if (this.IsViewerExtensionInstalled)
             {


### PR DESCRIPTION
## Changes:
- before solution analysis, we will clear all results
- before project analysis, we will clear all results
- if we close the solution, we will clear all results
- if we analyze a single file, it will clear just that file result
- fixed possible null reference if we analyze a single file and that file is a stand-alone file, which would generate the information bar showing that no results were found

## Minor changes:
- fixed a few message and warning issues