### PR TITLE
Fix issue when opening a .json file the checking logic invoked

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/CodeAnalysisResultManagerTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/CodeAnalysisResultManagerTests.cs
@@ -243,6 +243,36 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         }
 
         [Fact]
+        public void CodeAnalysisResultManager_GetRebaselinedFileName_RelativeUri_WithoutUriBaseId()
+        {
+            // Arrange.
+            const string PathInLogFile = @"src/Sarif/Notes.cs";
+            const string ExpectedResolvedPath = @"D:\Users\John\source\sarif-sdk\src\Sarif\Notes.cs";
+
+            const int RunId = 1;
+
+            this.pathFromPrompt = ExpectedResolvedPath;
+
+            var target = new CodeAnalysisResultManager(
+                null,                               // This test never touches the file system.
+                this.FakePromptForResolvedPath);
+            var dataCache = new RunDataCache();
+            target.RunIndexToRunDataCache.Add(RunId, dataCache);
+
+            // Act.
+            string actualResolvedPath = target.GetRebaselinedFileName(uriBaseId: null, pathFromLogFile: PathInLogFile, dataCache: dataCache);
+            actualResolvedPath = this.FakePromptForResolvedPath(null, actualResolvedPath);
+            target.SaveResolvedPathToUriBaseMapping(null, PathInLogFile, PathInLogFile, actualResolvedPath, dataCache);
+            // Assert.
+            actualResolvedPath.Should().Be(ExpectedResolvedPath);
+
+            Tuple<string, string>[] remappedPathPrefixes = target.GetRemappedPathPrefixes();
+            remappedPathPrefixes.Length.Should().Be(1);
+            remappedPathPrefixes[0].Item1.Should().Be(@"");
+            remappedPathPrefixes[0].Item2.Should().Be(@"D:\Users\John\source\sarif-sdk");
+        }
+
+        [Fact]
         public void CodeAnalysisResultManager_CacheUriBasePaths_EnsuresTrailingSlash()
         {
             var run = new Run

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Models\ArtifactChangeModelTests.cs" />
     <Compile Include="Models\ReplacementModelTests.cs" />
     <Compile Include="ProjectNameCacheTests.cs" />
+    <Compile Include="SarifTextViewCreationListenerTests.cs" />
     <Compile Include="SarifViewerPackageUnitTests.cs" />
     <Compile Include="Sarif\FixExtensionsTests.cs" />
     <Compile Include="Sarif\LocationExtensionsTest.cs" />

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/SarifTextViewCreationListenerTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/SarifTextViewCreationListenerTests.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
+{
+    public class SarifTextViewCreationListenerTests
+    {
+        [Fact]
+        public void SarifTextViewCreationListener_IsSarifLog()
+        {
+            var testcases = new[]
+            {
+                new { input = (string)null, expected = false },
+                new { input = "", expected = false },
+                new { input = "    ", expected = false },
+                new { input = @"F:\users\david\repo\", expected = false },
+                new { input = @"F:\users\david\repo\readme.txt", expected = false },
+                new { input = @"D:\sources\repo\AssemblyInfo.cs", expected = false },
+                new { input = @"D:\sources\repo\data\rules.json", expected = false },
+                new { input = @"\\fileserver\shares\reports\scan.sarif", expected = true },
+                new { input = @"C:\static analysis results\github.com\2021\04\16\nightly.sarif", expected = true },
+            };
+
+            var target = new SarifTextViewCreationListener();
+
+            foreach (var testcase in testcases)
+            {
+                target.IsSarifLogFile(testcase.input).Should().Be(testcase.expected);
+            }
+        }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
@@ -748,7 +748,7 @@ namespace Microsoft.Sarif.Viewer
 
             int uriBaseIdEndIndex = resolvedPath.IndexOf(originalPath.Replace("/", @"\"));
 
-            if (relativeUri != null && uriBaseIdEndIndex >= 0)
+            if (!string.IsNullOrEmpty(uriBaseId) && relativeUri != null && uriBaseIdEndIndex >= 0)
             {
                 // If we could determine the uriBaseId substitution value, then add it to the map.
                 dataCache.RemappedUriBasePaths[uriBaseId] = new Uri(resolvedPath.Substring(0, uriBaseIdEndIndex), UriKind.Absolute);

--- a/src/Sarif.Viewer.VisualStudio/SarifTextViewCreationListener.cs
+++ b/src/Sarif.Viewer.VisualStudio/SarifTextViewCreationListener.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Sarif.Viewer
             return persistFile.GetCurFile(out fileName, out _) == VSConstants.S_OK;
         }
 
-        private bool IsSarifLogFile(string fileName)
+        internal bool IsSarifLogFile(string fileName)
         {
             return !string.IsNullOrEmpty(fileName) &&
                 fileName.EndsWith(".sarif", StringComparison.OrdinalIgnoreCase);

--- a/src/Sarif.Viewer.VisualStudio/SarifTextViewCreationListener.cs
+++ b/src/Sarif.Viewer.VisualStudio/SarifTextViewCreationListener.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Sarif.Viewer
                 this.IsSarifLogFile(filename))
             {
                 // since Json (base type of sarif log) editor throws error when file size is greater than 5 MBs
-                // need to listen to content type "text". Only process log if file extension is .sarif or .json.
+                // need to listen to content type "text". Only process log if file extension is ".sarif".
                 if (!textBufferMap.ContainsKey(textView.TextBuffer))
                 {
                     textBufferMap.TryAdd(textView.TextBuffer, 0);
@@ -120,8 +120,7 @@ namespace Microsoft.Sarif.Viewer
         private bool IsSarifLogFile(string fileName)
         {
             return !string.IsNullOrEmpty(fileName) &&
-                (fileName.EndsWith(".sarif", StringComparison.OrdinalIgnoreCase) ||
-                    fileName.EndsWith(".json", StringComparison.OrdinalIgnoreCase));
+                fileName.EndsWith(".sarif", StringComparison.OrdinalIgnoreCase);
         }
     }
 }


### PR DESCRIPTION
Fixes 2 issues:
- When opens .json file, the sarif file verification logic is invoked. Change to only process when file extension is ".sarif". 
- Handles a null reference in resolving source file.