### PR TITLE
Try to resolve file location using version control provenance

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/CodeAnalysisResultManagerTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/CodeAnalysisResultManagerTests.cs
@@ -381,7 +381,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 .Returns(true);
 
             var resultManager = new CodeAnalysisResultManager(mockFileSystem.Object, promptForResolvedPathDelegate: null);
-            resultManager.AddAllowedDownloadHost("github.com");
+            resultManager.AddAllowedDownloadHost("raw.githubusercontent.com");
             bool result = resultManager.TryResolveFilePathFromSourceControl(versionControlList, fileFromLog, workingDirectory, mockFileSystem.Object, out string resolvedPath);
 
             result.Should().BeTrue();

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="ThreadFlowToTreeConverterTests.cs" />
     <Compile Include="Models\AnalysisStepNodeTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="VersionControlParserTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/SdkUiUtilitiesTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/SdkUiUtilitiesTests.cs
@@ -408,6 +408,50 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             actual.Should().Be(expected);
         }
 
+        [Fact]
+        public void ConvertToGithubRawPath_Tests()
+        {
+            var testcases = new[]
+            {
+                new
+                {
+                    Input = "https://github.com/microsoft/sarif-visualstudio-extension/blob/main/.github/workflows/dotnet-format.yml",
+                    Expected = "https://raw.githubusercontent.com/microsoft/sarif-visualstudio-extension/main/.github/workflows/dotnet-format.yml",
+                },
+                new
+                {
+                    Input = "http://github.com/microsoft/sarif-visualstudio-extension/tree/main/src/Sarif.Viewer.VisualStudio/Data/ruleLookup.json",
+                    Expected = "http://raw.githubusercontent.com/microsoft/sarif-visualstudio-extension/main/src/Sarif.Viewer.VisualStudio/Data/ruleLookup.json",
+                },
+                new
+                {
+                    Input = "https://test.com/path/to/file",
+                    Expected = "https://test.com/path/to/file",
+                },
+                new
+                {
+                    Input = "  ",
+                    Expected = "  ",
+                },
+                new
+                {
+                    Input = (string)null,
+                    Expected = (string)null,
+                },
+                new
+                {
+                    Input = "https://github.com/appsettings.json",
+                    Expected = "https://github.com/appsettings.json",
+                },
+            };
+
+            foreach (var testcase in testcases)
+            {
+                string actual = SdkUIUtilities.ConvertToGithubRawPath(testcase.Input);
+                actual.Should().Be(testcase.Expected);
+            }
+        }
+
         private static void VerifyTextRun(Inline expected, Inline actual)
         {
             actual.Should().BeOfType(expected.GetType());

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/SdkUiUtilitiesTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/SdkUiUtilitiesTests.cs
@@ -408,50 +408,6 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             actual.Should().Be(expected);
         }
 
