### PR TITLE
Add FileWatcher to load sarif logs from .sarif folder automatically

### DIFF
--- a/src/Sarif.Sarifer.UnitTests/Sarif.Sarifer.UnitTests.csproj
+++ b/src/Sarif.Sarifer.UnitTests/Sarif.Sarifer.UnitTests.csproj
@@ -21,6 +21,8 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SariferUnitTestBase.cs" />
+    <Compile Include="SarifFolderWatcherTests.cs" />
     <Compile Include="SpamBackgroundAnalyzerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -55,6 +57,10 @@
     <ProjectReference Include="..\Sarif.Sarifer\Sarif.Sarifer.csproj">
       <Project>{f3e3199f-c005-4a14-b96b-974896986edc}</Project>
       <Name>Sarif.Sarifer</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Sarif.Viewer.VisualStudio.Interop\Sarif.Viewer.VisualStudio.Interop.csproj">
+      <Project>{9D407555-D268-461E-BFAF-4251B0FBF7C9}</Project>
+      <Name>Sarif.Viewer.VisualStudio.Interop</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />

--- a/src/Sarif.Sarifer.UnitTests/SarifFolderWatcherTests.cs
+++ b/src/Sarif.Sarifer.UnitTests/SarifFolderWatcherTests.cs
@@ -1,0 +1,241 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.CodeAnalysis.Sarif.Sarifer;
+using Microsoft.CodeAnalysis.Sarif.Sarifer.FileWatcher;
+using Microsoft.Sarif.Viewer.Interop;
+
+using Moq;
+
+using Xunit;
+
+namespace Sarif.Sarifer.UnitTests
+{
+    public class SarifFolderWatcherTests : SariferUnitTestBase
+    {
+
+        [Fact]
+        public void SarifFolder_DoesNot_Exist()
+        {
+            string sarifDirectory = ".sarif";
+            string solutionDirectory = @"C:\some-solution-folder";
+            string combinedPath = Path.Combine(solutionDirectory, sarifDirectory);
+
+            var mockFileSystem = new Mock<IFileSystem>();
+            mockFileSystem.Setup(fs => fs.DirectoryExists(It.IsAny<string>())).Returns(false);
+
+            var mockFileWatcher = new Mock<IFileWatcher>();
+
+            var mockViewerInterop = new Mock<ISarifViewerInterop>();
+
+            var monitor = new SarifFolderMonitor(mockViewerInterop.Object, mockFileSystem.Object, mockFileWatcher.Object);
+            monitor.StartWatch(solutionDirectory);
+
+            mockViewerInterop.Verify(m => m.OpenSarifLogAsync(It.IsAny<IEnumerable<string>>()), Times.Never);
+            mockViewerInterop.Verify(m => m.OpenSarifLogAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Never);
+
+            monitor.StopWatch();
+
+            mockViewerInterop.Verify(m => m.CloseSarifLogAsync(It.IsAny<IEnumerable<string>>()), Times.Never);
+        }
+
+        [Fact]
+        public void SarifFolder_Does_Exist_WithoutSarifFile()
+        {
+            SariferOption.InitializeForUnitTests();
+
+            string sarifDirectory = ".sarif";
+            string solutionDirectory = @"C:\some-solution-folder";
+            string combinedPath = Path.Combine(solutionDirectory, sarifDirectory);
+            string searchPattern = Constants.SarifFileSearchPattern;
+
+            var mockFileSystem = new Mock<IFileSystem>();
+            mockFileSystem.Setup(fs => fs.DirectoryExists(It.IsAny<string>())).Returns(false);
+            mockFileSystem.Setup(fs => fs.DirectoryExists(solutionDirectory)).Returns(true);
+            mockFileSystem.Setup(fs => fs.DirectoryExists(combinedPath)).Returns(true);
+            mockFileSystem.Setup(fs => fs.DirectoryGetFiles(combinedPath, searchPattern)).Returns(new string[] { });
+
+            var mockFileWatcher = new Mock<IFileWatcher>();
+
+            var mockViewerInterop = new Mock<ISarifViewerInterop>();
+
+            var monitor = new SarifFolderMonitor(mockViewerInterop.Object, mockFileSystem.Object, mockFileWatcher.Object);
+            monitor.StartWatch(solutionDirectory);
+
+            mockViewerInterop.Verify(m => m.OpenSarifLogAsync(It.IsAny<IEnumerable<string>>()), Times.Once);
+            mockViewerInterop.Verify(m => m.OpenSarifLogAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Never);
+            mockFileWatcher.Verify(m => m.Start(), Times.Once);
+
+            monitor.StopWatch();
+
+            mockViewerInterop.Verify(m => m.CloseSarifLogAsync(It.IsAny<IEnumerable<string>>()), Times.Once);
+            mockFileWatcher.Verify(m => m.Stop(), Times.Once);
+        }
+
+        [Fact]
+        public void SarifFolder_Does_Exist_WithSarifFiles()
+        {
+            SariferOption.InitializeForUnitTests();
+
+            string sarifDirectory = ".sarif";
+            string solutionDirectory = @"C:\some-solution-folder";
+            string combinedPath = Path.Combine(solutionDirectory, sarifDirectory);
+            string searchPattern = Constants.SarifFileSearchPattern;
+            string[] sarifFiles = new string[]
+            {
+                Path.Combine(combinedPath, "Test1.sarif"),
+                Path.Combine(combinedPath, "Test2.sarif"),
+                Path.Combine(combinedPath, "Test3.sarif"),
+            };
+
+            var mockFileSystem = new Mock<IFileSystem>();
+            mockFileSystem.Setup(fs => fs.DirectoryExists(It.IsAny<string>())).Returns(false);
+            mockFileSystem.Setup(fs => fs.DirectoryExists(solutionDirectory)).Returns(true);
+            mockFileSystem.Setup(fs => fs.DirectoryExists(combinedPath)).Returns(true);
+            mockFileSystem.Setup(fs => fs.DirectoryGetFiles(combinedPath, searchPattern)).Returns(sarifFiles);
+
+            var mockFileWatcher = new Mock<IFileWatcher>();
+
+            var mockViewerInterop = new Mock<ISarifViewerInterop>();
+
+            var monitor = new SarifFolderMonitor(mockViewerInterop.Object, mockFileSystem.Object, mockFileWatcher.Object);
+            monitor.StartWatch(solutionDirectory);
+
+            mockViewerInterop.Verify(m => m.OpenSarifLogAsync(It.IsAny<IEnumerable<string>>()), Times.Once);
+            mockViewerInterop.Verify(m => m.OpenSarifLogAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Never);
+            mockFileWatcher.Verify(m => m.Start(), Times.Once);
+
+            monitor.StopWatch();
+
+            mockViewerInterop.Verify(m => m.CloseSarifLogAsync(It.IsAny<IEnumerable<string>>()), Times.Once);
+            mockFileWatcher.Verify(m => m.Stop(), Times.Once);
+        }
+
+        [Fact]
+        public void SarifFolder_Add_NewSarifFiles()
+        {
+            SariferOption.InitializeForUnitTests();
+
+            string sarifDirectory = ".sarif";
+            string solutionDirectory = @"C:\some-solution-folder";
+            string combinedPath = Path.Combine(solutionDirectory, sarifDirectory);
+            string searchPattern = Constants.SarifFileSearchPattern;
+            var sarifFiles = new List<string>
+            {
+                Path.Combine(combinedPath, "Test1.sarif"),
+                Path.Combine(combinedPath, "Test2.sarif"),
+                Path.Combine(combinedPath, "Test3.sarif"),
+            };
+
+            var mockFileSystem = new Mock<IFileSystem>();
+            mockFileSystem.Setup(fs => fs.DirectoryExists(It.IsAny<string>())).Returns(false);
+            mockFileSystem.Setup(fs => fs.DirectoryExists(solutionDirectory)).Returns(true);
+            mockFileSystem.Setup(fs => fs.DirectoryExists(combinedPath)).Returns(true);
+            mockFileSystem.Setup(fs => fs.DirectoryGetFiles(combinedPath, searchPattern)).Returns(sarifFiles);
+
+            var mockFileWatcher = new Mock<IFileWatcher>();
+
+            var mockViewerInterop = new Mock<ISarifViewerInterop>();
+
+            var monitor = new SarifFolderMonitor(mockViewerInterop.Object, mockFileSystem.Object, mockFileWatcher.Object);
+            monitor.StartWatch(solutionDirectory);
+
+            mockViewerInterop.Verify(m => m.OpenSarifLogAsync(It.IsAny<IEnumerable<string>>()), Times.Once);
+            mockViewerInterop.Verify(m => m.OpenSarifLogAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Never);
+            mockFileWatcher.Verify(m => m.Start(), Times.Once);
+
+            // simulating add one sarif file
+            string newFile = Path.Combine(combinedPath, "NewAdded1.sarif");
+            var eventArg = new FileSystemEventArgs(WatcherChangeTypes.Created, newFile, string.Empty);
+
+            // trigger file created event 1st time
+            mockFileWatcher.Raise(fw => fw.SarifLogFileCreated += null, eventArg);
+            mockViewerInterop.Verify(m => m.OpenSarifLogAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Once);
+
+            // trigger file created event 2nd time
+            newFile = Path.Combine(combinedPath, "NewAdded2.sarif");
+            eventArg = new FileSystemEventArgs(WatcherChangeTypes.Created, newFile, string.Empty);
+            mockFileWatcher.Raise(fw => fw.SarifLogFileCreated += null, eventArg);
+
+            newFile = Path.Combine(combinedPath, "NewAdded3.sarif");
+            eventArg = new FileSystemEventArgs(WatcherChangeTypes.Created, newFile, string.Empty);
+            mockFileWatcher.Raise(fw => fw.SarifLogFileCreated += null, eventArg);
+
+            // 2 files created, expect method to be called 1 + 2 times
+            mockViewerInterop.Verify(m => m.OpenSarifLogAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Exactly(3));
+
+            monitor.StopWatch();
+
+            mockViewerInterop.Verify(m => m.CloseSarifLogAsync(It.IsAny<IEnumerable<string>>()), Times.Once);
+            mockFileWatcher.Verify(m => m.Stop(), Times.Once);
+        }
+
+        [Fact]
+        public void SarifFolder_Delete_ExistingSarifFiles()
+        {
+            SariferOption.InitializeForUnitTests();
+
+            string sarifDirectory = ".sarif";
+            string solutionDirectory = @"C:\some-solution-folder";
+            string combinedPath = Path.Combine(solutionDirectory, sarifDirectory);
+            string searchPattern = Constants.SarifFileSearchPattern;
+            var sarifFiles = new List<string>
+            {
+                Path.Combine(combinedPath, "Test1.sarif"),
+                Path.Combine(combinedPath, "Test2.sarif"),
+                Path.Combine(combinedPath, "Test3.sarif"),
+            };
+
+            var mockFileSystem = new Mock<IFileSystem>();
+            mockFileSystem.Setup(fs => fs.DirectoryExists(It.IsAny<string>())).Returns(false);
+            mockFileSystem.Setup(fs => fs.DirectoryExists(solutionDirectory)).Returns(true);
+            mockFileSystem.Setup(fs => fs.DirectoryExists(combinedPath)).Returns(true);
+            mockFileSystem.Setup(fs => fs.DirectoryGetFiles(combinedPath, searchPattern)).Returns(sarifFiles);
+
+            var mockFileWatcher = new Mock<IFileWatcher>();
+
+            var mockViewerInterop = new Mock<ISarifViewerInterop>();
+
+            var monitor = new SarifFolderMonitor(mockViewerInterop.Object, mockFileSystem.Object, mockFileWatcher.Object);
+            monitor.StartWatch(solutionDirectory);
+
+            mockViewerInterop.Verify(m => m.OpenSarifLogAsync(It.IsAny<IEnumerable<string>>()), Times.Once);
+            mockViewerInterop.Verify(m => m.OpenSarifLogAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Never);
+            mockFileWatcher.Verify(m => m.Start(), Times.Once);
+
+            // simulate deleting one sarif file
+            string newFile = Path.Combine(combinedPath, "Test1.sarif");
+            var eventArg = new FileSystemEventArgs(WatcherChangeTypes.Deleted, newFile, string.Empty);
+
+            // trigger file deleted event 1st time
+            mockFileWatcher.Raise(fw => fw.SarifLogFileDeleted += null, eventArg);
+            mockViewerInterop.Verify(m => m.CloseSarifLogAsync(It.IsAny<IEnumerable<string>>()), Times.Once);
+
+
+            // trigger file created event 2nd time
+            newFile = Path.Combine(combinedPath, "Test2.sarif");
+            eventArg = new FileSystemEventArgs(WatcherChangeTypes.Deleted, newFile, string.Empty);
+            mockFileWatcher.Raise(fw => fw.SarifLogFileDeleted += null, eventArg);
+
+            newFile = Path.Combine(combinedPath, "Test3.sarif");
+            eventArg = new FileSystemEventArgs(WatcherChangeTypes.Deleted, newFile, string.Empty);
+            mockFileWatcher.Raise(fw => fw.SarifLogFileDeleted += null, eventArg);
+
+            // 2 files deleted, method expected to be called 1 + 2 times
+            mockViewerInterop.Verify(m => m.CloseSarifLogAsync(It.IsAny<IEnumerable<string>>()), Times.Exactly(3));
+
+            monitor.StopWatch();
+
+            mockViewerInterop.Verify(m => m.CloseSarifLogAsync(It.IsAny<IEnumerable<string>>()), Times.Exactly(4));
+            mockFileWatcher.Verify(m => m.Stop(), Times.Once);
+        }
+    }
+}

