### PR TITLE
Refresh Error List automatically if Sarif Log is changed

### DIFF
--- a/src/Sarif.Sarifer/BackgroundAnalysisTextViewCreationListener.cs
+++ b/src/Sarif.Sarifer/BackgroundAnalysisTextViewCreationListener.cs
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         // error list.
         private void TextBufferViewTracker_LastViewRemoved(object sender, LastViewRemovedEventArgs e)
         {
-            this.sarifViewerInterop.CloseSarifLogAsync(new string[] { e.Path })
+            this.backgroundAnalysisService.Value.CloseResultsAsync(e.Path)
                 .FileAndForget(FileAndForgetEventName.CloseSarifLogsFailure);
         }
 

--- a/src/Sarif.Sarifer/IBackgroundAnalysisService.cs
+++ b/src/Sarif.Sarifer/IBackgroundAnalysisService.cs
@@ -57,5 +57,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         /// A <see cref="Task"/> that represents the completion of the cleared results.
         /// </returns>
         Task ClearResultsAsync();
+
+        /// <summary>
+        /// Clear results of specified logId.
+        /// </summary>
+        /// <param name="logId">logId of set of results.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that represents the completion of the cleared results.
+        /// </returns>
+        Task CloseResultsAsync(string logId);
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/FileWatcher/FileWatcher.cs
+++ b/src/Sarif.Viewer.VisualStudio/FileWatcher/FileWatcher.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.Sarif.Viewer.FileWatcher
+{
+    /// <summary>
+    /// FileSystemWatcher wrapper class.
+    /// </summary>
+    internal class FileWatcher : IFileWatcher, IDisposable
+    {
+        private FileSystemWatcher fileSystemWatcher;
+
+        /// <summary>
+        /// Set to true once the instance has been disposed.
+        /// </summary>
+        private bool m_disposed;
+
+        internal FileWatcher(string filePath)
+        {
+            fileSystemWatcher = CreateFileSystemWatcher(filePath);
+        }
+
+        /// <summary>
+        /// Raised when Sarif log file is updated/changed.
+        /// </summary>
+        public event EventHandler<FileSystemEventArgs> SarifLogFileChanged;
+
+        /// <summary>
+        /// Raised when Sarif log file is renamed.
+        /// </summary>
+        public event EventHandler<RenamedEventArgs> SarifLogFileRenamed;
+
+        /// <summary>
+        /// Starts watching for changes to the Sarif log file.
+        /// </summary>
+        public void Start()
+        {
+            // Make sure we have not been disposed.
+            this.EnsureNotDisposed();
+
+            // Start listening for changes to the file.
+            fileSystemWatcher.EnableRaisingEvents = true;
+        }
+
+        /// <summary>
+        /// Stops watching for changes to the Sarif log file.
+        /// </summary>
+        public void Stop()
+        {
+            if (!m_disposed)
+            {
+                if (fileSystemWatcher != null)
+                {
+                    fileSystemWatcher.Dispose();
+                    fileSystemWatcher = null;
+                }
+
+                m_disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            this.Stop();
+        }
+
+        /// <summary>
+        /// Creates a <see cref="FileSystemWatcher"/> that detects changes to the Sarif log file.
+        /// </summary>
+        /// <returns>a <see cref="FileSystemWatcher"/> object.</returns>
+        /// <exception cref="ArgumentException"> if filePath does not exist.
+        /// </exception>
+        private FileSystemWatcher CreateFileSystemWatcher(string filePath)
+        {
+            FileSystemWatcher fileSystemWatcher = new FileSystemWatcher();
+            fileSystemWatcher.Path = Path.GetDirectoryName(filePath);
+            fileSystemWatcher.Filter = Path.GetFileName(filePath);
+            fileSystemWatcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName;
+            fileSystemWatcher.Changed += this.SarifLogFile_Changed;
+            fileSystemWatcher.Renamed += this.SarifLogFile_Renamed;
+
+            return fileSystemWatcher;
+        }
+
+        private void SarifLogFile_Renamed(object sender, RenamedEventArgs e)
+        {
+            this.SarifLogFileRenamed?.Invoke(this, e);
+        }
+
+        private void SarifLogFile_Changed(object sender, FileSystemEventArgs e)
+        {
+            try
+            {
+                // to avoid trigger changed event multiple times in a short time period.
+                this.fileSystemWatcher.EnableRaisingEvents = false;
+                this.SarifLogFileChanged?.Invoke(this, e);
+            }
+            finally
+            {
+                this.fileSystemWatcher.EnableRaisingEvents = true;
+            }
+        }
+
+        /// <summary>
+        /// Throws if this instance has been disposed.
+        /// </summary>
+        private void EnsureNotDisposed()
+        {
+            if (m_disposed)
+            {
+                throw new ObjectDisposedException(this.GetType().Name);
+            }
+        }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/FileWatcher/FileWatcher.cs
+++ b/src/Sarif.Viewer.VisualStudio/FileWatcher/FileWatcher.cs
@@ -54,6 +54,8 @@ namespace Microsoft.Sarif.Viewer.FileWatcher
             {
                 if (fileSystemWatcher != null)
                 {
+                    fileSystemWatcher.Changed -= this.SarifLogFile_Changed;
+                    fileSystemWatcher.Renamed -= this.SarifLogFile_Renamed;
                     fileSystemWatcher.Dispose();
                     fileSystemWatcher = null;
                 }

--- a/src/Sarif.Viewer.VisualStudio/FileWatcher/IFileWatcher.cs
+++ b/src/Sarif.Viewer.VisualStudio/FileWatcher/IFileWatcher.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.Sarif.Viewer.FileWatcher
+{
+    internal interface IFileWatcher
+    {
+        void Start();
+
+        void Stop();
+
+        event EventHandler<FileSystemEventArgs> SarifLogFileChanged;
+
+        event EventHandler<RenamedEventArgs> SarifLogFileRenamed;
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/FileWatcher/SarifLogsMonitor.cs
+++ b/src/Sarif.Viewer.VisualStudio/FileWatcher/SarifLogsMonitor.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.CodeAnalysis.Sarif.Converters;
+using Microsoft.Sarif.Viewer.ErrorList;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.Sarif.Viewer.FileWatcher
+{
+    internal class SarifLogsMonitor : IDisposable
+    {
+        private readonly IFileSystem fileSystem;
+
+        private IDictionary<string, IFileWatcher> FileWatcherMap { get; } = new ConcurrentDictionary<string, IFileWatcher>();
+
+        internal SarifLogsMonitor(IFileSystem fs)
+        {
+            this.fileSystem = fs;
+        }
+
+        internal static SarifLogsMonitor Instance = new SarifLogsMonitor(new FileSystem());
+
+        internal void StartWatch(string logFilePath)
+        {
+            if (!fileSystem.FileExists(logFilePath))
+            {
+                return;
+            }
+
+            string logPath = logFilePath.ToLower();
+            if (!FileWatcherMap.ContainsKey(logPath))
+            {
+                var watcher = new FileWatcher(logFilePath);
+                watcher.SarifLogFileChanged += this.Watcher_SarifLogFileChanged;
+                watcher.SarifLogFileRenamed += this.Watcher_SarifLogFileRenamed;
+                FileWatcherMap.Add(logPath, watcher);
+                watcher.Start();
+            }
+        }
+
+        internal void Clear()
+        {
+            if (FileWatcherMap.Any())
+            {
+                FileWatcherMap.Values.ToList().ForEach(w => w.Stop());
+                FileWatcherMap.Clear();
+            }
+        }
+
+        private void Watcher_SarifLogFileRenamed(object sender, System.IO.RenamedEventArgs e)
+        {
+            /*
+             * When updating a file in VS, it saves file content to a new temp file and rename current file to another temp file,
+             * then rename 1st temp file with latest content to current file name and delete 2nd temp file.
+             * Here we need to catch the event the 1st temp file is renamed to current file name
+             * and ignore event current file is renamed to 2nd temp file.
+             */
+            string filePath = e.FullPath;
+            if (FileWatcherMap.ContainsKey(filePath.ToLower()))
+            {
+                this.RefreshSarifErrors(filePath);
+            }
+        }
+
+        private void Watcher_SarifLogFileChanged(object sender, System.IO.FileSystemEventArgs e)
+        {
+            string filePath = e.FullPath;
+            this.RefreshSarifErrors(filePath);
+        }
+
+        private void RefreshSarifErrors(string filePath)
+        {
+            ThreadHelper.JoinableTaskFactory.Run(() => ErrorListService.CloseSarifLogItemsAsync(new string[] { filePath }));
+            ErrorListService.ProcessLogFile(filePath, ToolFormat.None, promptOnLogConversions: true, cleanErrors: false, openInEditor: true);
+        }
+
+        internal void StopWatch(string logFilePath)
+        {
+            string logPath = logFilePath.ToLower();
+            if (FileWatcherMap.TryGetValue(logPath, out IFileWatcher watcher))
+            {
+                watcher.Stop();
+                FileWatcherMap.Remove(logPath);
+            }
+        }
+
+        public void Dispose()
+        {
+            this.Clear();
+        }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -65,6 +65,9 @@
     <Compile Include="ExceptionalConditions.cs" />
     <Compile Include="ExceptionalConditionsCalculator.cs" />
     <Compile Include="FileAndForgetEventName.cs" />
+    <Compile Include="FileWatcher\FileWatcher.cs" />
+    <Compile Include="FileWatcher\IFileWatcher.cs" />
+    <Compile Include="FileWatcher\SarifLogsMonitor.cs" />
     <Compile Include="Fixes\EditActionPreviewProvider.cs" />
     <Compile Include="Fixes\IPreviewProvider.cs" />
     <Compile Include="Fixes\LineSpan.cs" />


### PR DESCRIPTION
Fix for #336 #318

Added FileSystemWatcher for each opened Sarif log file, and update Error list items when change is detected.

When Sarif log file is oped in VS text editor and updated/saved in VS, it wont fire file updated event.
Instead it saves file content to a new temp file and rename current file to another temp file, then rename 1st temp file with latest content to current file name and delete 2nd temp file.

So we need to catch the rename event for changes made in VS.

Will add corresponding Apex UI automation test cases.