-        [Fact]
-        public void ConvertToGithubRawPath_Tests()
-        {
-            var testcases = new[]
-            {
-                new
-                {
-                    Input = "https://github.com/microsoft/sarif-visualstudio-extension/blob/main/.github/workflows/dotnet-format.yml",
-                    Expected = "https://raw.githubusercontent.com/microsoft/sarif-visualstudio-extension/main/.github/workflows/dotnet-format.yml",
-                },
-                new
-                {
-                    Input = "http://github.com/microsoft/sarif-visualstudio-extension/tree/main/src/Sarif.Viewer.VisualStudio/Data/ruleLookup.json",
-                    Expected = "http://raw.githubusercontent.com/microsoft/sarif-visualstudio-extension/main/src/Sarif.Viewer.VisualStudio/Data/ruleLookup.json",
-                },
-                new
-                {
-                    Input = "https://test.com/path/to/file",
-                    Expected = "https://test.com/path/to/file",
-                },
-                new
-                {
-                    Input = "  ",
-                    Expected = "  ",
-                },
-                new
-                {
-                    Input = (string)null,
-                    Expected = (string)null,
-                },
-                new
-                {
-                    Input = "https://github.com/appsettings.json",
-                    Expected = "https://github.com/appsettings.json",
-                },
-            };
-
-            foreach (var testcase in testcases)
-            {
-                string actual = SdkUIUtilities.ConvertToGithubRawPath(testcase.Input);
-                actual.Should().Be(testcase.Expected);
-            }
-        }
-
         private static void VerifyTextRun(Inline expected, Inline actual)
         {
             actual.Should().BeOfType(expected.GetType());

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/VersionControlParserTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/VersionControlParserTests.cs
@@ -45,6 +45,11 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
                 new
                 {
+                    Input = "http://github1com/microsoft/sarif-visualstudio-extension/tree/main/src/Sarif.Viewer.VisualStudio/Data/ruleLookup.json",
+                    Expected = "http://github1com/microsoft/sarif-visualstudio-extension/tree/main/src/Sarif.Viewer.VisualStudio/Data/ruleLookup.json",
+                },
+                new
+                {
                     Input = "  ",
                     Expected = "  ",
                 },
@@ -92,6 +97,11 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 {
                     Input = "https://test.com/path/to/file",
                     Expected = "https://test.com/path/to/file",
+                },
+                new
+                {
+                    Input = "http://dev_azure.com/org1/project2/_git/repo3?path=%2Fsrc%2Fproduct%2Ftests.cs&version=GBusers%2Fyong%2Fadd",
+                    Expected = "http://dev_azure.com/org1/project2/_git/repo3?path=%2Fsrc%2Fproduct%2Ftests.cs&version=GBusers%2Fyong%2Fadd",
                 },
                 new
                 {

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/VersionControlParserTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/VersionControlParserTests.cs
@@ -1,0 +1,173 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.Sarif;
+
+using Xunit;
+
+namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
+{
+    public class VersionControlParserTests
+    {
+        [Fact]
+        public void ConvertToGithubRawPathTests()
+        {
+            var testcases = new[]
+            {
+                new
+                {
+                    Input = "https://github.com/microsoft/sarif-visualstudio-extension/blob/main/.github/workflows/dotnet-format.yml",
+                    Expected = "https://raw.githubusercontent.com/microsoft/sarif-visualstudio-extension/main/.github/workflows/dotnet-format.yml",
+                },
+                new
+                {
+                    Input = "http://github.com/microsoft/sarif-visualstudio-extension/tree/main/src/Sarif.Viewer.VisualStudio/Data/ruleLookup.json",
+                    Expected = "http://raw.githubusercontent.com/microsoft/sarif-visualstudio-extension/main/src/Sarif.Viewer.VisualStudio/Data/ruleLookup.json",
+                },
+                // input is already a raw file link
+                new
+                {
+                    Input = "https://raw.githubusercontent.com/microsoft/sarif-visualstudio-extension/main/.github/workflows/dotnet-format.yml",
+                    Expected = "https://raw.githubusercontent.com/microsoft/sarif-visualstudio-extension/main/.github/workflows/dotnet-format.yml",
+                },
+                new
+                {
+                    Input = "https://test.com/path/to/file",
+                    Expected = "https://test.com/path/to/file",
+                },
+                new
+                {
+                    Input = "  ",
+                    Expected = "  ",
+                },
+                new
+                {
+                    Input = (string)null,
+                    Expected = (string)null,
+                },
+                new
+                {
+                    Input = "https://github.com/appsettings.json",
+                    Expected = "https://github.com/appsettings.json",
+                },
+            };
+
+            foreach (var testcase in testcases)
+            {
+                string actual = new GithubVersionControlParser(null).ConvertToRawPath(testcase.Input);
+                actual.Should().Be(testcase.Expected);
+            }
+        }
+
+        [Fact]
+        public void ConvertToAdoRawPathTests()
+        {
+            var testcases = new[]
+            {
+                new
+                {
+                    Input = "https://dev.azure.com/org1/project2/_git/repo3?path=%2Fsrc%2Fproduct%2Ftests.cs",
+                    Expected = "https://dev.azure.com/org1/project2/_apis/git/repositories/repo3/items?path=%2Fsrc%2Fproduct%2Ftests.cs",
+                },
+                new
+                {
+                    Input = "http://dev.azure.com/org1/project2/_git/repo3?path=%2Fsrc%2Fproduct%2Ftests.cs&version=GBusers%2Fyong%2Fadd",
+                    Expected = "http://dev.azure.com/org1/project2/_apis/git/repositories/repo3/items?path=%2Fsrc%2Fproduct%2Ftests.cs&versionDescriptor[version]=users%2Fyong%2Fadd",
+                },
+                // input is already a raw file link
+                                new
+                {
+                    Input = "http://dev.azure.com/org1/project2/_apis/git/repositories/repo3/items?path=%2Fsrc%2Fproduct%2Ftests.cs&versionDescriptor[version]=users%2Fyong%2Fadd",
+                    Expected = "http://dev.azure.com/org1/project2/_apis/git/repositories/repo3/items?path=%2Fsrc%2Fproduct%2Ftests.cs&versionDescriptor[version]=users%2Fyong%2Fadd",
+                },
+                new
+                {
+                    Input = "https://test.com/path/to/file",
+                    Expected = "https://test.com/path/to/file",
+                },
+                new
+                {
+                    Input = "  ",
+                    Expected = "  ",
+                },
+                new
+                {
+                    Input = (string)null,
+                    Expected = (string)null,
+                },
+                new
+                {
+                    Input = "https://dev.azure.com/org1/project2/_git/commit/97e943dbc38fe370cd4b3f8630db182092095991",
+                    Expected = "https://dev.azure.com/org1/project2/_git/commit/97e943dbc38fe370cd4b3f8630db182092095991",
+                },
+            };
+
+            foreach (var testcase in testcases)
+            {
+                string actual = new AdoVersionControlParser(null).ConvertToRawPath(testcase.Input);
+                actual.Should().Be(testcase.Expected);
+            }
+        }
+
+        [Fact]
+        public void GithubVersionControlParserTests()
+        {
+            var testcases = new[]
+            {
+                new
+                {
+                    VCData = new VersionControlDetails
+                            {
+                                RepositoryUri = new Uri("https://github.com/microsoft/sarif-visualstudio-extension/"),
+                                RevisionId = "378c2ee96a7dc1d8e487e2a02ce4dc73f67750e7",
+                                Branch = "main",
+                            },
+                    ExpectedParser = true,
+                    RelativeFilePathInput = ".github/workflows/dotnet-format.yml",
+                    Expected = "https://raw.githubusercontent.com/microsoft/sarif-visualstudio-extension/main/.github/workflows/dotnet-format.yml",
+                },
+
+                // not supported source control
+                new
+                {
+                    VCData = new VersionControlDetails
+                            {
+                                RepositoryUri = new Uri("https://gitee.com/anji-plus/report"),
+                                RevisionId = "378c2ee96a7dc1d8e487e2a02ce4dc73f67750e7",
+                                Branch = "main",
+                            },
+                    ExpectedParser = false,
+                    RelativeFilePathInput = "pom.xml",
+                    Expected = "https://gitee.com/anji-plus/report/raw/master/pom.xml",
+                },
+
+                new
+                {
+                    VCData = (VersionControlDetails)null,
+                    ExpectedParser = false,
+                    RelativeFilePathInput = (string)null,
+                    Expected = (string)null,
+                },
+            };
+
+            foreach (var testcase in testcases)
+            {
+                bool result = VersionControlParserFactory.TryGetVersionControlParser(testcase.VCData, out IVersionControlParser parser);
+                result.Should().Be(testcase.ExpectedParser);
+                if (result)
+                {
+                    Uri actual = parser.GetSourceFileUri(testcase.RelativeFilePathInput);
+                    actual.Should().Be(testcase.Expected);
+                }
+            }
+        }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
@@ -443,7 +443,12 @@ namespace Microsoft.Sarif.Viewer
         // Internal rather than private for unit testability.
         internal string GetRebaselinedFileName(string uriBaseId, string pathFromLogFile, RunDataCache dataCache, string workingDirectory = null, string solutionFullPath = null)
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
+            if (!SarifViewerPackage.IsUnitTesting)
+            {
+#pragma warning disable VSTHRD108 // Assert thread affinity unconditionally
+                ThreadHelper.ThrowIfNotOnUIThread();
+#pragma warning restore VSTHRD108
+            }
 
             string originalPath = pathFromLogFile;
             Uri relativeUri = null;

--- a/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
@@ -410,7 +410,7 @@ namespace Microsoft.Sarif.Viewer
 
         internal void AddAllowedDownloadHost(string host)
         {
-            if (this._allowedDownloadHosts.Contains(host))
+            if (!this._allowedDownloadHosts.Contains(host))
             {
                 this._allowedDownloadHosts.Add(host);
                 SdkUIUtilities.StoreObject<List<string>>(this._allowedDownloadHosts, AllowedDownloadHostsFileName);

--- a/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
@@ -179,6 +179,12 @@ namespace Microsoft.Sarif.Viewer
                     }
                 });
             }
+
+            if (run.VersionControlProvenance != null && run.VersionControlProvenance.Any())
+            {
+                var sc = this.CurrentRunDataCache.SourceControlDetails as List<VersionControlDetails>;
+                sc.AddRange(run.VersionControlProvenance);
+            }
         }
 
         public bool TryResolveFilePath(int resultId, int runIndex, string uriBaseId, string relativePath, out string resolvedPath)
@@ -222,7 +228,7 @@ namespace Microsoft.Sarif.Viewer
             if (string.IsNullOrEmpty(resolvedPath))
             {
                 // resolve path, existing file in local disk
-                resolvedPath = this.GetRebaselinedFileName(uriBaseId, relativePath, dataCache, solutionPath);
+                resolvedPath = this.GetRebaselinedFileName(uriBaseId, relativePath, dataCache, solutionPath, sarifErrorListItem.WorkingDirectory);
             }
 
             // verify resolved file with artifact's Hash
@@ -347,13 +353,68 @@ namespace Microsoft.Sarif.Viewer
             return finalPath;
         }
 
