### PR TITLE
[abandoned] Support VS 2022 - upgrade Microsoft.VisualStudio.SDK version to 17.0 preview

### DIFF
--- a/src/Sarif.Sarifer.UnitTests/Sarif.Sarifer.UnitTests.csproj
+++ b/src/Sarif.Sarifer.UnitTests/Sarif.Sarifer.UnitTests.csproj
@@ -25,7 +25,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="15.0.1" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-3-31605-261" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />

--- a/src/Sarif.Sarifer/OutputWindowTracerListener.cs
+++ b/src/Sarif.Sarifer/OutputWindowTracerListener.cs
@@ -28,10 +28,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
             {
                 if (this.EnsurePane())
                 {
-                    ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                    _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                     {
                         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                        this.pane.OutputString(message);
+                        this.pane.OutputStringThreadSafe(message);
                     });
                 }
             }

--- a/src/Sarif.Sarifer/Sarif.Sarifer.csproj
+++ b/src/Sarif.Sarifer/Sarif.Sarifer.csproj
@@ -35,9 +35,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="15.0.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.7.27703" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="15.8.525" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-3-31605-261" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools">
+      <Version>17.0.3177-preview3</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>12.0.3</Version>
     </PackageReference>

--- a/src/Sarif.Viewer.VisualStudio.Interop/Sarif.Viewer.VisualStudio.Interop.csproj
+++ b/src/Sarif.Viewer.VisualStudio.Interop/Sarif.Viewer.VisualStudio.Interop.csproj
@@ -20,12 +20,7 @@
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., build.props))\build.props" />
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
-      <Version>5.0.3</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="15.0.1" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-3-31605-261" />
     <PackageReference Include="Nerdbank.GitVersioning">
       <Version>3.3.37</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/ErrorListServiceTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/ErrorListServiceTests.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
 ";
             int numberOfException = numberOfExceptionLogged;
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(invalidJson));
-            ErrorListService.ProcessSarifLogAsync(stream, "logId", false, false).ConfigureAwait(false);
+            _= ErrorListService.ProcessSarifLogAsync(stream, "logId", false, false).ConfigureAwait(false);
             // 1 exception logged
             numberOfExceptionLogged.Should().Be(numberOfException + 1);
         }
@@ -146,7 +146,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
 ";
             int numberOfException = this.numberOfExceptionLogged;
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonNotCompatible));
-            ErrorListService.ProcessSarifLogAsync(stream, "logId", false, false).ConfigureAwait(false);
+            _ = ErrorListService.ProcessSarifLogAsync(stream, "logId", false, false).ConfigureAwait(false);
             // 1 exception logged
             this.numberOfExceptionLogged.Should().Be(numberOfException + 1);
         }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/ErrorListServiceTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/ErrorListServiceTests.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
 ";
             int numberOfException = numberOfExceptionLogged;
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(invalidJson));
-            _= ErrorListService.ProcessSarifLogAsync(stream, "logId", false, false).ConfigureAwait(false);
+            _ = ErrorListService.ProcessSarifLogAsync(stream, "logId", false, false).ConfigureAwait(false);
             // 1 exception logged
             numberOfExceptionLogged.Should().Be(numberOfException + 1);
         }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., build.props))\build.props" />
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="15.0.1" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-3-31605-261" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />

--- a/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
@@ -999,7 +999,7 @@ namespace Microsoft.Sarif.Viewer
 
             // If we don't have an open folder situation, then we assume there is a ".sln" file.
             DTE2 dte = (DTE2)Package.GetGlobalService(typeof(DTE));
-            if (dte.Solution != null && dte.Solution.IsOpen)
+            if (dte.Solution != null && dte.Solution.IsOpen && !string.IsNullOrWhiteSpace(dte.Solution.FullName))
             {
                 solutionPath = Path.GetDirectoryName(dte.Solution.FullName);
             }

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -560,7 +560,12 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
         private int WriteRunToErrorList(Run run, string logFilePath, SarifLog sarifLog)
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
+            if (!SarifViewerPackage.IsUnitTesting)
+            {
+#pragma warning disable VSTHRD108 // Assert thread affinity unconditionally
+                ThreadHelper.ThrowIfNotOnUIThread();
+#pragma warning restore VSTHRD108
+            }
 
             int runIndex = CodeAnalysisResultManager.Instance.GetNextRunIndex();
             var dataCache = new RunDataCache(runIndex, logFilePath, sarifLog);
@@ -568,7 +573,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             CodeAnalysisResultManager.Instance.CacheUriBasePaths(run);
             var sarifErrors = new List<SarifErrorListItem>();
 
-            var dte = Package.GetGlobalService(typeof(DTE)) as DTE2;
+            DTE2 dte = SarifViewerPackage.IsUnitTesting ? null : Package.GetGlobalService(typeof(DTE)) as DTE2;
 
             var projectNameCache = new ProjectNameCache(dte?.Solution);
 