--- a/src/Sarif.Sarifer.UnitTests/SariferUnitTestBase.cs
+++ b/src/Sarif.Sarifer.UnitTests/SariferUnitTestBase.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis.Sarif.Sarifer;
+
+namespace Sarif.Sarifer.UnitTests
+{
+    public class SariferUnitTestBase
+    {
+        public SariferUnitTestBase()
+        {
+            SariferPackage.IsUnitTesting = true;
+            SariferOption.InitializeForUnitTests();
+        }
+    }
+}

--- a/src/Sarif.Sarifer/Constants.cs
+++ b/src/Sarif.Sarifer/Constants.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.CodeAnalysis.Sarif.Sarifer
+{
+    internal static class Constants
+    {
+        public const string SpamFolderName = ".spam";
+        public const string SarifFolderName = ".sarif";
+        public const string SarifFileExtensionName = ".sarif";
+        public const string SarifFileSearchPattern = "*.sarif";
+    }
+}

--- a/src/Sarif.Sarifer/FileWatcher/FileWatcher.cs
+++ b/src/Sarif.Sarifer/FileWatcher/FileWatcher.cs
@@ -18,9 +18,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer.FileWatcher
         /// </summary>
         private bool m_disposed;
 
+        internal FileWatcher()
+        {
+        }
+
         internal FileWatcher(string filePath, string filter)
         {
-            fileSystemWatcher = this.CreateFileSystemWatcher(filePath, filter);
+            this.WatcherFilePath = filePath;
+            this.WatcherFilter = filter;
         }
 
         /// <summary>