+        internal string HandleHttpFileDownloadRequest(Uri uri, string workingDirectory, string localRelativePath = null)
+        {
+            if (!SarifViewerPackage.IsUnitTesting)
+            {
+#pragma warning disable VSTHRD108 // Assert thread affinity unconditionally
+                ThreadHelper.ThrowIfNotOnUIThread();
+#pragma warning restore VSTHRD108
+            }
+
+            bool allow = this._allowedDownloadHosts.Contains(uri.Host);
+
+            // File needs to be downloaded, prompt for confirmation if host is not already allowed
+            if (!allow)
+            {
+                MessageDialogCommand result = MessageDialog.Show(Resources.ConfirmDownloadDialog_Title,
+                                                                 string.Format(Resources.ConfirmDownloadDialog_Message, uri),
+                                                                 MessageDialogCommandSet.YesNo,
+                                                                 string.Format(Resources.ConfirmDownloadDialog_CheckboxLabel, uri.Host),
+                                                                 out bool alwaysAllow);
+
+                if (result != MessageDialogCommand.No)
+                {
+                    allow = true;
+
+                    if (alwaysAllow)
+                    {
+                        this.AddAllowedDownloadHost(uri.Host);
+                    }
+                }
+            }
+
+            if (allow)
+            {
+                try
+                {
+                    workingDirectory = string.IsNullOrWhiteSpace(workingDirectory) ?
+                                       Path.Combine(Path.GetTempPath(), this.CurrentRunIndex.ToString()) :
+                                       workingDirectory;
+                    return this.DownloadFile(workingDirectory, uri.ToString(), localRelativePath);
+                }
+                catch (WebException wex)
+                {
+                    VsShellUtilities.ShowMessageBox(ServiceProvider.GlobalProvider,
+                               Resources.DownloadFail_DialogMessage + Environment.NewLine + wex.Message,
+                               null, // title
+                               OLEMSGICON.OLEMSGICON_CRITICAL,
+                               OLEMSGBUTTON.OLEMSGBUTTON_OK,
+                               OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST);
+                    throw wex;
+                }
+            }
+
+            return null;
+        }
+
         internal void AddAllowedDownloadHost(string host)
         {
             this._allowedDownloadHosts.Add(host);
             SdkUIUtilities.StoreObject<List<string>>(this._allowedDownloadHosts, AllowedDownloadHostsFileName);
         }
 
-        internal string DownloadFile(SarifErrorListItem sarifErrorListItem, string fileUrl)
+        internal string DownloadFile(string workingDirectory, string fileUrl, string localRelativeFilePath)
         {
             if (string.IsNullOrEmpty(fileUrl))
             {
@@ -361,8 +422,10 @@ namespace Microsoft.Sarif.Viewer
             }
 
             var sourceUri = new Uri(fileUrl);
+            string relativeLocalPath = localRelativeFilePath ?? sourceUri.LocalPath;
+            relativeLocalPath = relativeLocalPath.Replace('/', '\\').TrimStart('\\');
 
-            string destinationFile = Path.Combine(sarifErrorListItem.WorkingDirectory, sourceUri.LocalPath.Replace('/', '\\').TrimStart('\\'));
+            string destinationFile = Path.Combine(workingDirectory, relativeLocalPath);
             string destinationDirectory = Path.GetDirectoryName(destinationFile);
             this._fileSystem.DirectoryCreateDirectory(destinationDirectory);
 
@@ -378,8 +441,10 @@ namespace Microsoft.Sarif.Viewer
         }
 
         // Internal rather than private for unit testability.
