### PR TITLE
Fix issue tooltip displays partial text for error list items in editor.

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/Fixes/DisposableDifferenceViewerControlStringResources.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Fixes/DisposableDifferenceViewerControlStringResources.xaml
@@ -3,5 +3,5 @@
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
 
     <system:String x:Key="DifferenceViewer_Text_FixAll">Fix all occurrences in:&#160;</system:String>
-    <system:String x:Key="DifferenceViewer_Text_Document">Current Document</system:String>
+    <system:String x:Key="DifferenceViewer_Text_Document">Document</system:String>
 </ResourceDictionary>

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -282,6 +282,11 @@ namespace Microsoft.Sarif.Viewer
         public string RawMessage { get; set; }
 
         [Browsable(false)]
+        public string PlainMessage => !string.IsNullOrWhiteSpace(this.RawMessage) && this.HasEmbeddedLinks ?
+                                      SdkUIUtilities.GetPlainText(this.MessageInlines) :
+                                      this.RawMessage;
+
+        [Browsable(false)]
         public ObservableCollection<XamlDoc.Inline> MessageInlines => this._messageInlines
             ?? (this._messageInlines = new ObservableCollection<XamlDoc.Inline>(SdkUIUtilities.GetInlinesForErrorMessage(this.RawMessage)));
 
@@ -456,7 +461,7 @@ namespace Microsoft.Sarif.Viewer
                         nonHighlightedColor: ResultTextMarker.DEFAULT_SELECTION_COLOR,
                         highlightedColor: ResultTextMarker.HOVER_SELECTION_COLOR,
                         errorType: predefinedErrorType,
-                        tooltipContent: this.Message,
+                        tooltipContent: this.PlainMessage,
                         context: this);
                 }
 

--- a/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
@@ -7,7 +7,9 @@ using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.IsolatedStorage;
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Forms;
@@ -676,6 +678,27 @@ namespace Microsoft.Sarif.Viewer
             }
 
             return inlines;
+        }
+
+        /// <summary>
+        /// Convert a collection of Inline elements into plain text.
+        /// </summary>
+        /// <param name="inlines">A collection of Inline elements that represent the message.</param>
+        /// <returns>A plaint text of the message.</returns>
+        internal static string GetPlainText(IEnumerable<XamlDoc.Inline> inlines)
+        {
+            if (inlines == null || !inlines.Any())
+            {
+                return null;
+            }
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (XamlDoc.Inline inline in inlines)
+            {
+                stringBuilder.Append(new XamlDoc.TextRange(inline.ContentStart, inline.ContentEnd).Text);
+            }
+
+            return stringBuilder.ToString();
         }
 
         /// <summary>


### PR DESCRIPTION
If error list item message includes inline hyperlinks and its too long to be truncated, the tooltip when you move mouse over the selected text in editor shows partial message text.

The fix is to show the completed text. If raw text includes hyperlinks, convert to plain text first.