### PR TITLE
Fix issue squiggle displayed in wrong location

### DIFF
--- a/src/Sarif.Sarifer/SpamBackgroundAnalyzer.cs
+++ b/src/Sarif.Sarifer/SpamBackgroundAnalyzer.cs
@@ -94,6 +94,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
+                // clear region cache make sure latest text is cached
+                FileRegionsCache.Instance.ClearCache();
+
                 // Filtering file before analyzing.
                 IEnumerable<Skimmer<AnalyzeContext>> applicableSkimmers = AnalyzeCommand.DetermineApplicabilityForTargetHelper(context, this.rules, disabledSkimmers);
 

--- a/src/Sarif.Viewer.VisualStudio/Fixes/FixSuggestedActionsSource.cs
+++ b/src/Sarif.Viewer.VisualStudio/Fixes/FixSuggestedActionsSource.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Sarif.Viewer.Fixes
 
         private bool CaretIntersectsSingleErrorLocation(LocationModel locationModel, NormalizedSnapshotSpanCollection caretSpanCollection) =>
             caretSpanCollection.Any(
-                caretSpan => caretSpan.IntersectsWith(locationModel.PersistentSpan.Span.GetSpan(caretSpan.Snapshot)));
+                caretSpan => locationModel.PersistentSpan != null && caretSpan.IntersectsWith(locationModel.PersistentSpan.Span.GetSpan(caretSpan.Snapshot)));
 
         private IEnumerable<SuggestedActionSet> CreateActionSetFromErrors(IEnumerable<SarifErrorListItem> errors)
         {

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -153,16 +153,9 @@ namespace Microsoft.Sarif.Viewer
 
             if (result.Fixes != null)
             {
-                IDictionary<int, RunDataCache> runIndexToRunDataCache = CodeAnalysisResultManager.Instance.RunIndexToRunDataCache;
-                if (!runIndexToRunDataCache.TryGetValue(this.RunIndex, out RunDataCache runDataCache))
-                {
-                    runDataCache = null;
-                }
-
-                FileRegionsCache regionsCache = runDataCache?.FileRegionsCache;
                 foreach (Fix fix in result.Fixes)
                 {
-                    var fixModel = fix.ToFixModel(run.OriginalUriBaseIds, regionsCache);
+                    var fixModel = fix.ToFixModel(run.OriginalUriBaseIds, FileRegionsCache.Instance);
                     this.Fixes.Add(fixModel);
                 }
             }

--- a/src/Sarif.Viewer.VisualStudio/ResultTextMarker.cs
+++ b/src/Sarif.Viewer.VisualStudio/ResultTextMarker.cs
@@ -393,8 +393,7 @@ namespace Microsoft.Sarif.Viewer
                 Uri.TryCreate(this.resolvedFullFilePath, UriKind.Absolute, out Uri uri))
             {
                 // Fill out the region's properties
-                FileRegionsCache regionsCache = CodeAnalysisResultManager.Instance.RunIndexToRunDataCache[this.RunIndex].FileRegionsCache;
-                this.fullyPopulatedRegion = regionsCache.PopulateTextRegionProperties(this.region, uri, populateSnippet: true);
+                this.fullyPopulatedRegion = FileRegionsCache.Instance.PopulateTextRegionProperties(this.region, uri, populateSnippet: true);
             }
 
             this.regionAndFilePathAreFullyPopulated = this.fullyPopulatedRegion != null;


### PR DESCRIPTION
Fixes #361

The squiggle/text marker generation used an empty FileRegionCache, which will read from physical file instead of current text content in editor.
Fixed by using static FileRegionCahce.Instance cache includes latest text content.