### PR TITLE
Make Error List context menus dynamically visible

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -659,9 +659,14 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
         private static void ErrorListService_LogProcessed(object sender, LogProcessedEventArgs e)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (!SarifViewerPackage.IsUnitTesting)
             {
                 InfoBar.CreateInfoBarsForExceptionalConditionsAsync(e.ExceptionalConditions).FileAndForget(FileAndForgetEventName.InfoBarOpenFailure);
+
+                // After Sarif results loaded to Error List, make sure Viewer package is loaded
+                SarifViewerPackage.LoadViewerPackage();
             }
         }
     }

--- a/src/Sarif.Viewer.VisualStudio/SarifCommandPackage.vsct
+++ b/src/Sarif.Viewer.VisualStudio/SarifCommandPackage.vsct
@@ -34,6 +34,8 @@
     <Menus>
       <Menu guid="guidSarifErrorListCmdSet" id="cmdidProvideFeedbackSubmenu" priority="0x0080" type="Menu">
         <Parent guid="guidSarifErrorListCmdSet" id="ErrorListContextMenuGroup" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <ButtonText>Provide feedback on result</ButtonText>
         </Strings>
@@ -124,12 +126,13 @@
       </Button>
       <Button guid="guidSarifErrorListCmdSet" id="cmdidClearSarifItemsErrorListCommand" priority="0x0100" type="Button">
         <Parent guid="guidSarifErrorListCmdSet" id="ErrorListContextMenuGroup" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <ButtonText>Clear all SARIF results</ButtonText>
         </Strings>
       </Button>
     </Buttons>
-
   </Commands>
 
   <Symbols>


### PR DESCRIPTION
1. "Clear All SARIF Results" context menu only visible when error list has Sarif result item.
2. "Provide feedback on result" context menu only visible when Sarif result is selected.

Fixes #151