### PR TITLE
Improve Error List message readability

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
@@ -422,6 +422,25 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         }
 
         [Fact]
+        public void SarifErrorListItem_ResultMessageFormat_TextWitLinerBreak()
+        {
+            const string s0 = "The quick brown fox. Jumps over the lazy dog.";
+            // text with varies style of line breakers 
+            string s1 = "The\rquick brown fox." + Environment.NewLine + "Jumps over the lazy\ndog.";
+            var result = new Result
+            {
+                Message = new Message()
+                {
+                    Text = s1,
+                },
+            };
+
+            SarifErrorListItem item = MakeErrorListItem(result);
+            item.Message.Should().Be(s0);
+            item.ShortMessage.Should().Be(s0);
+        }
+
+        [Fact]
         public void SarifErrorListItem_HasEmbeddedLinks_MultipleSentencesWithEmbeddedLinks()
         {
             const string s1 = "The quick [brown](1) fox.";

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using FluentAssertions;
 
@@ -359,8 +360,10 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             };
 
             SarifErrorListItem item = MakeErrorListItem(result);
-            item.Message.Should().Be($"{s2}");
-            item.ShortMessage.Should().Be(s1);
+
+            // with the change related to #360, message is not separated by sentence.
+            item.Message.Should().Be($"{s1} {s2}");
+            item.ShortMessage.Should().Be($"{s1} {s2}");
         }
 
         [Fact]
@@ -378,6 +381,44 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             SarifErrorListItem item = MakeErrorListItem(result);
             item.Message.Should().Be(s1);
             item.ShortMessage.Should().Be(s1);
+        }
+
+        [Fact]
+        public void SarifErrorListItem_ResultMessageFormat_LongTextWithoutBreak()
+        {
+            // very long text without break like space or NewLine, longer than default max lengh 165
+            const string s1 = "1234567890";
+            var result = new Result
+            {
+                Message = new Message()
+                {
+                    Text = string.Concat(Enumerable.Repeat(s1, 20)), // replace s1 10 times, a string which length is 200
+                },
+            };
+
+            SarifErrorListItem item = MakeErrorListItem(result);
+            int breakPoistion = 165;
+            item.ShortMessage.Length.Should().Be(breakPoistion + 2);
+            item.Message.Length.Should().Be(200 - breakPoistion);
+        }
+
+        [Fact]
+        public void SarifErrorListItem_ResultMessageFormat_LongTextWitBreak()
+        {
+            // very long text has a space every 10 chars 
+            const string s1 = "123456789 ";
+            var result = new Result
+            {
+                Message = new Message()
+                {
+                    Text = string.Concat(Enumerable.Repeat(s1, 20)), // replace s1 10 times, a string which length is 200
+                },
+            };
+
+            SarifErrorListItem item = MakeErrorListItem(result);
+            int breakPoistion = 159; // 0 indexed
+            item.ShortMessage.Length.Should().Be(breakPoistion + 2); // the space break the text will be removed
+            item.Message.Length.Should().Be(200 - breakPoistion - 2); // last space is trimmed
         }
 
         [Fact]

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -673,29 +673,28 @@ namespace Microsoft.Sarif.Viewer
             return this.Locations.Select(location => location.ExtractSnippet(regionsCache));
         }
 
-        internal (string first, string second) SplitMessageText(string fullText, int maxLength = 120)
+        internal (string first, string second) SplitMessageText(string fullText, int maxLength = 165)
         {
-            string shortText = ExtensionMethods.GetFirstSentence(fullText);
+            // remove line breakers
+            fullText = fullText.Replace(Environment.NewLine, " ").Replace("\r", " ").Replace("\n", " ");
 
+            string text = fullText;
+            int endPosition = fullText.Length - 1;
             char[] endChars = new char[] { '\r', '\n', ' ', };
-            if (shortText.Length > maxLength)
+            if (text.Length > maxLength)
             {
-                // if need to split text longer than maxLength, make sure not split in middle of a word
-                int endPosition = maxLength;
-                if (!endChars.Contains(shortText[maxLength]))
+                // if need to split text longer than maxLength, make sure not split in middle of a word.
+                if (!endChars.Contains(text[maxLength]))
                 {
-                    endPosition = shortText.LastIndexOfAny(endChars);
+                    endPosition = text.LastIndexOfAny(endChars, maxLength);
                 }
 
-                if (endPosition != -1)
-                {
-                    shortText = shortText.Substring(0, endPosition);
-                }
+                endPosition = endPosition == -1 ? maxLength : endPosition;
+                text = text.Substring(0, endPosition) + " \u2026"; // u2026 is Unicode "horizontal ellipsis";
             }
 
-            string restText = shortText.Length < fullText.Length ? fullText.Substring(shortText.Length).TrimStart(endChars) : fullText;
-            shortText = shortText.TrimEnd(endChars);
-            return (shortText, restText);
+            string restText = endPosition + 1 < fullText.Length ? fullText.Substring(endPosition).TrimStart(endChars) : fullText;
+            return (text.TrimEnd(endChars), restText.TrimEnd(endChars));
         }
     }
 }


### PR DESCRIPTION
Fixes #360 

* Increase the max length of message display in error list table entry. from 120 to 165.
* Do not split message into shorter sentences and show first sentence in table entry. try to show full message as possible in the table entry, only separate message into 2 parts if full message length is longer than max length.