### PR TITLE
Fixing wide project/solution analysis

### DIFF
--- a/src/Sarif.Sarifer/AnalyzeSolutionCommand.cs
+++ b/src/Sarif.Sarifer/AnalyzeSolutionCommand.cs
@@ -83,16 +83,54 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
                 return;
             }
 
-            var targetFiles = new List<string>(projects.Count);
+            var targetFiles = new List<string>();
             foreach (Project project in projects)
             {
-                targetFiles.AddRange(project.GetMemberFiles());
+                targetFiles.AddRange(GetFiles(project));
             }
 
             // Disable the menu click when we are analysing.
             SariferPackageCommand.DisableAnalyzeCommands(this.menuCommandService);
             this.backgroundAnalysisService.AnalyzeAsync(solution.FullName, targetFiles, this.cancellationTokenSource.Token)
                 .FileAndForget(FileAndForgetEventName.BackgroundAnalysisFailure);
+        }
+
+        private static List<string> GetFiles(Project project)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            var targetFiles = new List<string>();
+
+            foreach (ProjectItem projectItem in project.ProjectItems)
+            {
+                GetFilesRecursive(targetFiles, projectItem);
+            }
+
+            return targetFiles;
+        }
+
+        private static void GetFilesRecursive(List<string> targetFiles, ProjectItem projectItem)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (projectItem.GetType().ToString().EndsWith("OAFolderItem", StringComparison.InvariantCulture))
+            {
+                foreach (ProjectItem projectFolder in projectItem.ProjectItems)
+                {
+                    GetFilesRecursive(targetFiles, projectFolder);
+                }
+            }
+            else
+            {
+                foreach (Property property in projectItem.Properties)
+                {
+                    if (property.Name == "LocalPath")
+                    {
+                        targetFiles.Add(property.Value.ToString());
+                        break;
+                    }
+                }
+            }
         }
 
         private void BackgroundAnalysisService_AnalysisCompleted(object sender, EventArgs e)


### PR DESCRIPTION
Fixes #333

Before this change, the "Run Static Analysis" wasn't finding the txt files that we had inside a project, inside a folder.

With this change, it will look at all files and folder referenced by the project itself.