-        internal string GetRebaselinedFileName(string uriBaseId, string pathFromLogFile, RunDataCache dataCache, string solutionFullPath = null)
+        internal string GetRebaselinedFileName(string uriBaseId, string pathFromLogFile, RunDataCache dataCache, string workingDirectory = null, string solutionFullPath = null)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             string originalPath = pathFromLogFile;
             Uri relativeUri = null;
             string resolvedPath = null;
@@ -394,12 +459,15 @@ namespace Microsoft.Sarif.Viewer
                 return resolvedPath;
             }
 
-            if (!string.IsNullOrEmpty(solutionFullPath))
+            if (this.TryResolveFilePathFromSolution(solutionFullPath, originalPath, this._fileSystem, out resolvedPath))
             {
-                if (this.TryResolveFilePathFromSolution(solutionFullPath, originalPath, this._fileSystem, out resolvedPath))
-                {
-                    return resolvedPath;
-                }
+                return resolvedPath;
+            }
+
+            // try to resolve using VersionControlProvenance
+            if (this.TryResolveFilePathFromSourceControl(dataCache.SourceControlDetails, pathFromLogFile, workingDirectory, this._fileSystem, out resolvedPath))
+            {
+                return resolvedPath;
             }
 
             return null;
@@ -587,46 +655,9 @@ namespace Microsoft.Sarif.Viewer
                  && Uri.TryCreate(baseUri, pathFromLogFile, out Uri uri)
                  && uri.IsHttpScheme())
             {
-                uri = new Uri(SdkUIUtilities.ConvertToGithubRawPath(uri.ToString()));
-                bool allow = this._allowedDownloadHosts.Contains(uri.Host);
-
-                // File needs to be downloaded, prompt for confirmation if host is not already allowed
-                if (!allow)
-                {
-                    MessageDialogCommand result = MessageDialog.Show(Resources.ConfirmDownloadDialog_Title,
-                                                                     string.Format(Resources.ConfirmDownloadDialog_Message, uri),
-                                                                     MessageDialogCommandSet.YesNo,
-                                                                     string.Format(Resources.ConfirmDownloadDialog_CheckboxLabel, uri.Host),
-                                                                     out bool alwaysAllow);
-
-                    if (result != MessageDialogCommand.No)
-                    {
-                        allow = true;
-
-                        if (alwaysAllow)
-                        {
-                            this.AddAllowedDownloadHost(uri.Host);
-                        }
-                    }
-                }
-
-                if (allow)
-                {
-                    try
-                    {
-                        return this.DownloadFile(sarifErrorListItem, uri.ToString());
-                    }
-                    catch (WebException wex)
-                    {
-                        VsShellUtilities.ShowMessageBox(ServiceProvider.GlobalProvider,
-                                   Resources.DownloadFail_DialogMessage + Environment.NewLine + wex.Message,
-                                   null, // title
-                                   OLEMSGICON.OLEMSGICON_CRITICAL,
-                                   OLEMSGBUTTON.OLEMSGBUTTON_OK,
-                                   OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST);
-                        throw wex;
-                    }
-                }
+                return this.HandleHttpFileDownloadRequest(
+                            VersionControlParserFactory.ConvertToRawFileLink(uri),
+                            sarifErrorListItem.WorkingDirectory);
             }
 
             return null;