@@ -43,6 +48,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer.FileWatcher
         /// </summary>
         public event EventHandler<FileSystemEventArgs> SarifLogFileDeleted;
 
+        public string WatcherFilePath { get; set; }
+
+        public string WatcherFilter { get; set; }
+
         /// <summary>
         /// Starts watching for changes to the Sarif log file.
         /// </summary>
@@ -50,6 +59,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer.FileWatcher
         {
             // Make sure we have not been disposed.
             this.EnsureNotDisposed();
+
+            if (string.IsNullOrEmpty(this.WatcherFilePath) || string.IsNullOrEmpty(this.WatcherFilter))
+            {
+                return;
+            }
+
+            this.fileSystemWatcher = CreateFileSystemWatcher(this.WatcherFilePath, this.WatcherFilter);
 
             // Start listening for changes to the file.
             fileSystemWatcher.EnableRaisingEvents = true;

--- a/src/Sarif.Sarifer/FileWatcher/FileWatcher.cs
+++ b/src/Sarif.Sarifer/FileWatcher/FileWatcher.cs
@@ -1,0 +1,154 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.CodeAnalysis.Sarif.Sarifer.FileWatcher
+{
+    /// <summary>
+    /// FileSystemWatcher wrapper class.
+    /// </summary>
+    internal class FileWatcher : IFileWatcher, IDisposable
+    {
+        private FileSystemWatcher fileSystemWatcher;
+
+        /// <summary>
+        /// Set to true once the instance has been disposed.
+        /// </summary>
+        private bool m_disposed;
+
+        internal FileWatcher(string filePath, string filter)
+        {
+            fileSystemWatcher = this.CreateFileSystemWatcher(filePath, filter);
+        }
+
+        /// <summary>
+        /// Raised when Sarif log file is updated/changed.
+        /// </summary>
+        public event EventHandler<FileSystemEventArgs> SarifLogFileChanged;
+
+        /// <summary>
+        /// Raised when Sarif log file is renamed.
+        /// </summary>
+        public event EventHandler<RenamedEventArgs> SarifLogFileRenamed;
+
+        /// <summary>
+        /// Raised when Sarif log file is created.
+        /// </summary>
+        public event EventHandler<FileSystemEventArgs> SarifLogFileCreated;
+
+        /// <summary>
+        /// Raised when Sarif log file is deleted.
+        /// </summary>
+        public event EventHandler<FileSystemEventArgs> SarifLogFileDeleted;
+
+        /// <summary>
+        /// Starts watching for changes to the Sarif log file.
+        /// </summary>
+        public void Start()
+        {
+            // Make sure we have not been disposed.
+            this.EnsureNotDisposed();
+
+            // Start listening for changes to the file.
+            fileSystemWatcher.EnableRaisingEvents = true;
+        }
+
+        /// <summary>
+        /// Stops watching for changes to the Sarif log file.
+        /// </summary>
+        public void Stop()
+        {
+            if (!m_disposed)
+            {
+                if (fileSystemWatcher != null)
+                {
+                    fileSystemWatcher.Changed -= this.SarifLogFile_Changed;
+                    fileSystemWatcher.Renamed -= this.SarifLogFile_Renamed;
+                    fileSystemWatcher.Created -= this.SarifLogFile_Created;
+                    fileSystemWatcher.Deleted -= this.SarifLogFile_Deleted;
+                    fileSystemWatcher.Dispose();
+                    fileSystemWatcher = null;
+                }
+
+                m_disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            this.Stop();
+        }
+
+        /// <summary>
+        /// Creates a <see cref="FileSystemWatcher"/> that detects changes to the Sarif log file.
+        /// </summary>
+        /// <returns>a <see cref="FileSystemWatcher"/> object.</returns>
+        /// <exception cref="ArgumentException"> if filePath does not exist.
+        /// </exception>
+        private FileSystemWatcher CreateFileSystemWatcher(string folderPath, string filter)
+        {
+            var fileSystemWatcher = new FileSystemWatcher
+            {
+                Path = folderPath,
+                Filter = filter,
+                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName,
+            };
+            fileSystemWatcher.Changed += this.SarifLogFile_Changed;
+            fileSystemWatcher.Renamed += this.SarifLogFile_Renamed;
+            fileSystemWatcher.Created += this.SarifLogFile_Created;
+            fileSystemWatcher.Deleted += this.SarifLogFile_Deleted;
+
+            return fileSystemWatcher;
+        }
+
+        private void SarifLogFile_Deleted(object sender, FileSystemEventArgs e)
+        {
+            this.SarifLogFileDeleted?.Invoke(this, e);
+        }
+
+        private void SarifLogFile_Created(object sender, FileSystemEventArgs e)
+        {
+            try
+            {
+                this.fileSystemWatcher.EnableRaisingEvents = false;
+                this.SarifLogFileCreated?.Invoke(this, e);
+            }
+            finally
+            {
+                this.fileSystemWatcher.EnableRaisingEvents = true;
+            }
+        }
+
+        private void SarifLogFile_Renamed(object sender, RenamedEventArgs e)
+        {
+            this.SarifLogFileRenamed?.Invoke(this, e);
+        }
+
+        private void SarifLogFile_Changed(object sender, FileSystemEventArgs e)
+        {
+            try
+            {
+                // to avoid trigger changed event multiple times in a short time period.
+                this.fileSystemWatcher.EnableRaisingEvents = false;
+                this.SarifLogFileChanged?.Invoke(this, e);
+            }
+            finally
+            {
+                this.fileSystemWatcher.EnableRaisingEvents = true;
+            }
+        }
+
+        /// <summary>
+        /// Throws if this instance has been disposed.
+        /// </summary>
+        private void EnsureNotDisposed()
+        {
+            if (m_disposed)
+            {
+                throw new ObjectDisposedException(this.GetType().Name);
+            }
+        }
+    }
+}

--- a/src/Sarif.Sarifer/FileWatcher/IFileWatcher.cs
+++ b/src/Sarif.Sarifer/FileWatcher/IFileWatcher.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.CodeAnalysis.Sarif.Sarifer.FileWatcher
+{
+    internal interface IFileWatcher
+    {
+        event EventHandler<FileSystemEventArgs> SarifLogFileCreated;
+
+        event EventHandler<FileSystemEventArgs> SarifLogFileChanged;
+
+        event EventHandler<FileSystemEventArgs> SarifLogFileDeleted;
+
+        event EventHandler<RenamedEventArgs> SarifLogFileRenamed;
+
+        void Start();
+
+        void Stop();
+    }
+}

--- a/src/Sarif.Sarifer/FileWatcher/IFileWatcher.cs
+++ b/src/Sarif.Sarifer/FileWatcher/IFileWatcher.cs
@@ -16,6 +16,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer.FileWatcher
 
         event EventHandler<RenamedEventArgs> SarifLogFileRenamed;
 
+        string WatcherFilePath { get; set; }
+
+        string WatcherFilter { get; set; }
+
         void Start();
 
         void Stop();

--- a/src/Sarif.Sarifer/FileWatcher/ISarifFileMonitor.cs
+++ b/src/Sarif.Sarifer/FileWatcher/ISarifFileMonitor.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.Sarif.Sarifer.FileWatcher
+{
+    public interface ISarifFileMonitor
+    {
+        void StartWatch(string solutionFolder = null);
+
+        void StopWatch();
+    }
+}

--- a/src/Sarif.Sarifer/FileWatcher/SarifFolderMonitor.cs
+++ b/src/Sarif.Sarifer/FileWatcher/SarifFolderMonitor.cs
@@ -1,0 +1,145 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using EnvDTE;
+
+using EnvDTE80;
+
+using Microsoft.Sarif.Viewer.Interop;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.CodeAnalysis.Sarif.Sarifer.FileWatcher
+{
+    /// <summary>
+    /// Handles loading & monitoring sarif logs under solution directory .sarif folder
+    /// </summary>
+    internal class SarifFolderMonitor : IDisposable
+    {
+        private readonly IFileSystem fileSystem;
+
+        private readonly SarifViewerInterop viewerInterop;
+
+        private IFileWatcher fileWatcher;
+
+        private string solutionFolder = null;
+
+        internal SarifFolderMonitor(IVsShell vsShell, IFileSystem fs = null)
+        {
+            this.viewerInterop = new SarifViewerInterop(vsShell);
+            this.fileSystem = fs ?? new FileSystem();
+        }
+
+        public void Dispose()
+        {
+            (this.fileWatcher as FileWatcher)?.Dispose();
+        }
+
+        internal void StartWatch(string solutionPath = null)
+        {
+            if (!SariferOption.Instance.ShouldMonitorSarifFolder)
+            {
+                return;
+            }
+
+            this.solutionFolder = solutionPath ?? this.GetSolutionDirectory();
+            if (string.IsNullOrEmpty(this.solutionFolder) || !fileSystem.DirectoryExists(this.solutionFolder))
+            {
+                return;
+            }
+
+            string sarifLogFolder = Path.Combine(this.solutionFolder, Constants.SarifFolderName);
+            if (!fileSystem.DirectoryExists(sarifLogFolder))
+            {
+                return;
+            }
+
+            // load existing sarif logs
+            this.LoadExistingSarifLogs(sarifLogFolder);
+
+            if (this.fileWatcher == null)
+            {
+                this.fileWatcher = new FileWatcher(sarifLogFolder, Constants.SarifFileSearchPattern);
+
+                // here no need to watch for sarif file log updates
+                // because when load the sarif log file in viewer, its already monitored by viewer's file watcher
+                this.fileWatcher.SarifLogFileCreated += this.Watcher_SarifLogFileCreated;
+                this.fileWatcher.SarifLogFileDeleted += this.Watcher_SarifLogFileDeleted;
+                this.fileWatcher.Start();
+            }
+        }
+
+        internal void StopWatch()
+        {
+            if (!SariferOption.Instance.ShouldMonitorSarifFolder)
+            {
+                return;
+            }
+
+            if (this.fileWatcher != null)
+            {
+                this.fileWatcher.Stop();
+                this.fileWatcher.SarifLogFileCreated -= this.Watcher_SarifLogFileCreated;
+                this.fileWatcher.SarifLogFileDeleted -= this.Watcher_SarifLogFileDeleted;
+                this.fileWatcher = null;
+            }
+
+            this.CloseExistingSarifLogs(Path.Combine(this.solutionFolder, Constants.SarifFolderName));
+            this.solutionFolder = null;
+        }
+
+        internal void LoadExistingSarifLogs(string targetFolderPath)
+        {
+            if (!string.IsNullOrEmpty(targetFolderPath))
+            {
+                IEnumerable<string> sarifLogFiles = this.fileSystem.DirectoryGetFiles(targetFolderPath, Constants.SarifFileSearchPattern);
+                ThreadHelper.JoinableTaskFactory.Run(() => this.viewerInterop.OpenSarifLogAsync(sarifLogFiles));
+            }
+        }
+
+        internal void CloseExistingSarifLogs(string targetFolderPath)
+        {
+            if (!string.IsNullOrEmpty(targetFolderPath))
+            {
+                IEnumerable<string> sarifLogFiles = this.fileSystem.DirectoryGetFiles(targetFolderPath, Constants.SarifFileSearchPattern);
+                ThreadHelper.JoinableTaskFactory.Run(() => this.viewerInterop.CloseSarifLogAsync(sarifLogFiles));
+            }
+        }
+
+        internal async System.Threading.Tasks.Task LoadSarifLogAsync(string path)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            await this.viewerInterop.OpenSarifLogAsync(path, cleanErrors: false, openInEditor: false);
+        }
+
+        internal async System.Threading.Tasks.Task CloseSarifLogAsync(string path)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            await this.viewerInterop.CloseSarifLogAsync(new string[] { path });
+        }
+
+        private void Watcher_SarifLogFileCreated(object sender, FileSystemEventArgs e)
+        {
+            ThreadHelper.JoinableTaskFactory.Run(() => this.LoadSarifLogAsync(e.FullPath));
+        }
+
+        private void Watcher_SarifLogFileDeleted(object sender, FileSystemEventArgs e)
+        {
+            ThreadHelper.JoinableTaskFactory.Run(() => this.CloseSarifLogAsync(e.FullPath));
+        }
+
+        /// <summary>
+        /// Returns the solution directory, or null if no solution is open.
+        /// </summary>
+        private string GetSolutionDirectory()
+        {
+            var dte = (DTE2)Package.GetGlobalService(typeof(DTE));
+            string solutionFilePath = dte.Solution?.FullName;
+            return string.IsNullOrEmpty(solutionFilePath) ? null : Path.GetDirectoryName(solutionFilePath);
+        }
+    }
+}

