### PR TITLE
Add retry to code block loading sarif log

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/Tags/SarifLocationErrorTagger.cs
+++ b/src/Sarif.Viewer.VisualStudio/Tags/SarifLocationErrorTagger.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Sarif.Viewer.Tags
                 this.currentTags = relevantTags.ToList();
             }
 
-            if (!this.currentTags.Any())
+            if (this.currentTags == null || !this.currentTags.Any())
             {
                 yield break;
             }


### PR DESCRIPTION
When file watcher monitors a sarif log file, if the log file is updated by external process and immediately trigger file changed event, and extension will load this file to refresh the results.

In some case the external process may take a long time to complete the updating, and causes IO exception when extension retries to load the file.

Add this retry logic to handle this case.