### PR TITLE
Fix an issue splitting long message

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
@@ -405,6 +405,27 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         }
 
         [Fact]
+        public void SarifErrorListItem_ResultMessageFormat_LongTextSplitAtSpace()
+        {
+            // a string that index at Max Length (165) happens to be a space
+            const string s1 = "In httplib2 before version 0.18.0, an attacker controlling unescaped part of uri for `httplib2.Http.request()` could change request headers and body, send additional hidden requests to same server. This vulnerability impacts software that uses httplib2 with uri constructed by string concatenation, as opposed to proper urllib building with escaping. This has been fixed in 0.18.0.";
+            var result = new Result
+            {
+                Message = new Message()
+                {
+                    Text = s1,
+                },
+            };
+
+            SarifErrorListItem item = MakeErrorListItem(result);
+            int breakPoistion = 165; // 0 indexed
+            item.ShortMessage.Length.Should().Be(breakPoistion + 2); // 2 chars is added at end " \u2026"
+            item.ShortMessage.Substring(0, breakPoistion).Should().Be(s1.Substring(0, breakPoistion));
+            item.Message.Length.Should().Be(s1.Length - breakPoistion - 1);
+            item.Message.Should().Be(s1.Substring(breakPoistion + 1)); // leading space trimmed
+        }
+
+        [Fact]
         public void SarifErrorListItem_ResultMessageFormat_LongTextWitBreak()
         {
             // very long text has a space every 10 chars 

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -683,21 +683,27 @@ namespace Microsoft.Sarif.Viewer
             fullText = fullText.Replace(Environment.NewLine, " ").Replace("\r", " ").Replace("\n", " ");
 
             string text = fullText;
-            int endPosition = fullText.Length - 1;
+            string restText = fullText;
+
             char[] endChars = new char[] { '\r', '\n', ' ', };
             if (text.Length > maxLength)
             {
+                int endPosition = maxLength;
+
                 // if need to split text longer than maxLength, make sure not split in middle of a word.
                 if (!endChars.Contains(text[maxLength]))
                 {
+                    // find nearest whitespace before max length to separate the string
                     endPosition = text.LastIndexOfAny(endChars, maxLength);
+
+                    // if not found, set end position to max length
+                    endPosition = (endPosition == -1) ? maxLength : endPosition;
                 }
 
-                endPosition = endPosition == -1 ? maxLength : endPosition;
                 text = text.Substring(0, endPosition) + " \u2026"; // u2026 is Unicode "horizontal ellipsis";
+                restText = restText.Substring(endPosition).TrimStart(endChars);
             }
 
-            string restText = endPosition + 1 < fullText.Length ? fullText.Substring(endPosition).TrimStart(endChars) : fullText;
             return (text.TrimEnd(endChars), restText.TrimEnd(endChars));
         }
     }


### PR DESCRIPTION
An issue that long message happens to be split at a whitespace, both short message/message set to full message.
Refactor and fixed the issue. Added tests.

Issue screenshot, both description and detail content are set to full message string.
![image](https://user-images.githubusercontent.com/76094515/118906321-7164b380-b8d2-11eb-9129-f0c4aee18429.png)

After fix:
![image](https://user-images.githubusercontent.com/76094515/118906546-d28c8700-b8d2-11eb-87aa-c603973af23e.png)