--- a/src/Sarif.Sarifer/FileWatcher/SarifFolderMonitor.cs
+++ b/src/Sarif.Sarifer/FileWatcher/SarifFolderMonitor.cs
@@ -16,7 +16,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 namespace Microsoft.CodeAnalysis.Sarif.Sarifer.FileWatcher
 {
     /// <summary>
-    /// Handles loading & monitoring sarif logs under solution directory .sarif folder
+    /// Handles loading & monitoring sarif logs under solution directory .sarif folder.
     /// </summary>
     internal class SarifFolderMonitor : IDisposable
     {

--- a/src/Sarif.Sarifer/Sarif.Sarifer.csproj
+++ b/src/Sarif.Sarifer/Sarif.Sarifer.csproj
@@ -59,6 +59,11 @@
     <Compile Include="BackgroundAnalysisService.cs" />
     <Compile Include="BackgroundAnalysisTextViewCreationListener.cs" />
     <Compile Include="BackgroundAnalyzerBase.cs" />
+    <Compile Include="Constants.cs" />
+    <Compile Include="FileWatcher\FileWatcher.cs" />
+    <Compile Include="FileWatcher\IFileWatcher.cs" />
+    <Compile Include="FileWatcher\ISarifFileMonitor.cs" />
+    <Compile Include="FileWatcher\SarifFolderMonitor.cs" />
     <Compile Include="FirstViewAddedEventArgs.cs" />
     <Compile Include="Commands\AnalyzeProjectCommand.cs" />
     <Compile Include="IBackgroundAnalysisService.cs" />

--- a/src/Sarif.Sarifer/SariferExtensionOptionPage.cs
+++ b/src/Sarif.Sarifer/SariferExtensionOptionPage.cs
@@ -20,6 +20,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         private const string AnalyzeSarifFileDisplayName = "Enable analysis for .sarif files";
         private const string AnalyzeSarifFileDescription = "If enabled, .sarif files will be analyzed by default.";
 
+        private const string MonitorSarifFolderDisplayName = "Enable loading sarif results in .sarif folder automatically";
+        private const string MonitorSarifFolderDescription = "If enabled, .sarif files under .sarif folder will be loaded to error list automatically.";
+
         [Category(CategoryName)]
         [DisplayName(BackgroundAnalysisEnabledDisplayName)]
         [Description(BackgroundAnalysisEnabledDescription)]
@@ -29,5 +32,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         [DisplayName(AnalyzeSarifFileDisplayName)]
         [Description(AnalyzeSarifFileDescription)]
         public bool AnalyzeSarifFile { get; set; }
+
+        [Category(CategoryName)]
+        [DisplayName(MonitorSarifFolderDisplayName)]
+        [Description(MonitorSarifFolderDescription)]
+        public bool MonitorSarifFolder { get; set; } = true;
     }
 }

