### PR TITLE
Open Sarif log from memory if log doesn't exists in disk

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
@@ -77,6 +77,8 @@ namespace Microsoft.Sarif.Viewer
             this.userDialogPreference = new ConcurrentDictionary<string, ResolveEmbeddedFileDialogResult>();
         }
 
+        public string TempDirectoryPath => this.temporaryFilePath;
+
         public static CodeAnalysisResultManager Instance = new CodeAnalysisResultManager(new FileSystem());
 
         public IDictionary<int, RunDataCache> RunIndexToRunDataCache { get; } = new Dictionary<int, RunDataCache>();


### PR DESCRIPTION
This is the case that background analyzer scan the files and generate sarif log in memory. You can not check the sarif log content since it doesn't exists in disk.

Now can you open the sarif log content in a document window in VS.