@@ -635,6 +666,11 @@ namespace Microsoft.Sarif.Viewer
         internal bool TryResolveFilePathFromSolution(string solutionPath, string pathFromLogFile, IFileSystem fileSystem, out string resolvedPath)
         {
             resolvedPath = null;
+            if (string.IsNullOrWhiteSpace(solutionPath))
+            {
+                return false;
+            }
+
             try
             {
                 pathFromLogFile = pathFromLogFile.Replace('/', '\\');
@@ -716,6 +752,60 @@ namespace Microsoft.Sarif.Viewer
                 {
                     resolvedPath = remapped;
                     return true;
+                }
+            }
+
+            return false;
+        }
+
+        internal bool TryResolveFilePathFromSourceControl(IList<VersionControlDetails> sources, string pathFromLogFile, string workingDirectory, IFileSystem fileSystem, out string resolvedPath)
+        {
+            if (!SarifViewerPackage.IsUnitTesting)
+            {
+#pragma warning disable VSTHRD108 // Assert thread affinity unconditionally
+                ThreadHelper.ThrowIfNotOnUIThread();
+#pragma warning restore VSTHRD108
+            }
+
+            resolvedPath = null;
+            if (sources == null || !sources.Any())
+            {
+                return false;
+            }
+
+            foreach (VersionControlDetails versionControl in sources)
+            {
+                string localFilePath;
+
+                // check if file exists in mapped location
+                Uri mapToPath = versionControl.MappedTo?.Uri;
+                if (mapToPath != null)
+                {
+                    localFilePath = new Uri(mapToPath, pathFromLogFile).LocalPath;
+                    if (fileSystem.FileExists(localFilePath))
+                    {
+                        resolvedPath = localFilePath;
+                        return true;
+                    }
+                }
+
+                // try to read from remote repo
+                Uri soureFileFromRepo = null;
+                string localRelativePath = null;
+                if (VersionControlParserFactory.TryGetVersionControlParser(versionControl, out IVersionControlParser parser))
+                {
+                    soureFileFromRepo = parser.GetSourceFileUri(pathFromLogFile);
+                    localRelativePath = parser.GetLocalRelativePath(soureFileFromRepo, pathFromLogFile);
+                }
+
+                if (soureFileFromRepo != null)
+                {
+                    localFilePath = this.HandleHttpFileDownloadRequest(soureFileFromRepo, workingDirectory, localRelativePath);
+                    if (fileSystem.FileExists(localFilePath))
+                    {
+                        resolvedPath = localFilePath;
+                        return true;
+                    }
                 }
             }
 

--- a/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
@@ -410,8 +410,11 @@ namespace Microsoft.Sarif.Viewer
 
         internal void AddAllowedDownloadHost(string host)
         {
-            this._allowedDownloadHosts.Add(host);
-            SdkUIUtilities.StoreObject<List<string>>(this._allowedDownloadHosts, AllowedDownloadHostsFileName);
+            if (this._allowedDownloadHosts.Contains(host))
+            {
+                this._allowedDownloadHosts.Add(host);
+                SdkUIUtilities.StoreObject<List<string>>(this._allowedDownloadHosts, AllowedDownloadHostsFileName);
+            }
         }
 
         internal string DownloadFile(string workingDirectory, string fileUrl, string localRelativeFilePath)

--- a/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
@@ -364,7 +364,7 @@ namespace Microsoft.Sarif.Viewer
 
             string destinationFile = Path.Combine(sarifErrorListItem.WorkingDirectory, sourceUri.LocalPath.Replace('/', '\\').TrimStart('\\'));
             string destinationDirectory = Path.GetDirectoryName(destinationFile);
-            Directory.CreateDirectory(destinationDirectory);
+            this._fileSystem.DirectoryCreateDirectory(destinationDirectory);
 
             if (!this._fileSystem.FileExists(destinationFile))
             {
@@ -583,10 +583,11 @@ namespace Microsoft.Sarif.Viewer
             ThreadHelper.ThrowIfNotOnUIThread();
 
             if (uriBaseId != null
-                    && dataCache.OriginalUriBasePaths.TryGetValue(uriBaseId, out Uri baseUri)
-                    && Uri.TryCreate(baseUri, pathFromLogFile, out Uri uri)
-                    && uri.IsHttpScheme())
+                 && dataCache.OriginalUriBasePaths.TryGetValue(uriBaseId, out Uri baseUri)
+                 && Uri.TryCreate(baseUri, pathFromLogFile, out Uri uri)
+                 && uri.IsHttpScheme())
             {
+                uri = new Uri(SdkUIUtilities.ConvertToGithubRawPath(uri.ToString()));
                 bool allow = this._allowedDownloadHosts.Contains(uri.Host);
 
                 // File needs to be downloaded, prompt for confirmation if host is not already allowed

--- a/src/Sarif.Viewer.VisualStudio/RunDataCache.cs
+++ b/src/Sarif.Viewer.VisualStudio/RunDataCache.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Sarif.Viewer
 
         public IDictionary<string, NewLineIndex> FileToNewLineIndexMap { get; } = new Dictionary<string, NewLineIndex>();
 
+        public IList<VersionControlDetails> SourceControlDetails = new List<VersionControlDetails>();
+
         public FileRegionsCache FileRegionsCache { get; }
 
         public string LogFilePath { get; }

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -178,6 +178,10 @@
     <Compile Include="Telemetry\Events.cs" />
     <Compile Include="Telemetry\FeedbackTelemetryEvent.cs" />
     <Compile Include="Telemetry\TelemetryProvider.cs" />
+    <Compile Include="VersionControlParser\GithubVersionControlParser.cs" />
+    <Compile Include="VersionControlParser\IVersionControlParser.cs" />
+    <Compile Include="VersionControlParser\VersionControlParserFactory.cs" />
+    <Compile Include="VersionControlParser\AdoVersionControlParser.cs" />
     <Compile Include="Views\AnalysisStepView.cs" />
     <Compile Include="Uri.extensions.cs" />
     <Compile Include="Views\ResolveEmbeddedFileDialog.xaml.cs">

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -50,6 +50,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+	<PackageReference Include="System.Net.Http" Version="4.3.0" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
       <Version>17.0.1600</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -275,7 +276,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Windows.Forms" />

--- a/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
@@ -762,32 +762,5 @@ namespace Microsoft.Sarif.Viewer
 
             return false;
         }
-
-        internal static string ConvertToGithubRawPath(string url)
-        {
-            // convert github file access page link to file raw content link
-            // from http://github.com/<username>/<repo>/<blob|tree>/<branch>/path/to/file
-            // to   http://raw.githubusercontent.com/<username>/<repo>/<branch>/path/to/file
-
-            if (string.IsNullOrWhiteSpace(url) ||
-                !(url.StartsWith("http://github.com") || url.StartsWith("https://github.com")))
-            {
-                return url;
-            }
-
-            Regex regex = new Regex("^(?<protocol>https?://)(?<site>github.com)/(?<user>.*?)/(?<repo>.*?)(?<folder>/tree/|/blob/)(?<path>.*?)$");
-
-            if (!regex.IsMatch(url))
-            {
-                return url;
-            }
-
-            return regex.Replace(url,
-                          m => m.Groups["protocol"].Value +
-                               "raw.githubusercontent.com" + "/" +
-                               m.Groups["user"].Value + "/" +
-                               m.Groups["repo"].Value + "/" +
-                               m.Groups["path"]);
-        }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
@@ -762,5 +762,32 @@ namespace Microsoft.Sarif.Viewer
 
             return false;
         }