--- a/src/Sarif.Sarifer/SariferOption.cs
+++ b/src/Sarif.Sarifer/SariferOption.cs
@@ -76,6 +76,22 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
             }
         }
 
+        public bool ShouldMonitorSarifFolder
+        {
+            get
+            {
+                try
+                {
+                    return this.OptionPage.MonitorSarifFolder;
+                }
+                catch
+                {
+                    // default value
+                    return false;
+                }
+            }
+        }
+
         /// <summary>
         /// Initializes the singleton instance of the <see cref="SariferOption"/> class.
         /// </summary>

--- a/src/Sarif.Sarifer/SariferOption.cs
+++ b/src/Sarif.Sarifer/SariferOption.cs
@@ -11,6 +11,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
 {
     internal class SariferOption
     {
+        private readonly bool isBackgroundAnalysisEnabledDefaultValue = true;
+
+        private readonly bool shouldAnalyzeSarifFileDefaultValue = false;
+
+        private readonly bool shouldMonitorSarifFolderDefaultValue = true;
+
         private readonly AsyncPackage package;
 
         private SariferExtensionOptionPage optionPage;
@@ -23,6 +29,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         private SariferOption(AsyncPackage package)
         {
             this.package = package ?? throw new ArgumentNullException(nameof(package));
+        }
+
+        private SariferOption()
+        {
         }
 
         /// <summary>
@@ -38,8 +48,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         {
             get
             {
-                this.optionPage ??= (SariferExtensionOptionPage)this.package.GetDialogPage(typeof(SariferExtensionOptionPage));
+                if (this.package == null)
+                {
+                    return null;
+                }
 
+                this.optionPage ??= (SariferExtensionOptionPage)this.package.GetDialogPage(typeof(SariferExtensionOptionPage));
                 return this.optionPage;
             }
         }
@@ -50,12 +64,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
             {
                 try
                 {
-                    return this.OptionPage.BackgroundAnalysisEnabled;
+                    return this.OptionPage != null ? this.OptionPage.BackgroundAnalysisEnabled : this.isBackgroundAnalysisEnabledDefaultValue;
                 }
                 catch
                 {
                     // default value
-                    return true;
+                    return this.isBackgroundAnalysisEnabledDefaultValue;
                 }
             }
         }
@@ -66,12 +80,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
             {
                 try
                 {
-                    return this.OptionPage.AnalyzeSarifFile;
+                    return this.OptionPage != null ? this.OptionPage.AnalyzeSarifFile : this.shouldAnalyzeSarifFileDefaultValue;
                 }
                 catch
                 {
                     // default value
-                    return false;
+                    return this.shouldAnalyzeSarifFileDefaultValue;
                 }
             }
         }
