### PR TITLE
Fix an issue cannot load sarif tool execution notification

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/SdkUiUtilitiesTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/SdkUiUtilitiesTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         public void GetFileLocationPath_UriIsNull()
         {
             var dataCache = new RunDataCache();
-            int runId = 1;
+            int runId = CodeAnalysisResultManager.Instance.GetNextRunIndex();
             CodeAnalysisResultManager.Instance.RunIndexToRunDataCache.Add(runId, dataCache);
 
             var artifact = new ArtifactLocation();
@@ -38,7 +38,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         public void GetFileLocationPath_UriIsLocalPath()
         {
             var dataCache = new RunDataCache();
-            int runId = 1;
+            int runId = CodeAnalysisResultManager.Instance.GetNextRunIndex();
             CodeAnalysisResultManager.Instance.RunIndexToRunDataCache.Add(runId, dataCache);
 
             string filePath = @"C:\repo\src\AnalysisStep.cs";
@@ -62,8 +62,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
             var dataCache = new RunDataCache();
-            int runId = 1;
-            CodeAnalysisResultManager.Instance.CurrentRunIndex = runId;
+            int runId = CodeAnalysisResultManager.Instance.GetNextRunIndex();
             CodeAnalysisResultManager.Instance.RunIndexToRunDataCache.Add(runId, dataCache);
             CodeAnalysisResultManager.Instance.CacheUriBasePaths(run);
 
@@ -88,8 +87,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
             var dataCache = new RunDataCache();
-            int runId = 1;
-            CodeAnalysisResultManager.Instance.CurrentRunIndex = runId;
+            int runId = CodeAnalysisResultManager.Instance.GetNextRunIndex();
             CodeAnalysisResultManager.Instance.RunIndexToRunDataCache.Add(runId, dataCache);
             CodeAnalysisResultManager.Instance.CacheUriBasePaths(run);
 

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/SdkUiUtilitiesTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/SdkUiUtilitiesTests.cs
@@ -8,12 +8,97 @@ using System.Windows.Documents;
 
 using FluentAssertions;
 
+using Microsoft.CodeAnalysis.Sarif;
+
 using Xunit;
+
+using Run = System.Windows.Documents.Run;
 
 namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
 {
     public class SdkUIUtilitiesTests : SarifViewerPackageUnitTests
     {
+        [Fact]
+        public void GetFileLocationPath_UriIsNull()
+        {
+            var dataCache = new RunDataCache();
+            int runId = 1;
+            CodeAnalysisResultManager.Instance.RunIndexToRunDataCache.Add(runId, dataCache);
+
+            var artifact = new ArtifactLocation();
+            string path = SdkUIUtilities.GetFileLocationPath(artifact, runId);
+            path.Should().BeNull();
+
+            artifact = null;
+            path = SdkUIUtilities.GetFileLocationPath(artifact, runId);
+            path.Should().BeNull();
+        }
+
+        [Fact]
+        public void GetFileLocationPath_UriIsLocalPath()
+        {
+            var dataCache = new RunDataCache();
+            int runId = 1;
+            CodeAnalysisResultManager.Instance.RunIndexToRunDataCache.Add(runId, dataCache);
+
+            string filePath = @"C:\repo\src\AnalysisStep.cs";
+            var artifact = new ArtifactLocation { Uri = new Uri(filePath, UriKind.Absolute) };
+            string path = SdkUIUtilities.GetFileLocationPath(artifact, runId);
+            path.Should().Be(filePath);
+        }
+
+        [Fact]
+        public void GetFileLocationPath_UriPathCanNotBeResolved()
+        {
+            string repoPath = "file:///C:/code/myProject/src/";
+            var run = new Microsoft.CodeAnalysis.Sarif.Run
+            {
+                OriginalUriBaseIds = new Dictionary<string, ArtifactLocation>
+                {
+                    ["REPO_ROOT"] = new ArtifactLocation
+                    {
+                        Uri = new Uri(repoPath),
+                    }
+                },
+            };
+            var dataCache = new RunDataCache();
+            int runId = 1;
+            CodeAnalysisResultManager.Instance.CurrentRunIndex = runId;
+            CodeAnalysisResultManager.Instance.RunIndexToRunDataCache.Add(runId, dataCache);
+            CodeAnalysisResultManager.Instance.CacheUriBasePaths(run);
+
+            string filePath = @"AnalysisStep.cs";
+            var artifact = new ArtifactLocation { Uri = new Uri(filePath, UriKind.Relative), UriBaseId = "NOTEXIST" };
+            string path = SdkUIUtilities.GetFileLocationPath(artifact, runId);
+            path.Should().Be(filePath);
+        }
+
+        [Fact]
+        public void GetFileLocationPath_UriPathCanBeResolved()
+        {
+            string repoPath = "file:///C:/code/myProject/src/";
+            var run = new Microsoft.CodeAnalysis.Sarif.Run
+            {
+                OriginalUriBaseIds = new Dictionary<string, ArtifactLocation>
+                {
+                    ["REPO_ROOT"] = new ArtifactLocation
+                    {
+                        Uri = new Uri(repoPath),
+                    }
+                },
+            };
+            var dataCache = new RunDataCache();
+            int runId = 1;
+            CodeAnalysisResultManager.Instance.CurrentRunIndex = runId;
+            CodeAnalysisResultManager.Instance.RunIndexToRunDataCache.Add(runId, dataCache);
+            CodeAnalysisResultManager.Instance.CacheUriBasePaths(run);
+
+            string filePath = @"AnalysisStep.cs";
+            var artifact = new ArtifactLocation { Uri = new Uri(filePath, UriKind.Relative), UriBaseId = "REPO_ROOT" };
+            string path = SdkUIUtilities.GetFileLocationPath(artifact, runId);
+            path.Should().Be(@"C:\code\myProject\src\AnalysisStep.cs");
+        }
+
         [Fact]
         public void GetInlinesForErrorMessage_DoesNotCreateLinks()
         {
@@ -26,7 +111,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 new Run(" jumps over the lazy dog."),
             };
 
-            var actual = SdkUIUtilities.GetInlinesForErrorMessage(message);
+            List<Inline> actual = SdkUIUtilities.GetInlinesForErrorMessage(message);
 
             actual.Count.Should().Be(expected.Count);
 
@@ -50,7 +135,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 new Run(" jumps over the lazy dog."),
             };
 
-            var actual = SdkUIUtilities.GetInlinesForErrorMessage(message);
+            List<Inline> actual = SdkUIUtilities.GetInlinesForErrorMessage(message);
 
             actual.Count.Should().Be(expected.Count);
 
@@ -66,7 +151,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             const string message = @"The quick \[brown fox\] jumps over the lazy dog.";
 
             // Because there are no embedded links, we shouldn't get anything back
-            var actual = SdkUIUtilities.GetMessageInlines(message, clickHandler: this.Hyperlink_Click);
+            List<Inline> actual = SdkUIUtilities.GetMessageInlines(message, clickHandler: this.Hyperlink_Click);
 
             actual.Count.Should().Be(0);
         }
@@ -76,8 +161,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         {
             const string message = @"The quick [brown fox](1) jumps over the lazy dog.";
 
-            var link = new Hyperlink();
-            link.Tag = 1;
+            var link = new Hyperlink { Tag = 1 };
             link.Inlines.Add(new Run("brown fox"));
 
             var expected = new List<Inline>
@@ -87,7 +171,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 new Run(" jumps over the lazy dog."),
             };
 
-            var actual = SdkUIUtilities.GetMessageInlines(message, clickHandler: this.Hyperlink_Click);
+            List<Inline> actual = SdkUIUtilities.GetMessageInlines(message, clickHandler: this.Hyperlink_Click);
 
             actual.Count.Should().Be(expected.Count);
 
@@ -101,12 +185,10 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         {
             const string message = @"The quick [brown fox](1) jumps over the [lazy dog](2)";
 
-            var link1 = new Hyperlink();
-            link1.Tag = 1;
+            var link1 = new Hyperlink { Tag = 1 };
             link1.Inlines.Add(new Run("brown fox"));
 
-            var link2 = new Hyperlink();
-            link2.Tag = 2;
+            var link2 = new Hyperlink { Tag = 2 };
             link2.Inlines.Add(new Run("lazy dog"));
 
             var expected = new List<Inline>
@@ -117,7 +199,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 link2,
             };
 
-            var actual = SdkUIUtilities.GetMessageInlines(message, clickHandler: this.Hyperlink_Click);
+            List<Inline> actual = SdkUIUtilities.GetMessageInlines(message, clickHandler: this.Hyperlink_Click);
 
             actual.Count.Should().Be(expected.Count);
 
@@ -132,8 +214,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         {
             const string message = @"The quick [brown fox](1) jumps over the \[lazy dog\].";
 
-            var link = new Hyperlink();
-            link.Tag = 1;
+            var link = new Hyperlink { Tag = 1 };
             link.Inlines.Add(new Run("brown fox"));
 
             var expected = new List<Inline>
@@ -143,7 +224,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 new Run(" jumps over the [lazy dog]."),
             };
 
-            var actual = SdkUIUtilities.GetMessageInlines(message, clickHandler: this.Hyperlink_Click);
+            List<Inline> actual = SdkUIUtilities.GetMessageInlines(message, clickHandler: this.Hyperlink_Click);
 
             actual.Count.Should().Be(expected.Count);
 
@@ -169,7 +250,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 new Run(" jumps over the lazy dog."),
             };
 
-            var actual = SdkUIUtilities.GetMessageInlines(message, clickHandler: this.Hyperlink_Click);
+            List<Inline> actual = SdkUIUtilities.GetMessageInlines(message, clickHandler: this.Hyperlink_Click);
 
             actual.Count.Should().Be(expected.Count);
 
@@ -195,7 +276,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 new Run(" has a problem."),
             };
 
