### PR TITLE
Handle JSON deserialization error

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/ErrorListServiceTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/ErrorListServiceTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 using System.Text.RegularExpressions;
 
 using FluentAssertions;
@@ -75,6 +77,80 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             failedTestCases.Should().BeEmpty();
         }
 
+        [Fact]
+        public void ErrorListService_ProcessSarifLogAsync_InvalidJson()
+        {
+            // unhook original event handler and hook test event
+            ErrorListService.LogProcessed -= ErrorListService.ErrorListService_LogProcessed;
+            ErrorListService.LogProcessed += ErrorListServiceTest_LogProcessed;
+
+            // invalid Json syntax, a separate comma in line 4
+            // {"Invalid property identifier character: ,. Path '$schema', line 4, position 2."}
+            string invalidJson =
+@"
+{
+  ""$schema"": ""https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json"",
+  ,
+  ""version"": ""2.1.0"",
+  ""runs"": [
+    {
+      ""tool"": {
+        ""name"": ""CodeScanner""
+      },
+      ""results"": [
+      ]
+    }
+  ]
+}
+";
+            int numberOfException = numberOfExceptionLogged;
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(invalidJson));
+            ErrorListService.ProcessSarifLogAsync(stream, "logId", false, false).ConfigureAwait(false);
+            // 1 exception logged
+            numberOfExceptionLogged.Should().Be(numberOfException + 1);
+        }
+
+        [Fact]
+        public void ErrorListService_ProcessSarifLogAsync_JsonNotCompatibleWithSarifShema()
+        {
+            // unhook original event handler and hook test event
+            ErrorListService.LogProcessed -= ErrorListService.ErrorListService_LogProcessed;
+            ErrorListService.LogProcessed += ErrorListServiceTest_LogProcessed;
+
+            // valid Json syntax, but not satisfy schema, missing required property driver
+            // {"Required property 'text' not found in JSON. Path 'runs[0].tool.driver.rules[0].fullDescription', line 14, position 36."}
+            string jsonNotCompatible =
+@"
+{
+  ""$schema"": ""https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json"",
+  ""version"": ""2.1.0"",
+  ""runs"": [
+    {
+      ""tool"": {
+        ""driver"": {
+          ""name"": ""CodeScanner"",
+          ""rules"": [
+            {
+              ""id"": ""Intrafile1001"",
+              ""name"": ""IntrafileRule"",
+              ""fullDescription"": { },
+              ""helpUri"": ""https://github.com/microsoft/sarif-pattern-matcher""
+            }
+          ]
+        },
+      ""results"": [
+      ]
+    }
+  ]
+}
+";
+            int numberOfException = this.numberOfExceptionLogged;
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonNotCompatible));
+            ErrorListService.ProcessSarifLogAsync(stream, "logId", false, false).ConfigureAwait(false);
+            // 1 exception logged
+            this.numberOfExceptionLogged.Should().Be(numberOfException + 1);
+        }
+
         private struct TestCase
         {
             public string Title { get; set; }
@@ -84,6 +160,12 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             public bool ExpectedMatchSuccess { get; set; }
 
             public string ExpectedVersion { get; set; }
+        }
+
+        private int numberOfExceptionLogged = 0;
+        private void ErrorListServiceTest_LogProcessed(object sender, LogProcessedEventArgs e)
+        {
+            this.numberOfExceptionLogged++;
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             {
                 await ProcessLogFileCoreAsync(filePath, toolFormat, promptOnLogConversions, cleanErrors, openInEditor);
             }
-            catch (JsonReaderException)
+            catch (JsonException)
             {
                 RaiseLogProcessed(ExceptionalConditions.InvalidJson);
             }
@@ -459,7 +459,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             {
                 sarifLog = SarifLog.Load(stream);
             }
-            catch (JsonReaderException)
+            catch (JsonException)
             {
                 RaiseLogProcessed(ExceptionalConditions.InvalidJson);
             }
@@ -718,7 +718,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             LogProcessed?.Invoke(Instance, new LogProcessedEventArgs(conditions));
         }
 
-        private static void ErrorListService_LogProcessed(object sender, LogProcessedEventArgs e)
+        internal static void ErrorListService_LogProcessed(object sender, LogProcessedEventArgs e)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 


### PR DESCRIPTION
Invalid Json syntax causes JsonReaderException.
Valid Json but not satisfies schema causes JsonSerializationException.

JsonException ccovers below exceptions:
- JsonReaderException
- JsonSerializationException
- JsonWriterException
- JsonSchemaException