@@ -82,12 +96,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
             {
                 try
                 {
-                    return this.OptionPage.MonitorSarifFolder;
+                    return this.OptionPage != null ? this.OptionPage.MonitorSarifFolder : this.shouldMonitorSarifFolderDefaultValue;
                 }
                 catch
                 {
                     // default value
-                    return false;
+                    return this.shouldMonitorSarifFolderDefaultValue;
                 }
             }
         }
@@ -103,6 +117,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(package.DisposalToken);
 
             Instance = new SariferOption(package);
+        }
+
+        public static void InitializeForUnitTests()
+        {
+            Instance = new SariferOption();
         }
     }
 }

--- a/src/Sarif.Sarifer/SariferPackage.cs
+++ b/src/Sarif.Sarifer/SariferPackage.cs
@@ -7,6 +7,8 @@ using System.Runtime.InteropServices;
 using System.Threading;
 
 using Microsoft.CodeAnalysis.Sarif.Sarifer.Commands;
+using Microsoft.CodeAnalysis.Sarif.Sarifer.FileWatcher;
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Events;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -27,6 +29,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [ComVisible(true)]
     [ProvideService(typeof(IBackgroundAnalysisService))]
+    [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExistsAndFullyLoaded_string, PackageAutoLoadFlags.BackgroundLoad)]
     [ProvideOptionPage(typeof(SariferExtensionOptionPage), OptionCategoryName, OptionPageName, 0, 0, true)]
     public sealed class SariferPackage : AsyncPackage, IDisposable
     {
@@ -39,6 +42,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         private AnalyzeProjectCommand analyzeProjectCommand;
         private AnalyzeFileCommand analyzeFileCommand;
         private OutputWindowTracerListener outputWindowTraceListener;
+        private SarifFolderMonitor sarifFolderMonitor;
 
         public void Dispose()
         {
@@ -81,6 +85,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
                 this.analyzeSolutionCommand = new AnalyzeSolutionCommand(mcs);
                 this.analyzeProjectCommand = new AnalyzeProjectCommand(mcs);
                 this.analyzeFileCommand = new AnalyzeFileCommand(mcs);
+                this.sarifFolderMonitor = new SarifFolderMonitor(vsShell);
             }
 
             if (await this.GetServiceAsync(typeof(SVsOutputWindow)).ConfigureAwait(continueOnCapturedContext: true) is IVsOutputWindow output)
@@ -89,6 +94,17 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
             }
 
             SolutionEvents.OnBeforeCloseSolution += this.SolutionEvents_OnBeforeCloseSolution;
