### PR TITLE
Add hyperlink to Error List ErrorCode if helpUri is set

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
@@ -492,6 +492,64 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         }
 
         [Fact]
+        public void SarifErrorListItem_HelpLinkShouldBeSameAs_RuleHelpUri()
+        {
+            string link = "https://example.com/TST0001";
+            var result = new Result
+            {
+                Message = new Message
+                {
+                    Text = "The quick brown fox.",
+                },
+                RuleId = "TST0001",
+            };
+
+            var run = new Run
+            {
+                Tool = new Tool
+                {
+                    Driver = new ToolComponent
+                    {
+                        Rules = new List<ReportingDescriptor>
+                        {
+                            new ReportingDescriptor
+                            {
+                                Id = "TST0001",
+                                HelpUri = new Uri(link),
+                            },
+                        },
+                    },
+                },
+            };
+
+            SarifErrorListItem item = MakeErrorListItem(run, result);
+
+            item.HelpLink.Should().NotBeNull();
+            item.HelpLink.Should().BeEquivalentTo(link);
+
+            // without help Uri
+            run = new Run
+            {
+                Tool = new Tool
+                {
+                    Driver = new ToolComponent
+                    {
+                        Rules = new List<ReportingDescriptor>
+                        {
+                            new ReportingDescriptor
+                            {
+                                Id = "TST0001"
+                            },
+                        },
+                    },
+                },
+            };
+
+            item = MakeErrorListItem(run, result);
+            item.HelpLink.Should().BeNull();
+        }
+
+        [Fact]
         public void SarifErrorListItem_TreatsInformationalResultAsNote()
         {
             var result = new Result

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/SarifResultTableEntry.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/SarifResultTableEntry.cs
@@ -85,8 +85,8 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             // i.e. if we pass 5, the error list will display 6.
             // Subtract one from the line number so the error list displays the correct value.
             this.columnKeyToContent[StandardTableKeyNames.Line] = this.Error.LineNumber - 1;
+            this.columnKeyToContent[StandardTableKeyNames.Column] = this.Error.ColumnNumber - 1;
 
-            this.columnKeyToContent[StandardTableKeyNames.Column] = this.Error.ColumnNumber;
             this.columnKeyToContent[StandardTableKeyNames.ErrorSeverity] = GetSeverity(this.Error.Level);
             this.columnKeyToContent[StandardTableKeyNames.Priority] = GetSeverity(this.Error.Level) == __VSERRORCATEGORY.EC_ERROR
                     ? vsTaskPriority.vsTaskPriorityHigh

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -84,6 +84,9 @@ namespace Microsoft.Sarif.Viewer
             this.Tool = run.Tool.ToToolModel();
             this.Rule = rule.ToRuleModel(result.RuleId);
             this.Invocation = run.Invocations?[0]?.ToInvocationModel();
+            this.WorkingDirectory = Path.Combine(Path.GetTempPath(), this.RunIndex.ToString());
+            this.HelpLink = this.Rule?.HelpUri;
+
             this.RawMessage = result.GetMessageText(rule);
             (this.ShortMessage, this.Message) = this.SplitMessageText(RawMessage);
             if (!this.Message.EndsWith("."))
@@ -106,11 +109,6 @@ namespace Microsoft.Sarif.Viewer
                 this.LineNumber = this.Region.StartLine;
                 this.ColumnNumber = this.Region.StartColumn;
             }
-
-            this.Tool = run.Tool.ToToolModel();
-            this.Rule = rule.ToRuleModel(result.RuleId);
-            this.Invocation = run.Invocations?[0]?.ToInvocationModel();
-            this.WorkingDirectory = Path.Combine(Path.GetTempPath(), this.RunIndex.ToString());
 
             if (result.Locations?.Any() == true)
             {
@@ -227,6 +225,7 @@ namespace Microsoft.Sarif.Viewer
             this.Rule = rule.ToRuleModel(ruleId);
             this.Invocation = run.Invocations?[0]?.ToInvocationModel();
             this.WorkingDirectory = Path.Combine(Path.GetTempPath(), this.RunIndex.ToString());
+            this.HelpLink = this.Rule?.HelpUri;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #376

Help link Uri is read from associated rule (ReportingDescriptor) property HelpUri [§3.49.12](https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317848)

Before fix: 
![image](https://user-images.githubusercontent.com/76094515/109726905-4d61c380-7b68-11eb-806a-28f306cc9c58.png)

After fix:
![image](https://user-images.githubusercontent.com/76094515/109727129-aa5d7980-7b68-11eb-9640-40eb34d9e9c4.png)
