### PR TITLE
Fix issue cannot load results from large size Sarif log

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/SarifTextViewCreationListenerTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/SarifTextViewCreationListenerTests.cs
@@ -54,6 +54,8 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 new { input = "SARIFX", expected = false },
                 new { input = "sarif", expected = true },
                 new { input = "SARIF", expected = true },
+                new { input = "text", expected = true },
+                new { input = "TEXT", expected = true },
             };
 
             var target = new SarifTextViewCreationListener();

--- a/src/Sarif.Viewer.VisualStudio/SarifTextViewCreationListener.cs
+++ b/src/Sarif.Viewer.VisualStudio/SarifTextViewCreationListener.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
 
 using Microsoft.CodeAnalysis.Sarif.Converters;
 using Microsoft.Sarif.Viewer.ErrorList;
@@ -67,6 +68,8 @@ namespace Microsoft.Sarif.Viewer
 
                 textBufferMap[textView.TextBuffer]++;
             }
+
+            Trace.WriteLine($"Opening file: {filename} content type: {textView.TextBuffer.ContentType.TypeName}");
         }
 
         private void TextView_Closed(object sender, EventArgs e)
@@ -132,7 +135,8 @@ namespace Microsoft.Sarif.Viewer
             // just for editing and doesn't need process Sarif log
             // For these cases the content type will be corresponding type e.g. JSON
             return !string.IsNullOrEmpty(typeName) &&
-                    typeName.Equals(ContentTypes.Sarif, StringComparison.OrdinalIgnoreCase);
+                   (typeName.Equals(ContentTypes.Sarif, StringComparison.OrdinalIgnoreCase) ||
+                    typeName.Equals(ContentTypes.Text, StringComparison.OrdinalIgnoreCase));
         }
     }
 }


### PR DESCRIPTION
Its a regression from commit a9888d5ed059241e981212a2a2514016dc4c4703 caught by Apex UI tests.
Should allow content type "text" to keep processing a larg size Sarif log file after JSON editor stop loading due to large size.
