### PR TITLE
Enable Error List expanded detail panel

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/ErrorList/SarifResultTableEntry.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/SarifResultTableEntry.cs
@@ -20,7 +20,7 @@ using Microsoft.VisualStudio.Shell.TableManager;
 
 namespace Microsoft.Sarif.Viewer.ErrorList
 {
-    internal sealed class SarifResultTableEntry : ITableEntry, IDisposable
+    internal sealed class SarifResultTableEntry : WpfTableEntryBase, IDisposable
     {
         internal const string SuppressionStateColumnName = "suppression";
 
@@ -143,11 +143,11 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
         public SarifErrorListItem Error { get; }
 
-        public object Identity { get; }
+        public override object Identity { get; }
 
-        public bool CanSetValue(string keyName) => false;
+        public override bool CanSetValue(string keyName) => false;
 
-        public bool TryGetValue(string keyName, out object content)
+        public override bool TryGetValue(string keyName, out object content)
         {
             if (this.columnKeyToContent.TryGetValue(keyName, out content))
             {
@@ -163,7 +163,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             return false;
         }
 
-        public bool TrySetValue(string keyName, object content) => false;
+        public override bool TrySetValue(string keyName, object content) => false;
 
         private static __VSERRORCATEGORY GetSeverity(FailureLevel level)
         {


### PR DESCRIPTION
This is the fix for #330 

SarifResultTableEntry inherits from ITableEntry, which doesn’t have interface to create the detail panel to show full message.
Update it to inherit from VS built-in WpfTableEntryBase (implemented IWpfTableEntry), it has implementation for create expander and detail panel if the result has extra detail message.