+
+            if (await this.IsSolutionLoadedAsync())
+            {
+                // Async package initilized after solution is fully loaded according to
+                // [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExistsAndFullyLoaded_string, PackageAutoLoadFlags.BackgroundLoad)]
+                // SolutionEvents.OnAfterBackgroundSolutionLoadComplete will not by triggered until the user opens another solution.
+                // Need to manually start monitor in this case.
+                this.SolutionEvents_OnAfterBackgroundSolutionLoadComplete(null, EventArgs.Empty);
+            }
+
+            SolutionEvents.OnAfterBackgroundSolutionLoadComplete += this.SolutionEvents_OnAfterBackgroundSolutionLoadComplete;
 
             await SariferOption.InitializeAsync(this).ConfigureAwait(false);
         }
@@ -103,6 +119,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
                     this.analyzeProjectCommand?.Dispose();
                     this.analyzeFileCommand?.Dispose();
                     this.outputWindowTraceListener?.Dispose();
+                    this.sarifFolderMonitor?.Dispose();
+
+                    SolutionEvents.OnBeforeCloseSolution -= this.SolutionEvents_OnBeforeCloseSolution;
+                    SolutionEvents.OnAfterBackgroundSolutionLoadComplete -= this.SolutionEvents_OnAfterBackgroundSolutionLoadComplete;
                 }
 
                 this.disposed = true;
