### PR TITLE
Fix partial message issue when there is long hyper link url in message.

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
@@ -11,6 +11,8 @@ using Microsoft.CodeAnalysis.Sarif;
 
 using Xunit;
 
+using XamlDoc = System.Windows.Documents;
+
 namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
 {
     public class SarifErrorListItemTests
@@ -441,6 +443,29 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         }
 
         [Fact]
+        public void SarifErrorListItem_HasLongEmbeddedLink()
+        {
+            const string s1 = "The quick brown fox. Jumps over the lazy dog. Reference to [docs](https://github.com/long/path/to/docs/1234567890/1234567890/1234567890/1234567890/1234567890/1234567890/1234567890/)";
+            var result = new Result
+            {
+                Message = new Message()
+                {
+                    Text = s1,
+                },
+            };
+
+            SarifErrorListItem item = MakeErrorListItem(result);
+            item.HasEmbeddedLinks.Should().BeTrue();
+
+            // "The quick brown fox. Jumps over the lazy dog. Reference to ", "docs"
+            item.MessageInlines.Count.Should().Be(2);
+            item.MessageInlines[0].ContentStart.GetTextInRun(XamlDoc.LogicalDirection.Forward)
+                .Should().BeEquivalentTo("The quick brown fox. Jumps over the lazy dog. Reference to ");
+            item.MessageInlines[1].ContentStart.GetTextInRun(XamlDoc.LogicalDirection.Forward)
+                .Should().BeEquivalentTo("docs");
+        }
+
+        [Fact]
         public void SarifErrorListItem_HasEmbeddedLinks_MultipleSentencesWithEmbeddedLinks()
         {
             const string s1 = "The quick [brown](1) fox.";
@@ -455,6 +480,15 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
 
             SarifErrorListItem item = MakeErrorListItem(result);
             item.HasEmbeddedLinks.Should().BeTrue();
+
+            // "The quick ", "brown", " fox. Jumps over the ", "lazy", " dog."
+            item.MessageInlines.Count.Should().Be(5);
+            item.MessageInlines[0].ContentStart.GetTextInRun(XamlDoc.LogicalDirection.Forward).Should().BeEquivalentTo("The quick ");
+            item.MessageInlines[1].ContentStart.GetTextInRun(XamlDoc.LogicalDirection.Forward).Should().BeEquivalentTo("brown");
+            item.MessageInlines[2].ContentStart.GetTextInRun(XamlDoc.LogicalDirection.Forward).Should().BeEquivalentTo(" fox. Jumps over the ");
+            item.MessageInlines[3].ContentStart.GetTextInRun(XamlDoc.LogicalDirection.Forward).Should().BeEquivalentTo("lazy");
+            item.MessageInlines[4].ContentStart.GetTextInRun(XamlDoc.LogicalDirection.Forward).Should().BeEquivalentTo(" dog.");
+
         }
 
         [Fact]

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/SarifResultTableEntry.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/SarifResultTableEntry.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             // it when it's asked for.
             this.columnKeyToContent[StandardTableKeyNames2.TextInlines] = new Lazy<object>(() =>
             {
-                string message = this.Error.Message;
+                string message = this.Error.RawMessage;
                 List<Inline> inlines = SdkUIUtilities.GetMessageInlines(message, this.ErrorListInlineLink_Click);
 
                 if (inlines.Count > 0)

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -84,7 +84,8 @@ namespace Microsoft.Sarif.Viewer
             this.Tool = run.Tool.ToToolModel();
             this.Rule = rule.ToRuleModel(result.RuleId);
             this.Invocation = run.Invocations?[0]?.ToInvocationModel();
-            (this.ShortMessage, this.Message) = this.SplitMessageText(result.GetMessageText(rule));
+            this.RawMessage = result.GetMessageText(rule);
+            (this.ShortMessage, this.Message) = this.SplitMessageText(RawMessage);
             if (!this.Message.EndsWith("."))
             {
                 this.ShortMessage = this.ShortMessage.TrimEnd('.');
@@ -207,7 +208,8 @@ namespace Microsoft.Sarif.Viewer
             }
 
             run.TryGetRule(ruleId, out ReportingDescriptor rule);
-            (this.ShortMessage, this.Message) = this.SplitMessageText(notification.Message.Text?.Trim() ?? string.Empty);
+            this.RawMessage = notification.Message.Text?.Trim() ?? string.Empty;
+            (this.ShortMessage, this.Message) = this.SplitMessageText(this.RawMessage);
 
             // This is not locale friendly.
             if (!this.Message.EndsWith("."))
@@ -278,8 +280,11 @@ namespace Microsoft.Sarif.Viewer
         public string Message { get; set; }
 
         [Browsable(false)]
+        public string RawMessage { get; set; }
+
+        [Browsable(false)]
         public ObservableCollection<XamlDoc.Inline> MessageInlines => this._messageInlines
-            ?? (this._messageInlines = new ObservableCollection<XamlDoc.Inline>(SdkUIUtilities.GetInlinesForErrorMessage(this.Message)));
+            ?? (this._messageInlines = new ObservableCollection<XamlDoc.Inline>(SdkUIUtilities.GetInlinesForErrorMessage(this.RawMessage)));
 
         [Browsable(false)]
         public bool HasEmbeddedLinks => this.MessageInlines.Any();


### PR DESCRIPTION
Fix for issue #374 

The issue caused by the inline texts (rich text format with hyperlink) are calculated by Message property of SarifErrorListItem, not the raw message. 

The fix is to use raw message to generate inline texts.