### PR TITLE
Fix crash issue when editing Sarif file in VS into an invalid Json format

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/FileWatcher/SarifLogsMonitor.cs
+++ b/src/Sarif.Viewer.VisualStudio/FileWatcher/SarifLogsMonitor.cs
@@ -80,7 +80,6 @@ namespace Microsoft.Sarif.Viewer.FileWatcher
         {
             ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 await ErrorListService.CloseSarifLogItemsAsync(new string[] { filePath });
                 await ErrorListService.ProcessLogFileAsync(filePath, ToolFormat.None, promptOnLogConversions: true, cleanErrors: false, openInEditor: false);
             });

--- a/src/Sarif.Viewer.VisualStudio/FileWatcher/SarifLogsMonitor.cs
+++ b/src/Sarif.Viewer.VisualStudio/FileWatcher/SarifLogsMonitor.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Sarif.Viewer.FileWatcher
         {
             ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 await ErrorListService.CloseSarifLogItemsAsync(new string[] { filePath });
                 await ErrorListService.ProcessLogFileAsync(filePath, ToolFormat.None, promptOnLogConversions: true, cleanErrors: false, openInEditor: false);
             });


### PR DESCRIPTION
Fixes #406

When open sarif file in VS editor, the monitor starts to watch it in background thread.
If the sarif file is updated, monitor will reload the sarif log in background thread. The extension get invalid Json and create a InfoBar notification about the invalid Json. This can only be called from UI thread, otherwise it throws exception.

https://github.com/microsoft/sarif-visualstudio-extension/blob/324eabc7d22dc71ef0e91f92f7972f4d3b9deac4/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs#L721-L732

The fix is to switch to UI thread before showing the InfoBar.