+
+        internal static string ConvertToGithubRawPath(string url)
+        {
+            // convert github file access page link to file raw content link
+            // from http://github.com/<username>/<repo>/<blob|tree>/<branch>/path/to/file
+            // to   http://raw.githubusercontent.com/<username>/<repo>/<branch>/path/to/file
+
+            if (string.IsNullOrWhiteSpace(url) ||
+                !(url.StartsWith("http://github.com") || url.StartsWith("https://github.com")))
+            {
+                return url;
+            }
+
+            Regex regex = new Regex("^(?<protocol>https?://)(?<site>github.com)/(?<user>.*?)/(?<repo>.*?)(?<folder>/tree/|/blob/)(?<path>.*?)$");
+
+            if (!regex.IsMatch(url))
+            {
+                return url;
+            }
+
+            return regex.Replace(url,
+                          m => m.Groups["protocol"].Value +
+                               "raw.githubusercontent.com" + "/" +
+                               m.Groups["user"].Value + "/" +
+                               m.Groups["repo"].Value + "/" +
+                               m.Groups["path"]);
+        }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/VersionControlParser/AdoVersionControlParser.cs
+++ b/src/Sarif.Viewer.VisualStudio/VersionControlParser/AdoVersionControlParser.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Sarif.Viewer
                 return url;
             }
 