--- a/src/Sarif.Viewer.VisualStudio/Fixes/FixSuggestedActionsSource.cs
+++ b/src/Sarif.Viewer.VisualStudio/Fixes/FixSuggestedActionsSource.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Sarif.Viewer.Fixes
 {
     internal class FixSuggestedActionsSource : ISuggestedActionsSource
     {
+        private static readonly string SuggestionCategory = "Sarif Viewer Suggestions";
+
         private readonly ITextView textView;
         private readonly ITextBuffer textBuffer;
         private readonly IPersistentSpanFactory persistentSpanFactory;
@@ -266,7 +268,7 @@ namespace Microsoft.Sarif.Viewer.Fixes
             return suggestedActions.Any() ?
                 new List<SuggestedActionSet>
                 {
-                    new SuggestedActionSet(suggestedActions),
+                    new SuggestedActionSet(SuggestionCategory, suggestedActions),
                 }
                 :
                 null;

--- a/src/Sarif.Viewer.VisualStudio/Models/FeedbackModel.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/FeedbackModel.cs
@@ -53,15 +53,18 @@ namespace Microsoft.Sarif.Viewer.Models
                 ThreadHelper.ThrowIfNotOnUIThread();
                 if (this.sendFeedbackCommand == null)
                 {
-                    this.sendFeedbackCommand = new Microsoft.VisualStudio.PlatformUI.DelegateCommand((param) =>
-                    {
-                        ThreadHelper.ThrowIfNotOnUIThread();
+                    this.sendFeedbackCommand = new Microsoft.VisualStudio.PlatformUI.DelegateCommand(
+                        execute: (param) =>
+                        {
+                            ThreadHelper.ThrowIfNotOnUIThread();
 
-                        ErrorListService.SendFeedback(this);
+                            ErrorListService.SendFeedback(this);
 
-                        DialogWindow dialogWindow = param as DialogWindow;
-                        dialogWindow.Close();
-                    });
+                            DialogWindow dialogWindow = param as DialogWindow;
+                            dialogWindow.Close();
+                        },
+                        canExecute: delegate { return true; },
+                        jtf: null);
                 }
 
                 return this.sendFeedbackCommand;

--- a/src/Sarif.Viewer.VisualStudio/Models/LocationCollection.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/LocationCollection.cs
@@ -58,7 +58,12 @@ namespace Microsoft.Sarif.Viewer.Models
 
         private void LocationModelPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
+            if (!SarifViewerPackage.IsUnitTesting)
+            {
+#pragma warning disable VSTHRD108 // Assert thread affinity unconditionally
+                ThreadHelper.ThrowIfNotOnUIThread();
+#pragma warning restore VSTHRD108
+            }
 
             if (e.PropertyName == nameof(LocationModel.IsSelected) && sender is LocationModel locationModel)
             {

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -40,12 +40,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="15.0.1" />
-    <!-- Necessary to provide TaskStatusCenter and ITextViewCreationListener: -->
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.7.27703" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="15.8.525" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-3-31605-261" />
     <PackageReference Include="Microsoft.VisualStudio.Workspace.VSIntegration">
       <Version>16.3.43</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools">
+      <Version>17.0.3177-preview3</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Nerdbank.GitVersioning">
       <Version>3.3.37</Version>
@@ -54,11 +56,6 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.0.1600</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Controls\FeedbackControl.xaml.cs">

--- a/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
@@ -192,11 +192,14 @@ namespace Microsoft.Sarif.Viewer
             IVsWindowFrame windowFrame;
             Guid textViewGuid = VSConstants.LOGVIEWID_TextView;
 
-            // Unused variables
-            IVsUIHierarchy uiHierarchy;
-            Microsoft.VisualStudio.OLE.Interop.IServiceProvider serviceProvider;
-            uint itemId;
-            int hr = openDoc.OpenDocumentViaProject(file, ref textViewGuid, out serviceProvider, out uiHierarchy, out itemId, out windowFrame);
+            int hr = openDoc.OpenDocumentViaProject(
+                file,
+                ref textViewGuid,
+                out Microsoft.VisualStudio.OLE.Interop.IServiceProvider serviceProvider,
+                out IVsUIHierarchy uiHierarchy,
+                out uint itemId,
+                out windowFrame);
+
             if (ErrorHandler.Failed(hr))
             {
                 throw Marshal.GetExceptionForHR(hr);

--- a/src/Sarif.Viewer.VisualStudio/Tags/SarifLocationTagHelpers.cs
+++ b/src/Sarif.Viewer.VisualStudio/Tags/SarifLocationTagHelpers.cs
@@ -18,6 +18,11 @@ namespace Microsoft.Sarif.Viewer.Tags
         /// </param>
         public static void RefreshTags(ITextBuffer textBuffer = null)
         {
+            if (SarifViewerPackage.IsUnitTesting)
+            {
+                return;
+            }
+
             var componentModel = (IComponentModel)Package.GetGlobalService(typeof(SComponentModel));
             if (componentModel != null)
             {

--- a/src/Sarif.Viewer.VisualStudio/Tags/TextViewCaretListener.cs
+++ b/src/Sarif.Viewer.VisualStudio/Tags/TextViewCaretListener.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Sarif.Viewer.Tags
             // entered notifications for a newly created text view.
             // This allows the SARIF explorer to proper set selection to items
             // on initial load.
-            ThreadHelper.JoinableTaskFactory.RunAsync(() => this.UpdateInitialCaretPositionAsync());
+            _ = ThreadHelper.JoinableTaskFactory.RunAsync(() => this.UpdateInitialCaretPositionAsync());
         }
 
         /// <summary>


### PR DESCRIPTION
Currently Microsoft.VisualStudio.SDK 15.0 references to old PIA assemblies which are incompatible with VS 2022.
To support latest Visual Studio 2022 need to upgrade the VS SDK to 17.0.
Fixed couple API changes due to the SDK version upgrading.

Attached the results of ILDASM tool shows no old PIA assembly references.
[SarifViewerIldasm.zip](https://github.com/microsoft/sarif-visualstudio-extension/files/7172769/SarifViewerIldasm.zip)
