### PR TITLE
Fix issue cannot load SARIF log size greater than 5 MBs

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/MultipleRunsPerSarifTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/MultipleRunsPerSarifTests.cs
@@ -123,11 +123,11 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         {
             await TestUtilities.InitializeTestEnvironmentAsync(this.testLog);
 
-            var hasFirstError = SarifTableDataSource.Instance.HasErrors("/item1.cpp");
-            var hasSecondError = SarifTableDataSource.Instance.HasErrors("/item2.cpp");
-            var hasThirdError = SarifTableDataSource.Instance.HasErrors("/item3.cpp");
+            bool hasFirstError = SarifTableDataSource.Instance.HasErrors("/item1.cpp");
+            bool hasSecondError = SarifTableDataSource.Instance.HasErrors("/item2.cpp");
+            bool hasThirdError = SarifTableDataSource.Instance.HasErrors("/item3.cpp");
 
-            var hasBothErrors = hasFirstError && hasSecondError && hasThirdError;
+            bool hasBothErrors = hasFirstError && hasSecondError && hasThirdError;
 
             hasBothErrors.Should().BeTrue();
         }
@@ -137,9 +137,51 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         {
             await TestUtilities.InitializeTestEnvironmentAsync(this.testLog);
 
-            var errorCount = CodeAnalysisResultManager.Instance.RunIndexToRunDataCache.Sum(c => c.Value.SarifErrors.Count);
+            int errorCount = CodeAnalysisResultManager.Instance.RunIndexToRunDataCache.Sum(c => c.Value.SarifErrors.Count);
 
             errorCount.Should().Be(3);
+        }
+
+        [Fact]
+        public async Task ErrorList_IsSarifLogOpened()
+        {
+            TestUtilities.InitializeTestEnvironment();
+
+            string logFileName1 = @"C:\git\repo\sarif-sdk\test_data\testresult1.sarif";
+            string logFileName2 = @"C:\git\repo\sarif-sdk\test_data\testtool2.sarif";
+            bool sarifLogOpened = ErrorListService.IsSarifLogOpened(logFileName1);
+            sarifLogOpened.Should().BeFalse();
+            sarifLogOpened = ErrorListService.IsSarifLogOpened(logFileName2);
+            sarifLogOpened.Should().BeFalse();
+
+            // load sarif log 1
+            await TestUtilities.InitializeTestEnvironmentAsync(this.testLog, logFileName1);
+
+            bool hasFirstError = SarifTableDataSource.Instance.HasErrors("/item1.cpp");
+            bool hasSecondError = SarifTableDataSource.Instance.HasErrors("/item2.cpp");
+            bool hasThirdError = SarifTableDataSource.Instance.HasErrors("/item3.cpp");
+
+            bool hasBothErrors = hasFirstError && hasSecondError && hasThirdError;
+            hasBothErrors.Should().BeTrue();
+
+            sarifLogOpened = ErrorListService.IsSarifLogOpened(logFileName1);
+            sarifLogOpened.Should().BeTrue();
+            sarifLogOpened = ErrorListService.IsSarifLogOpened(logFileName2);
+            sarifLogOpened.Should().BeFalse();
+
+            // load sarif log 2
+            await TestUtilities.InitializeTestEnvironmentAsync(this.testLog, logFileName2, cleanErrors: false);
+            sarifLogOpened = ErrorListService.IsSarifLogOpened(logFileName1);
+            sarifLogOpened.Should().BeTrue();
+            sarifLogOpened = ErrorListService.IsSarifLogOpened(logFileName2);
+            sarifLogOpened.Should().BeTrue();
+
+            // close sairf log 1
+            await ErrorListService.CloseSarifLogItemsAsync(new string[] { logFileName1 });
+            sarifLogOpened = ErrorListService.IsSarifLogOpened(logFileName1);
+            sarifLogOpened.Should().BeFalse();
+            sarifLogOpened = ErrorListService.IsSarifLogOpened(logFileName2);
+            sarifLogOpened.Should().BeTrue();
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifFileWithContentsTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifFileWithContentsTests.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         {
             await TestUtilities.InitializeTestEnvironmentAsync(this.testLog);
 
-            var fileDetails = this.CurrentRunDataCache.FileDetails;
+            IDictionary<string, Models.ArtifactDetailsModel> fileDetails = this.CurrentRunDataCache.FileDetails;
 
             fileDetails.Should().ContainKey(Key1);
         }
@@ -219,8 +219,8 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         {
             await TestUtilities.InitializeTestEnvironmentAsync(this.testLog);
 
-            var fileDetail = this.CurrentRunDataCache.FileDetails[Key2];
-            var contents = fileDetail.GetContents();
+            Models.ArtifactDetailsModel fileDetail = this.CurrentRunDataCache.FileDetails[Key2];
+            string contents = fileDetail.GetContents();
 
             fileDetail.Sha256Hash.Should().Be(ExpectedHashValue2);
             contents.Should().Be(ExpectedContents2);
@@ -231,9 +231,9 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         {
             await TestUtilities.InitializeTestEnvironmentAsync(this.testLog);
 
-            var rebaselinedFile = CodeAnalysisResultManager.Instance.CreateFileFromContents(this.CurrentRunIndex, Key2);
-            var fileDetail = this.CurrentRunDataCache.FileDetails[Key2];
-            var fileText = File.ReadAllText(rebaselinedFile);
+            string rebaselinedFile = CodeAnalysisResultManager.Instance.CreateFileFromContents(this.CurrentRunIndex, Key2);
+            Models.ArtifactDetailsModel fileDetail = this.CurrentRunDataCache.FileDetails[Key2];
+            string fileText = File.ReadAllText(rebaselinedFile);
 
             fileDetail.Sha256Hash.Should().Be(ExpectedHashValue2);
             fileText.Should().Be(ExpectedContents2);
@@ -244,9 +244,9 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         {
             await TestUtilities.InitializeTestEnvironmentAsync(this.testLog);
 
-            var rebaselinedFile = CodeAnalysisResultManager.Instance.CreateFileFromContents(this.CurrentRunIndex, Key8);
-            var fileDetail = this.CurrentRunDataCache.FileDetails[Key8];
-            var fileText = File.ReadAllText(rebaselinedFile);
+            string rebaselinedFile = CodeAnalysisResultManager.Instance.CreateFileFromContents(this.CurrentRunIndex, Key8);
+            Models.ArtifactDetailsModel fileDetail = this.CurrentRunDataCache.FileDetails[Key8];
+            string fileText = File.ReadAllText(rebaselinedFile);
 
             fileDetail.Sha256Hash.Should().Be(ExpectedHashValue2);
             fileText.Should().Be(ExpectedContents2);
@@ -257,8 +257,8 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         {
             await TestUtilities.InitializeTestEnvironmentAsync(this.testLog);
 
-            var fileDetail = this.CurrentRunDataCache.FileDetails[Key3];
-            var contents = fileDetail.GetContents();
+            Models.ArtifactDetailsModel fileDetail = this.CurrentRunDataCache.FileDetails[Key3];
+            string contents = fileDetail.GetContents();
 
             contents.Should().Be(ExpectedContents1);
         }
@@ -268,8 +268,8 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         {
             await TestUtilities.InitializeTestEnvironmentAsync(this.testLog);
 
-            var fileDetail = this.CurrentRunDataCache.FileDetails[Key4];
-            var contents = fileDetail.GetContents();
+            Models.ArtifactDetailsModel fileDetail = this.CurrentRunDataCache.FileDetails[Key4];
+            string contents = fileDetail.GetContents();
 
             fileDetail.Sha256Hash.Should().Be(ExpectedHashValue2);
             contents.Should().Be(ExpectedContents2);
@@ -280,8 +280,8 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         {
             await TestUtilities.InitializeTestEnvironmentAsync(this.testLog);
 
-            var fileDetail = this.CurrentRunDataCache.FileDetails[Key5];
-            var contents = fileDetail.GetContents();
+            Models.ArtifactDetailsModel fileDetail = this.CurrentRunDataCache.FileDetails[Key5];
+            string contents = fileDetail.GetContents();
 
             fileDetail.Sha256Hash.Should().Be(EmptyStringHash);
             contents.Should().Be(string.Empty);
@@ -290,8 +290,8 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         [Fact]
         public void SarifFileWithContents_HandlesEmptyTextContents()
         {
-            var fileDetail = this.CurrentRunDataCache.FileDetails[Key6];
-            var contents = fileDetail.GetContents();
+            Models.ArtifactDetailsModel fileDetail = this.CurrentRunDataCache.FileDetails[Key6];
+            string contents = fileDetail.GetContents();
 
             fileDetail.Sha256Hash.Should().Be(EmptyStringHash);
             contents.Should().Be(string.Empty);
@@ -302,8 +302,8 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         {
             await TestUtilities.InitializeTestEnvironmentAsync(this.testLog);
 
-            var fileDetail = this.CurrentRunDataCache.FileDetails[Key7];
-            var contents = fileDetail.GetContents();
+            Models.ArtifactDetailsModel fileDetail = this.CurrentRunDataCache.FileDetails[Key7];
+            string contents = fileDetail.GetContents();
 
             fileDetail.Sha256Hash.Should().Be(ExpectedHashValue1);
             contents.Should().Be(ExpectedContents2);
@@ -314,8 +314,8 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         {
             await TestUtilities.InitializeTestEnvironmentAsync(this.testLog);
 
-            var fileDetail = this.CurrentRunDataCache.FileDetails[Key1];
-            var contents = fileDetail.GetContents();
+            Models.ArtifactDetailsModel fileDetail = this.CurrentRunDataCache.FileDetails[Key1];
+            string contents = fileDetail.GetContents();
 
             fileDetail.Sha256Hash.Should().Be(ExpectedHashValue1);
             contents.Should().Be(ExpectedContents1);

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/TestUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/TestUtilities.cs
@@ -15,11 +15,11 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             SarifViewerPackage.IsUnitTesting = true;
         }
 
-        public static async Task InitializeTestEnvironmentAsync(SarifLog sarifLog)
+        public static async Task InitializeTestEnvironmentAsync(SarifLog sarifLog, string logFile = "", bool cleanErrors = true)
         {
             InitializeTestEnvironment();
 
-            await ErrorListService.ProcessSarifLogAsync(sarifLog, string.Empty, cleanErrors: true, openInEditor: false);
+            await ErrorListService.ProcessSarifLogAsync(sarifLog, logFile, cleanErrors: cleanErrors, openInEditor: false);
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/ContentTypes.cs
+++ b/src/Sarif.Viewer.VisualStudio/ContentTypes.cs
@@ -20,6 +20,11 @@ namespace Microsoft.Sarif.Viewer
         public const string Any = "any";
 
         /// <summary>
+        /// The content type name for text files.
+        /// </summary>
+        public const string Text = "text";
+
+        /// <summary>
         /// Gets the base content type definition for SARIF log files..
         /// </summary>
         [Export]

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -359,7 +359,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
         public static bool IsSarifLogOpened(string logFile)
         {
-            return SarifTableDataSource.Instance.HasErrors(logFile) ||
+            return SarifTableDataSource.Instance.HasErrorsFromLog(logFile) ||
                 CodeAnalysisResultManager.Instance.RunIndexToRunDataCache.
                     Any(runDataCacheKvp => runDataCacheKvp.Value.LogFilePath?.Equals(logFile, StringComparison.OrdinalIgnoreCase) == true);
         }

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -357,6 +357,13 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             CleanAllErrors();
         }
 
+        public static bool IsSarifLogOpened(string logFile)
+        {
+            return SarifTableDataSource.Instance.HasErrors(logFile) ||
+                CodeAnalysisResultManager.Instance.RunIndexToRunDataCache.
+                    Any(runDataCacheKvp => runDataCacheKvp.Value.LogFilePath?.Equals(logFile, StringComparison.OrdinalIgnoreCase) == true);
+        }
+
         internal static Match MatchVersionProperty(string logText)
         {
             int headSegmentLength = Math.Min(logText.Length, HeadSegmentLength);

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/SarifTableDataSource.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/SarifTableDataSource.cs
@@ -225,6 +225,19 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             }
         }
 
+        /// <summary>
+        /// Check if log table has entries from particular log file.
+        /// </summary>
+        /// <param name="logFileName">Sarif log file.</param>
+        /// <returns>If true means this log file has been processed and loaded into error list.</returns>
+        internal bool HasErrorsFromLog(string logFileName)
+        {
+            using (this.tableEntriesLock.EnterReadLock())
+            {
+                return this.logFileToTableEntries.Any(entry => entry.Key.Equals(logFileName, StringComparison.OrdinalIgnoreCase));
+            }
+        }
+
         private void CallSinks(Action<ITableDataSink> action)
         {
             IReadOnlyList<SinkHolder> sinkHolders;

--- a/src/Sarif.Viewer.VisualStudio/SarifTextViewCreationListener.cs
+++ b/src/Sarif.Viewer.VisualStudio/SarifTextViewCreationListener.cs
@@ -50,16 +50,11 @@ namespace Microsoft.Sarif.Viewer
 
             textView.Closed += this.TextView_Closed;
 
-            if (this.TryGetFileNameFromTextView(textView, out string filename))
+            if (this.TryGetFileNameFromTextView(textView, out string filename) &&
+                this.IsSarifLogFile(filename))
             {
-                if (!filename.EndsWith(".sarif", StringComparison.OrdinalIgnoreCase) &&
-                    !filename.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
-                {
-                    // since Json (base type of sarif log) editor throws error when file size is greater than 5 MBs
-                    // need to listner to content type "text". Only process log if file extension is .sarif or .json
-                    return;
-                }
-
+                // since Json (base type of sarif log) editor throws error when file size is greater than 5 MBs
+                // need to listen to content type "text". Only process log if file extension is .sarif or .json.
                 if (!textBufferMap.ContainsKey(textView.TextBuffer))
                 {
                     textBufferMap.TryAdd(textView.TextBuffer, 0);
@@ -81,16 +76,9 @@ namespace Microsoft.Sarif.Viewer
             {
                 textView.Closed -= this.TextView_Closed;
 
-                if (this.TryGetFileNameFromTextView(textView, out string filename))
+                if (this.TryGetFileNameFromTextView(textView, out string filename) &&
+                    this.IsSarifLogFile(filename))
                 {
-                    if (!filename.EndsWith(".sarif", StringComparison.OrdinalIgnoreCase) &&
-                        !filename.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
-                    {
-                        // since Json (base type of sarif log) editor throws error when file size is greater than 5 MBs
-                        // need to listner to content type "text". Only process log if file extension is .sarif or .json
-                        return;
-                    }
-
                     if (textBufferMap.ContainsKey(textView.TextBuffer))
                     {
                         textBufferMap[textView.TextBuffer]--;
@@ -127,6 +115,13 @@ namespace Microsoft.Sarif.Viewer
             }
 
             return persistFile.GetCurFile(out fileName, out _) == VSConstants.S_OK;
+        }
+
+        private bool IsSarifLogFile(string fileName)
+        {
+            return !string.IsNullOrEmpty(fileName) &&
+                (fileName.EndsWith(".sarif", StringComparison.OrdinalIgnoreCase) ||
+                    fileName.EndsWith(".json", StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/SarifTextViewCreationListener.cs
+++ b/src/Sarif.Viewer.VisualStudio/SarifTextViewCreationListener.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Sarif.Viewer
     /// Factory for creating our editors.
     /// </summary>
     [ContentType(ContentTypes.Sarif)]
+    [ContentType(ContentTypes.Text)]
     [TextViewRole(PredefinedTextViewRoles.Document)]
     [Export(typeof(ITextViewCreationListener))]
     public class SarifTextViewCreationListener : ITextViewCreationListener
@@ -51,10 +52,21 @@ namespace Microsoft.Sarif.Viewer
 
             if (this.TryGetFileNameFromTextView(textView, out string filename))
             {
+                if (!filename.EndsWith(".sarif", StringComparison.OrdinalIgnoreCase) &&
+                    !filename.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+                {
+                    // since Json (base type of sarif log) editor throws error when file size is greater than 5 MBs
+                    // need to listner to content type "text". Only process log if file extension is .sarif or .json
+                    return;
+                }
+
                 if (!textBufferMap.ContainsKey(textView.TextBuffer))
                 {
                     textBufferMap.TryAdd(textView.TextBuffer, 0);
-                    ErrorListService.ProcessLogFile(filename, ToolFormat.None, promptOnLogConversions: true, cleanErrors: false, openInEditor: false);
+                    if (!ErrorListService.IsSarifLogOpened(filename))
+                    {
+                        ErrorListService.ProcessLogFile(filename, ToolFormat.None, promptOnLogConversions: true, cleanErrors: false, openInEditor: false);
+                    }
                 }
 
                 textBufferMap[textView.TextBuffer]++;
@@ -71,6 +83,14 @@ namespace Microsoft.Sarif.Viewer
 
                 if (this.TryGetFileNameFromTextView(textView, out string filename))
                 {
+                    if (!filename.EndsWith(".sarif", StringComparison.OrdinalIgnoreCase) &&
+                        !filename.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // since Json (base type of sarif log) editor throws error when file size is greater than 5 MBs
+                        // need to listner to content type "text". Only process log if file extension is .sarif or .json
+                        return;
+                    }
+
                     if (textBufferMap.ContainsKey(textView.TextBuffer))
                     {
                         textBufferMap[textView.TextBuffer]--;


### PR DESCRIPTION
Fix #385

Setup listener to base type "text" so that TextViewCreated event can be caught even Json editor throws error.