@@ -111,12 +131,32 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
             base.Dispose(disposing);
         }
 
+        private async System.Threading.Tasks.Task<bool> IsSolutionLoadedAsync()
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync();
+            var solutionService = await GetServiceAsync(typeof(SVsSolution)) as IVsSolution;
+            if (solutionService == null)
+            {
+                return false;
+            }
+
+            solutionService.GetProperty((int)__VSPROPID.VSPROPID_IsSolutionOpen, out object value);
+            return value is bool isSolOpen && isSolOpen;
+        }
+
         private void SolutionEvents_OnBeforeCloseSolution(object sender, EventArgs e)
         {
             // Cancelling analysis from project / solution when the solution is closed.
             this.analyzeProjectCommand.Cancel();
             this.analyzeSolutionCommand.Cancel();
             this.analyzeFileCommand.Cancel();
+
+            this.sarifFolderMonitor?.StopWatch();
+        }
+
+        private void SolutionEvents_OnAfterBackgroundSolutionLoadComplete(object sender, EventArgs e)
+        {
+            this.sarifFolderMonitor?.StartWatch();
         }
     }
 }

--- a/src/Sarif.Sarifer/SpamBackgroundAnalyzer.cs
+++ b/src/Sarif.Sarifer/SpamBackgroundAnalyzer.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
 
         internal static ISet<Skimmer<AnalyzeContext>> LoadSearchDefinitionsFiles(IFileSystem fileSystem, string solutionDirectory)
         {
-            string spamDirectory = Path.Combine(solutionDirectory, ".spam");
+            string spamDirectory = Path.Combine(solutionDirectory, Constants.SpamFolderName);
             if (!fileSystem.DirectoryExists(spamDirectory))
             {
                 return new HashSet<Skimmer<AnalyzeContext>>();

--- a/src/Sarif.Viewer.VisualStudio.Interop/ISarifViewerInterop.cs
+++ b/src/Sarif.Viewer.VisualStudio.Interop/ISarifViewerInterop.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.Sarif.Viewer.Interop
+{
+    public interface ISarifViewerInterop
+    {
+        Task<bool> OpenSarifLogAsync(IEnumerable<string> paths);
+
+        Task<bool> OpenSarifLogAsync(string path, bool cleanErrors = true, bool openInEditor = false);
+
+        Task<bool> CloseSarifLogAsync(IEnumerable<string> paths);
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio.Interop/Sarif.Viewer.VisualStudio.Interop.csproj
+++ b/src/Sarif.Viewer.VisualStudio.Interop/Sarif.Viewer.VisualStudio.Interop.csproj
@@ -47,6 +47,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ISarifViewerInterop.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SarifViewerInterop.cs" />
   </ItemGroup>

--- a/src/Sarif.Viewer.VisualStudio.Interop/SarifViewerInterop.cs
+++ b/src/Sarif.Viewer.VisualStudio.Interop/SarifViewerInterop.cs
@@ -12,7 +12,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.Sarif.Viewer.Interop
 {
-    public class SarifViewerInterop
+    public class SarifViewerInterop : ISarifViewerInterop
     {
         /// <summary>
         /// Gets the unique identifier of the SARIF Viewer package.

--- a/src/Sarif.Viewer.VisualStudio/FileWatcher/SarifLogsMonitor.cs
+++ b/src/Sarif.Viewer.VisualStudio/FileWatcher/SarifLogsMonitor.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Sarif.Viewer.FileWatcher
         private void RefreshSarifErrors(string filePath)
         {
             ThreadHelper.JoinableTaskFactory.Run(() => ErrorListService.CloseSarifLogItemsAsync(new string[] { filePath }));
-            ErrorListService.ProcessLogFile(filePath, ToolFormat.None, promptOnLogConversions: true, cleanErrors: false, openInEditor: true);
+            ErrorListService.ProcessLogFile(filePath, ToolFormat.None, promptOnLogConversions: true, cleanErrors: false, openInEditor: false);
         }
 
         internal void StopWatch(string logFilePath)


### PR DESCRIPTION
for #380 

- Automatically load all sarif log files from .sarif folder under solution directory to error lists when solution is loaded.
- Close all sarif logs when solution is closed.
- Monitor the folder and watch sarif log files created/deleted, load/unload results accordingly.
- Updates error list when any sarif log file in the folder is updated.
- Enabled/disable the behavior using option.