### PR TITLE
Expose extension option type to COM

### DIFF
--- a/src/Sarif.Sarifer/SariferExtensionOptionPage.cs
+++ b/src/Sarif.Sarifer/SariferExtensionOptionPage.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.Shell;
 namespace Microsoft.CodeAnalysis.Sarif.Sarifer
 {
     [Guid("BB3665D5-E661-48C0-801A-19B034F3CD5F")]
+    [ComVisible(true)]
     public class SariferExtensionOptionPage : DialogPage
     {
         private const string CategoryName = "Sarifer Options";


### PR DESCRIPTION
So that the extension option can be read/write outside of extension itself. E.g. other extensions, test process etc.