### PR TITLE
Only process Sarif log if its opened as Sarif format.

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/SarifTextViewCreationListenerTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/SarifTextViewCreationListenerTests.cs
@@ -38,5 +38,30 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 target.IsSarifLogFile(testcase.input).Should().Be(testcase.expected);
             }
         }
+
+        [Fact]
+        public void SarifTextViewCreationListener_IsSarifContentType()
+        {
+            var testcases = new[]
+            {
+                new { input = (string)null, expected = false },
+                new { input = "", expected = false },
+                new { input = "    ", expected = false },
+                new { input = "JSON", expected = false },
+                new { input = "XML", expected = false },
+                new { input = "code", expected = false },
+                new { input = "XSARIF", expected = false },
+                new { input = "SARIFX", expected = false },
+                new { input = "sarif", expected = true },
+                new { input = "SARIF", expected = true },
+            };
+
+            var target = new SarifTextViewCreationListener();
+
+            foreach (var testcase in testcases)
+            {
+                target.IsSarifLogFile(testcase.input).Should().Be(testcase.expected);
+            }
+        }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/SarifTextViewCreationListenerTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/SarifTextViewCreationListenerTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
 
             foreach (var testcase in testcases)
             {
-                target.IsSarifLogFile(testcase.input).Should().Be(testcase.expected);
+                target.IsSarifContentType(testcase.input).Should().Be(testcase.expected);
             }
         }
     }

--- a/src/Sarif.Viewer.VisualStudio/SarifTextViewCreationListener.cs
+++ b/src/Sarif.Viewer.VisualStudio/SarifTextViewCreationListener.cs
@@ -51,7 +51,8 @@ namespace Microsoft.Sarif.Viewer
             textView.Closed += this.TextView_Closed;
 
             if (this.TryGetFileNameFromTextView(textView, out string filename) &&
-                this.IsSarifLogFile(filename))
+                this.IsSarifLogFile(filename) &&
+                this.IsSarifContentType(textView.TextBuffer.ContentType.TypeName))
             {
                 // since Json (base type of sarif log) editor throws error when file size is greater than 5 MBs
                 // need to listen to content type "text". Only process log if file extension is ".sarif".
@@ -77,7 +78,8 @@ namespace Microsoft.Sarif.Viewer
                 textView.Closed -= this.TextView_Closed;
 
                 if (this.TryGetFileNameFromTextView(textView, out string filename) &&
-                    this.IsSarifLogFile(filename))
+                    this.IsSarifLogFile(filename) &&
+                    this.IsSarifContentType(textView.TextBuffer.ContentType.TypeName))
                 {
                     if (textBufferMap.ContainsKey(textView.TextBuffer))
                     {
@@ -121,6 +123,15 @@ namespace Microsoft.Sarif.Viewer
         {
             return !string.IsNullOrEmpty(fileName) &&
                 fileName.EndsWith(".sarif", StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal bool IsSarifContentType(string typeName)
+        {
+            // check if a Sarif file is opened as SARIF format.
+            // In VS user can open a Sarif file with other editors like JSON editor
+            // just for editing and doesn't need process Sarif log
+            // For these cases the content type will be corresponding type e.g. JSON
+            return typeName.Equals(ContentTypes.Sarif, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/SarifTextViewCreationListener.cs
+++ b/src/Sarif.Viewer.VisualStudio/SarifTextViewCreationListener.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Sarif.Viewer
         internal bool IsSarifLogFile(string fileName)
         {
             return !string.IsNullOrEmpty(fileName) &&
-                fileName.EndsWith(".sarif", StringComparison.OrdinalIgnoreCase);
+                    fileName.EndsWith(".sarif", StringComparison.OrdinalIgnoreCase);
         }
 
         internal bool IsSarifContentType(string typeName)
@@ -131,7 +131,8 @@ namespace Microsoft.Sarif.Viewer
             // In VS user can open a Sarif file with other editors like JSON editor
             // just for editing and doesn't need process Sarif log
             // For these cases the content type will be corresponding type e.g. JSON
-            return typeName.Equals(ContentTypes.Sarif, StringComparison.OrdinalIgnoreCase);
+            return !string.IsNullOrEmpty(typeName) &&
+                    typeName.Equals(ContentTypes.Sarif, StringComparison.OrdinalIgnoreCase);
         }
     }
 }


### PR DESCRIPTION
Fixes #196

If its opened with other editors like JSON editor for editing, do not process Sarif log.