### PR TITLE
Apply fixes to same error occurrences in current document.

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/Fixes/ApplyFixEventArgs.cs
+++ b/src/Sarif.Viewer.VisualStudio/Fixes/ApplyFixEventArgs.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sarif.Viewer.Fixes
+{
+    internal enum FixScope
+    {
+        /// <summary>
+        /// Scope of fixes to be applied is in current document.
+        /// </summary>
+        Document,
+
+        /// <summary>
+        /// Scope of fixes to be applied is in current project.
+        /// </summary>
+        Project,
+
+        /// <summary>
+        /// Scope of fixes to be applied is in current solution.
+        /// </summary>
+        Solution,
+    }
+
+    internal class ApplyFixEventArgs
+    {
+        internal ApplyFixEventArgs(FixScope scope, SarifErrorListItem errorItem)
+        {
+            this.Scope = scope;
+            this.ErrorItem = errorItem;
+        }
+
+        public FixScope Scope { get; }
+
+        public SarifErrorListItem ErrorItem { get; }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/Fixes/DisposableDifferenceViewerControl.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Fixes/DisposableDifferenceViewerControl.xaml
@@ -6,5 +6,15 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d">
-    <StackPanel x:Name="StackPanelContent"/>
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="DisposableDifferenceViewerControlStringResources.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <StackPanel>
+        <StackPanel x:Name="StackPanelContent" />
+        <TextBlock xml:space="preserve" Text="{StaticResource DifferenceViewer_Text_FixAll}"><Hyperlink Name="applyInDocument" Click="ApplyInDocument_Click" ><TextBlock Text="{StaticResource DifferenceViewer_Text_Document}" /></Hyperlink></TextBlock>
+    </StackPanel>
 </UserControl>

--- a/src/Sarif.Viewer.VisualStudio/Fixes/DisposableDifferenceViewerControl.xaml.cs
+++ b/src/Sarif.Viewer.VisualStudio/Fixes/DisposableDifferenceViewerControl.xaml.cs
@@ -17,19 +17,26 @@ namespace Microsoft.Sarif.Viewer.Fixes
     {
         private IWpfDifferenceViewer differenceViewer = null;
 
+        private readonly SarifErrorListItem sarifErrorListItem = null;
+
+        internal event EventHandler<ApplyFixEventArgs> ApplyFixesInDocument;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DisposableDifferenceViewerControl"/> class.
         /// </summary>
+        /// <param name="errorListItem">Corresponding SarifErrorListItem object.</param>
         /// <param name="differenceViewer"><see cref="IWpfDifferenceViewer"/> instance.</param>
         /// <param name="description">Description of the changes. Optional.</param>
         /// <param name="additionalContent">Additional content to display at the bottom. Optional.</param>
         internal DisposableDifferenceViewerControl(
+            SarifErrorListItem errorListItem,
             IWpfDifferenceViewer differenceViewer,
             string description = null,
             FrameworkElement additionalContent = null)
         {
             this.InitializeComponent();
 
+            this.sarifErrorListItem = errorListItem;
             this.differenceViewer = Requires.NotNull(differenceViewer, nameof(differenceViewer));
 
             if (!string.IsNullOrWhiteSpace(description))
@@ -64,6 +71,12 @@ namespace Microsoft.Sarif.Viewer.Fixes
                 this.differenceViewer.Close();
                 this.differenceViewer = null;
             }
+        }
+
+        private void ApplyInDocument_Click(object sender, RoutedEventArgs e)
+        {
+            this.StackPanelContent.Children.Clear();
+            ApplyFixesInDocument?.Invoke(this, new ApplyFixEventArgs(FixScope.Document, this.sarifErrorListItem));
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/Fixes/DisposableDifferenceViewerControl.xaml.cs
+++ b/src/Sarif.Viewer.VisualStudio/Fixes/DisposableDifferenceViewerControl.xaml.cs
@@ -71,6 +71,16 @@ namespace Microsoft.Sarif.Viewer.Fixes
                 this.differenceViewer.Close();
                 this.differenceViewer = null;
             }
+
+            if (ApplyFixesInDocument != null)
+            {
+                foreach (Delegate x in ApplyFixesInDocument?.GetInvocationList())
+                {
+                    ApplyFixesInDocument -= (EventHandler<ApplyFixEventArgs>)x;
+                }
+
+                System.Diagnostics.Debug.Assert(ApplyFixesInDocument == null, "Should not have hooked events.");
+            }
         }
 
         private void ApplyInDocument_Click(object sender, RoutedEventArgs e)

--- a/src/Sarif.Viewer.VisualStudio/Fixes/DisposableDifferenceViewerControlStringResources.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Fixes/DisposableDifferenceViewerControlStringResources.xaml
@@ -1,0 +1,7 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <system:String x:Key="DifferenceViewer_Text_FixAll">Fix all occurrences in:&#160;</system:String>
+    <system:String x:Key="DifferenceViewer_Text_Document">Current Document</system:String>
+</ResourceDictionary>

--- a/src/Sarif.Viewer.VisualStudio/Fixes/EditActionPreviewProvider.cs
+++ b/src/Sarif.Viewer.VisualStudio/Fixes/EditActionPreviewProvider.cs
@@ -138,13 +138,11 @@ namespace Microsoft.Sarif.Viewer.Fixes
             await sizeFitter.SizeToFitAsync();
 
             var diffViewerControl = new DisposableDifferenceViewerControl(errorListItem, diffViewer, description, additionalContent);
-            diffViewerControl.ApplyFixesInDocument += this.Control_ApplyFixesInDocument;
+            diffViewerControl.ApplyFixesInDocument += (sender, e) =>
+            {
+                ApplyFixesInDocument?.Invoke(this, e);
+            };
             return diffViewerControl;
-        }
-
-        private void Control_ApplyFixesInDocument(object sender, ApplyFixEventArgs e)
-        {
-            ApplyFixesInDocument?.Invoke(this, e);
         }
 
         private ITextBuffer CloneBuffer(ITextBuffer buffer)