-            var regex = new Regex("^(?<protocol>https?://)(?<site>dev.azure.com)/(?<org>.*?)/(?<project>.*?)/(?<api>_git)/(?<repo>.*?)\\?path=(?<filepath>.*?)(&version=GB(?<version>.*?))?$");
+            var regex = new Regex(@"^(?<protocol>https?://)(?<site>dev\.azure\.com)/(?<org>.*?)/(?<project>.*?)/(?<api>_git)/(?<repo>.*?)\?path=(?<filepath>.*?)(&version=GB(?<version>.*?))?$");
 
             if (!regex.IsMatch(url))
             {

--- a/src/Sarif.Viewer.VisualStudio/VersionControlParser/AdoVersionControlParser.cs
+++ b/src/Sarif.Viewer.VisualStudio/VersionControlParser/AdoVersionControlParser.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.Sarif.Viewer.Sarif;
+
+namespace Microsoft.Sarif.Viewer
+{
+    public class AdoVersionControlParser : IVersionControlParser
+    {
+        private readonly VersionControlDetails details;
+
+        internal AdoVersionControlParser(VersionControlDetails versionControl)
+        {
+            this.details = versionControl;
+        }
+
+        public Uri GetSourceFileUri(string relativeFilePath)
+        {
+            // github link format:
+            // https://dev.azure.com/{org}/{project}/_git/{repo}?path={filepath}
+
+            string sourceRelativePath = $"?path={relativeFilePath}";
+            string version = this.details.Branch ?? this.details.RevisionId;
+            sourceRelativePath += string.IsNullOrWhiteSpace(version) ? string.Empty : $"version=GB{version}";
+
+            if (Uri.TryCreate(this.details.RepositoryUri, sourceRelativePath, out Uri sourceUri) &&
+                sourceUri.IsHttpScheme())
+            {
+                return new Uri(ConvertToRawPath(sourceUri.ToString()));
+            }
+
+            return null;
+        }
+
+        public string ConvertToRawPath(string url)
+        {
+            // convert ado file access page link to file raw content link
+            // from https://dev.azure.com/{org}/{project}/_git/{repo}?path={filepath}&version={branch|commitId}
+            // to   https://dev.azure.com/{org}/{project}/_apis/git/repositories/{repo}/items?path={filepath}&version={branch|commitId}
+
+            if (string.IsNullOrWhiteSpace(url) ||
+                !(url.StartsWith($"http://{VersionControlParserFactory.AdoHost}", StringComparison.OrdinalIgnoreCase) ||
+                  url.StartsWith($"https://{VersionControlParserFactory.AdoHost}", StringComparison.OrdinalIgnoreCase)))
+            {
+                return url;
+            }
+
+            var regex = new Regex("^(?<protocol>https?://)(?<site>dev.azure.com)/(?<org>.*?)/(?<project>.*?)/(?<api>_git)/(?<repo>.*?)\\?path=(?<filepath>.*?)(&version=GB(?<version>.*?))?$");
+
+            if (!regex.IsMatch(url))
+            {
+                return url;
+            }
+
+            return regex.Replace(url,
+                          m => m.Groups["protocol"].Value +
+                               m.Groups["site"].Value + "/" +
+                               m.Groups["org"].Value + "/" +
+                               m.Groups["project"].Value + "/" +
+                               "_apis/git/repositories" + "/" +
+                               m.Groups["repo"].Value + "/" +
+                               "items?path=" + m.Groups["filepath"].Value +
+                               (m.Groups["version"].Success ?
+                                   "&versionDescriptor[version]=" + m.Groups["version"].Value :
+                                   string.Empty));
+        }
+
+        public string GetLocalRelativePath(Uri uri, string relativeFilePath)
+        {
+            // for Ado the file link url has not full path to the file.
+            // e.g. https://dev.azure.com/{org}/{project}/_git/{repo}?path={filepath}
+            // the file path is part of query parameter, not the path.
+            // so return the file path to let caller use this path instead.
+            return relativeFilePath;
+        }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/VersionControlParser/AdoVersionControlParser.cs
+++ b/src/Sarif.Viewer.VisualStudio/VersionControlParser/AdoVersionControlParser.cs
@@ -16,6 +16,9 @@ namespace Microsoft.Sarif.Viewer
     public class AdoVersionControlParser : IVersionControlParser
     {
         private readonly VersionControlDetails details;
+        private static readonly Regex regex = new Regex(
+            @"^(?<protocol>https?://)(?<site>dev\.azure\.com)/(?<org>.*?)/(?<project>.*?)/(?<api>_git)/(?<repo>.*?)\?path=(?<filepath>.*?)(&version=GB(?<version>.*?))?$",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         internal AdoVersionControlParser(VersionControlDetails versionControl)
         {
@@ -52,8 +55,6 @@ namespace Microsoft.Sarif.Viewer
             {
                 return url;
             }
-
-            var regex = new Regex(@"^(?<protocol>https?://)(?<site>dev\.azure\.com)/(?<org>.*?)/(?<project>.*?)/(?<api>_git)/(?<repo>.*?)\?path=(?<filepath>.*?)(&version=GB(?<version>.*?))?$");
 
             if (!regex.IsMatch(url))
             {

--- a/src/Sarif.Viewer.VisualStudio/VersionControlParser/GithubVersionControlParser.cs
+++ b/src/Sarif.Viewer.VisualStudio/VersionControlParser/GithubVersionControlParser.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+
+using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.Sarif.Viewer.Sarif;
+
+namespace Microsoft.Sarif.Viewer
+{
+    internal class GithubVersionControlParser : IVersionControlParser
+    {
+        private readonly VersionControlDetails details;
+
+        internal GithubVersionControlParser(VersionControlDetails versionControl)
+        {
+            this.details = versionControl;
+        }
+
+        public Uri GetSourceFileUri(string relativeFilePath)
+        {
+            // github link format:
+            // https://github.com/<username>/<reponame>/<blob|tree>/<commitmentid|branch>/path/to/file
+
+            string sourceRelativePath = "blob/";
+            sourceRelativePath += this.details.Branch ?? this.details.RevisionId;
+            sourceRelativePath += "/";
+            sourceRelativePath += relativeFilePath;
+
+            if (Uri.TryCreate(this.details.RepositoryUri, sourceRelativePath, out Uri sourceUri) &&
+                sourceUri.IsHttpScheme())
+            {
+                return new Uri(ConvertToRawPath(sourceUri.ToString()));
+            }
+
+            return null;
+        }
+
+        public string ConvertToRawPath(string url)
+        {
+            // convert github file access page link to file raw content link
+            // from https://github.com/<username>/<repo>/<blob|tree>/<branch>/path/to/file
+            // to   https://raw.githubusercontent.com/<username>/<repo>/<branch>/path/to/file
+
+            if (string.IsNullOrWhiteSpace(url) ||
+                !(url.StartsWith("http://github.com") || url.StartsWith("https://github.com")))
+            {
+                return url;
+            }
+
+            var regex = new Regex("^(?<protocol>https?://)(?<site>github.com)/(?<user>.*?)/(?<repo>.*?)(?<folder>/tree/|/blob/)(?<path>.*?)$");
+
+            if (!regex.IsMatch(url))
+            {
+                return url;
+            }
+
+            return regex.Replace(url,
+                          m => m.Groups["protocol"].Value +
+                               "raw.githubusercontent.com" + "/" +
+                               m.Groups["user"].Value + "/" +
+                               m.Groups["repo"].Value + "/" +
+                               m.Groups["path"]);
+        }
+
+        public string GetLocalRelativePath(Uri uri, string relativeFilePath)
+        {
+            // for Github the file link url has full path to the file.
+            // e.g. https://github.com/<username>/<repo>/<blob|tree>/<branch>/path/to/file
+            // so return null to let caller construct file path using url
+            return null;
+        }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/VersionControlParser/GithubVersionControlParser.cs
+++ b/src/Sarif.Viewer.VisualStudio/VersionControlParser/GithubVersionControlParser.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Sarif.Viewer
                 return url;
             }
 
-            var regex = new Regex("^(?<protocol>https?://)(?<site>github.com)/(?<user>.*?)/(?<repo>.*?)(?<folder>/tree/|/blob/)(?<path>.*?)$");
+            var regex = new Regex(@"^(?<protocol>https?://)(?<site>github\.com)/(?<user>.*?)/(?<repo>.*?)(?<folder>/tree/|/blob/)(?<path>.*?)$");
 
             if (!regex.IsMatch(url))
             {

--- a/src/Sarif.Viewer.VisualStudio/VersionControlParser/GithubVersionControlParser.cs
+++ b/src/Sarif.Viewer.VisualStudio/VersionControlParser/GithubVersionControlParser.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Sarif.Viewer
     internal class GithubVersionControlParser : IVersionControlParser
     {
         private readonly VersionControlDetails details;
+        private static readonly Regex regex = new Regex(
+            @"^(?<protocol>https?://)(?<site>github\.com)/(?<user>.*?)/(?<repo>.*?)(?<folder>/tree/|/blob/)(?<path>.*?)$",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         internal GithubVersionControlParser(VersionControlDetails versionControl)
         {
@@ -48,8 +51,6 @@ namespace Microsoft.Sarif.Viewer
             {
                 return url;
             }
-
-            var regex = new Regex(@"^(?<protocol>https?://)(?<site>github\.com)/(?<user>.*?)/(?<repo>.*?)(?<folder>/tree/|/blob/)(?<path>.*?)$");
 
             if (!regex.IsMatch(url))
             {

--- a/src/Sarif.Viewer.VisualStudio/VersionControlParser/IVersionControlParser.cs
+++ b/src/Sarif.Viewer.VisualStudio/VersionControlParser/IVersionControlParser.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Sarif.Viewer
+{
+    public interface IVersionControlParser
+    {
+        public Uri GetSourceFileUri(string relativeFilePath);
+
+        public string ConvertToRawPath(string url);
+
+        public string GetLocalRelativePath(Uri uri, string relativeFilePath);
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/VersionControlParser/VersionControlParserFactory.cs
+++ b/src/Sarif.Viewer.VisualStudio/VersionControlParser/VersionControlParserFactory.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Sarif.Viewer
         internal static string GithubHost = "github.com";
         internal static string AdoHost = "dev.azure.com";
 
-        internal static Regex githubRegx = new Regex(@"^https?://github\.com", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        internal static Regex adoRegx = new Regex(@"^https?://dev\.azure\.com", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex s_githubRegex = new Regex(@"^https?://github\.com", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex s_adoRegex = new Regex(@"^https?://dev\.azure\.com", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         internal static bool TryGetVersionControlParser(VersionControlDetails versionControl, out IVersionControlParser parser)
         {
@@ -45,7 +45,7 @@ namespace Microsoft.Sarif.Viewer
 
         internal static string ConvertToRawFileLink(string url)
         {
-            if (!string.IsNullOrWhiteSpace(url) && githubRegx.IsMatch(url))
+            if (!string.IsNullOrWhiteSpace(url) && s_githubRegex.IsMatch(url))
             {
                 return new GithubVersionControlParser(null).ConvertToRawPath(url);
             }

--- a/src/Sarif.Viewer.VisualStudio/VersionControlParser/VersionControlParserFactory.cs
+++ b/src/Sarif.Viewer.VisualStudio/VersionControlParser/VersionControlParserFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Text.RegularExpressions;
 
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.Sarif;
@@ -13,6 +14,9 @@ namespace Microsoft.Sarif.Viewer
         // known version control host
         internal static string GithubHost = "github.com";
         internal static string AdoHost = "dev.azure.com";
+
+        internal static Regex githubRegx = new Regex(@"^https?://github\.com", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        internal static Regex adoRegx = new Regex(@"^https?://dev\.azure\.com", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         internal static bool TryGetVersionControlParser(VersionControlDetails versionControl, out IVersionControlParser parser)
         {
@@ -41,16 +45,14 @@ namespace Microsoft.Sarif.Viewer
 
         internal static string ConvertToRawFileLink(string url)
         {
-            if (!string.IsNullOrWhiteSpace(url) &&
-                (url.StartsWith($"http://{GithubHost}") || url.StartsWith($"https://{GithubHost}")))
+            if (!string.IsNullOrWhiteSpace(url) && githubRegx.IsMatch(url))
             {
                 return new GithubVersionControlParser(null).ConvertToRawPath(url);
             }
 
             // not working due to need credential to access ado/vsts files
             /*
-            if (!string.IsNullOrWhiteSpace(url) &&
-                (url.StartsWith($"http://{AdoHost}") || url.StartsWith($"https://{AdoHost}")))
+            if (!string.IsNullOrWhiteSpace(url) && adoRegx.IsMatch(url))
             {
                 return new AdoVersionControlParser(null).ConvertToRawPath(url);
             }

--- a/src/Sarif.Viewer.VisualStudio/VersionControlParser/VersionControlParserFactory.cs
+++ b/src/Sarif.Viewer.VisualStudio/VersionControlParser/VersionControlParserFactory.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.Sarif.Viewer.Sarif;
+
+namespace Microsoft.Sarif.Viewer
+{
+    internal class VersionControlParserFactory
+    {
+        // known version control host
+        internal static string GithubHost = "github.com";
+        internal static string AdoHost = "dev.azure.com";
+
+        internal static bool TryGetVersionControlParser(VersionControlDetails versionControl, out IVersionControlParser parser)
+        {
+            if (versionControl?.RepositoryUri != null &&
+                versionControl.RepositoryUri.IsHttpScheme() &&
+                versionControl.RepositoryUri.Host.Equals(GithubHost, StringComparison.OrdinalIgnoreCase))
+            {
+                parser = new GithubVersionControlParser(versionControl);
+                return true;
+            }
+
+            // not working due to need credential to access ado/vsts files
+            /*
+            if (versionControl.RepositoryUri.IsHttpScheme() &&
+                versionControl.RepositoryUri.Host.Equals(AdoHost, StringComparison.OrdinalIgnoreCase))
+            {
+                parser = new AdoVersionControlParser(versionControl);
+                return true;
+            }
+            */
+
+            // no corresponding parser found
+            parser = null;
+            return false;
+        }
+
+        internal static string ConvertToRawFileLink(string url)
+        {
+            if (!string.IsNullOrWhiteSpace(url) &&
+                (url.StartsWith($"http://{GithubHost}") || url.StartsWith($"https://{GithubHost}")))
+            {
+                return new GithubVersionControlParser(null).ConvertToRawPath(url);
+            }
+
+            // not working due to need credential to access ado/vsts files
+            /*
+            if (!string.IsNullOrWhiteSpace(url) &&
+                (url.StartsWith($"http://{AdoHost}") || url.StartsWith($"https://{AdoHost}")))
+            {
+                return new AdoVersionControlParser(null).ConvertToRawPath(url);
+            }
+            */
+
+            return url;
+        }
+
+        internal static Uri ConvertToRawFileLink(Uri url)
+        {
+            return new Uri(ConvertToRawFileLink(url.ToString()));
+        }
+    }
+}


### PR DESCRIPTION
When it cannot resolve the file path using other information in the result e.g. base Uri id/solution folder etc., try to use VersionControlProvenance data to find the source file related to the results.
- If can find source file in VersionControlProvenance MappedTo location, use this location.
- If cannot, try to download the source file from repository according to VersionControlProvenance data.
- Save to temp folder and return the temp file path.

Can support Github repository now.
For ADO the right link can be generated but cannot download the file since needs of credentials.