-            var actual = SdkUIUtilities.GetMessageInlines(message, clickHandler: this.Hyperlink_Click);
+            List<Inline> actual = SdkUIUtilities.GetMessageInlines(message, clickHandler: this.Hyperlink_Click);
 
             actual.Count.Should().Be(expected.Count);
 

--- a/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
@@ -710,7 +710,7 @@ namespace Microsoft.Sarif.Viewer
                 {
                     path = uri.LocalPath;
                 }
-                catch
+                catch (InvalidOperationException)
                 {
                     // if cannot resolve local path return original uri string
                     // it will try to resolve the path when user navigates to the error list item

--- a/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
@@ -13,6 +13,7 @@ using System.Windows;
 using System.Windows.Forms;
 
 using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.Sarif.Viewer.Sarif;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -696,15 +697,25 @@ namespace Microsoft.Sarif.Viewer
                 RunDataCache dataCache = CodeAnalysisResultManager.Instance.RunIndexToRunDataCache[runId];
 
                 Uri uri = artifactLocation.Uri;
-                string uriBaseId = artifactLocation.UriBaseId;
 
+                // try to resolve path using OriginalUriBasePaths
+                string uriBaseId = artifactLocation.UriBaseId;
                 if (!string.IsNullOrEmpty(uriBaseId) && dataCache.OriginalUriBasePaths.ContainsKey(uriBaseId))
                 {
                     Uri baseUri = dataCache.OriginalUriBasePaths[uriBaseId];
                     uri = new Uri(baseUri, uri);
                 }
 
-                path = uri.LocalPath;
+                try
+                {
+                    path = uri.LocalPath;
+                }
+                catch
+                {
+                    // if cannot resolve local path return original uri string
+                    // it will try to resolve the path when user navigates to the error list item
+                    path = uri.ToPath();
+                }
             }
 
             return path;


### PR DESCRIPTION
Sarif viewer tries to resolve the tool execution notification location local file path when loading a sarif log contains tool notification, if it cannot resolve the path then it stops loading the log.