--- a/src/Sarif.Viewer.VisualStudio/Fixes/EditActionPreviewProvider.cs
+++ b/src/Sarif.Viewer.VisualStudio/Fixes/EditActionPreviewProvider.cs
@@ -16,10 +16,11 @@ using Microsoft.VisualStudio.Text.Projection;
 namespace Microsoft.Sarif.Viewer.Fixes
 {
     [Export(typeof(IPreviewProvider))]
-    public class EditActionPreviewProvider : IPreviewProvider
+    internal class EditActionPreviewProvider : IPreviewProvider
     {
-        private readonly ITextViewRoleSet previewRoleSet;
+        internal event EventHandler<ApplyFixEventArgs> ApplyFixesInDocument;
 
+        private readonly ITextViewRoleSet previewRoleSet;
         private readonly ITextBufferFactoryService textBufferFactoryService;
         private readonly ITextDocumentFactoryService textDocumentFactoryService;
         private readonly ITextDifferencingSelectorService textDifferencingSelectorService;
@@ -29,7 +30,7 @@ namespace Microsoft.Sarif.Viewer.Fixes
         private readonly IWpfDifferenceViewerFactoryService wpfDifferenceViewerFactoryService;
 
         [ImportingConstructor]
-        public EditActionPreviewProvider(
+        internal EditActionPreviewProvider(
             ITextBufferFactoryService textBufferFactoryService,
             ITextDocumentFactoryService textDocumentFactoryService,
             ITextDifferencingSelectorService textDifferencingSelectorService,
@@ -51,6 +52,7 @@ namespace Microsoft.Sarif.Viewer.Fixes
         }
 
         public Task<object> CreateChangePreviewAsync(
+            SarifErrorListItem errorListItem,
             ITextBuffer buffer,
             Action<ITextBuffer,
             ITextSnapshot> applyEdit,
@@ -92,10 +94,11 @@ namespace Microsoft.Sarif.Viewer.Fixes
                 Separator,
                 changedLineSpans.ToArray());
 
-            return this.CreateNewDifferenceViewerAsync(originalProjectionBuffer, newProjectionBuffer, description, additionalContent);
+            return this.CreateNewDifferenceViewerAsync(errorListItem, originalProjectionBuffer, newProjectionBuffer, description, additionalContent);
         }
 
         private async Task<object> CreateNewDifferenceViewerAsync(
+            SarifErrorListItem errorListItem,
             IProjectionBuffer originalBuffer,
             IProjectionBuffer newBuffer,
             string description,
@@ -134,7 +137,14 @@ namespace Microsoft.Sarif.Viewer.Fixes
             var sizeFitter = new SizeToFitHelper(diffViewer, 400.0);
             await sizeFitter.SizeToFitAsync();
 
-            return new DisposableDifferenceViewerControl(diffViewer, description, additionalContent);
+            var diffViewerControl = new DisposableDifferenceViewerControl(errorListItem, diffViewer, description, additionalContent);
+            diffViewerControl.ApplyFixesInDocument += this.Control_ApplyFixesInDocument;
+            return diffViewerControl;
+        }
+
+        private void Control_ApplyFixesInDocument(object sender, ApplyFixEventArgs e)
+        {
+            ApplyFixesInDocument?.Invoke(this, e);
         }
 
         private ITextBuffer CloneBuffer(ITextBuffer buffer)

--- a/src/Sarif.Viewer.VisualStudio/Fixes/FixSuggestedAction.cs
+++ b/src/Sarif.Viewer.VisualStudio/Fixes/FixSuggestedAction.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Sarif.Viewer.Fixes
     /// </summary>
     internal class FixSuggestedAction : ISuggestedAction
     {
+        private readonly SarifErrorListItem sarifErrorListItem;
         private readonly FixModel fix;
         private readonly ITextBuffer textBuffer;
         private readonly IPreviewProvider previewProvider;
@@ -30,6 +31,9 @@ namespace Microsoft.Sarif.Viewer.Fixes
         /// <summary>
         /// Initializes a new instance of the <see cref="FixSuggestedAction"/> class.
         /// </summary>
+        /// <param name="errorListItem">
+        /// SarifErrorListItem object which corresponds to this fix action.
+        /// </param>
         /// <param name="fix">
         /// The SARIF <see cref="Fix"/> object that describes the action.
         /// </param>
@@ -40,10 +44,12 @@ namespace Microsoft.Sarif.Viewer.Fixes
         /// Creates the XAML UIControl that displays the preview.
         /// </param>
         public FixSuggestedAction(
+            SarifErrorListItem errorListItem,
             FixModel fix,
             ITextBuffer textBuffer,
             IPreviewProvider previewProvider)
         {
+            this.sarifErrorListItem = errorListItem;
             this.fix = fix;
             this.textBuffer = textBuffer;
             this.previewProvider = previewProvider;
@@ -84,7 +90,7 @@ namespace Microsoft.Sarif.Viewer.Fixes
             if (this.edits.Count != 0)
             {
                 return await this.previewProvider.CreateChangePreviewAsync(
-                    this.textBuffer, this.ApplyTextEdits, this.DisplayText);
+                    this.sarifErrorListItem, this.textBuffer, this.ApplyTextEdits, this.DisplayText);
             }
 
             return null;

--- a/src/Sarif.Viewer.VisualStudio/Fixes/FixSuggestedActionsSource.cs
+++ b/src/Sarif.Viewer.VisualStudio/Fixes/FixSuggestedActionsSource.cs
@@ -107,9 +107,10 @@ namespace Microsoft.Sarif.Viewer.Fixes
         /// <inheritdoc/>
         public void Dispose()
         {
-            if (this.previewProvider != null)
+            if (this.previewProvider != null &&
+                this.previewProvider is EditActionPreviewProvider editActionPreviewProvider)
             {
-                ((EditActionPreviewProvider)this.previewProvider).ApplyFixesInDocument -= this.PreviewProdiver_ApplyFixesInDocument;
+                editActionPreviewProvider.ApplyFixesInDocument -= this.PreviewProdiver_ApplyFixesInDocument;
             }
 
             if (this.errorListTableControl != null)

--- a/src/Sarif.Viewer.VisualStudio/Fixes/FixSuggestedActionsSource.cs
+++ b/src/Sarif.Viewer.VisualStudio/Fixes/FixSuggestedActionsSource.cs
@@ -61,8 +61,13 @@ namespace Microsoft.Sarif.Viewer.Fixes
             this.persistentSpanFactory = persistentSpanFactory;
             this.previewProvider = previewProvider;
 
+            if (this.previewProvider is EditActionPreviewProvider editActionPreviewProvider)
+            {
+                editActionPreviewProvider.ApplyFixesInDocument += this.PreviewProdiver_ApplyFixesInDocument;
+            }
+
             // when text changed and sarif errors item changes, need to refresh errorInFile
-            IErrorList errorList = ServiceProvider.GlobalProvider.GetService(typeof(SVsErrorList)) as IErrorList;
+            var errorList = ServiceProvider.GlobalProvider.GetService(typeof(SVsErrorList)) as IErrorList;
             this.errorListTableControl = errorList?.TableControl;
             this.errorListTableControl.EntriesChanged += this.ErrorListTableControl_EntriesChanged;
             this.RefreshPersistentSpans();
@@ -74,6 +79,25 @@ namespace Microsoft.Sarif.Viewer.Fixes
             this.fixToErrorDictionary = new Dictionary<FixSuggestedAction, SarifErrorListItem>();
         }
 
+        private void PreviewProdiver_ApplyFixesInDocument(object sender, ApplyFixEventArgs e)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            // get same fixable errors in this document
+            IEnumerable<SarifErrorListItem> selectedFixableErrors = this.errorsInFile
+                .Where(error => error.Rule.Id.Equals(e.ErrorItem.Rule.Id, StringComparison.Ordinal))
+                .Where(error => error.IsFixable());
+
+            if (selectedFixableErrors == null || !selectedFixableErrors.Any())
+            {
+                return;
+            }
+
+            // execute action
+            IEnumerable<ISuggestedAction> suggestedActions = this.CreateActionSetFromErrors(selectedFixableErrors).SelectMany(set => set.Actions);
+            suggestedActions.ToList().ForEach(action => action.Invoke(CancellationToken.None));
+        }
+
 #pragma warning disable 0067
 
         /// <inheritdoc/>
@@ -83,6 +107,15 @@ namespace Microsoft.Sarif.Viewer.Fixes
         /// <inheritdoc/>
         public void Dispose()
         {
+            if (this.previewProvider != null)
+            {
+                ((EditActionPreviewProvider)this.previewProvider).ApplyFixesInDocument -= this.PreviewProdiver_ApplyFixesInDocument;
+            }
+
+            if (this.errorListTableControl != null)
+            {
+                this.errorListTableControl.EntriesChanged -= this.ErrorListTableControl_EntriesChanged;
+            }
         }
 
         /// <inheritdoc/>
@@ -201,7 +234,7 @@ namespace Microsoft.Sarif.Viewer.Fixes
             {
                 foreach (FixModel fix in error.Fixes.Where(fix => fix.CanBeAppliedToFile(error.FileName)))
                 {
-                    var suggestedAction = new FixSuggestedAction(fix, this.textBuffer, this.previewProvider);
+                    var suggestedAction = new FixSuggestedAction(error, fix, this.textBuffer, this.previewProvider);
                     this.fixToErrorDictionary.Add(suggestedAction, error);
                     suggestedAction.FixApplied += this.SuggestedAction_FixApplied;
                     suggestedActions.Add(suggestedAction);

--- a/src/Sarif.Viewer.VisualStudio/Fixes/IPreviewProvider.cs
+++ b/src/Sarif.Viewer.VisualStudio/Fixes/IPreviewProvider.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Sarif.Viewer.Fixes
     internal interface IPreviewProvider
     {
         Task<object> CreateChangePreviewAsync(
+            SarifErrorListItem errorListItem,
             ITextBuffer buffer,
             Action<ITextBuffer, ITextSnapshot> applyEdit,
             string description = null,

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -70,6 +70,7 @@
     <Compile Include="FileWatcher\ISarifFileMonitor.cs" />
     <Compile Include="FileWatcher\SarifFolderMonitor.cs" />
     <Compile Include="FileWatcher\SarifLogsMonitor.cs" />
+    <Compile Include="Fixes\ApplyFixEventArgs.cs" />
     <Compile Include="Fixes\EditActionPreviewProvider.cs" />
     <Compile Include="Fixes\IPreviewProvider.cs" />
     <Compile Include="Fixes\LineSpan.cs" />
@@ -301,6 +302,10 @@
     <Page Include="Fixes\DisposableDifferenceViewerControl.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Fixes\DisposableDifferenceViewerControlStringResources.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Themes\AnalysisStepsStyles.xaml">
       <SubType>Designer</SubType>


### PR DESCRIPTION
Added the functionality which allows user to apply the all fixes from sarif Log, which belongs to same error, to current document.
![image](https://user-images.githubusercontent.com/76094515/114930052-70c79180-9de9-11eb-982f-61bc40562241.png)
