### PR TITLE
Handle empty temporary solution path

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/CodeAnalysisResultManagerTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/CodeAnalysisResultManagerTests.cs
@@ -686,7 +686,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         [Fact]
         public void CodeAnalysisResultManager_GetSolutionPath_SolutionFolderOpened()
         {
-            string folder = @"C:\github\repo\myproject\";
+            const string folder = @"C:\github\repo\myproject\";
             IVsFolderWorkspaceService workspaceService = SetupWorkspaceService(folder);
             DTE2 dte = null;
 
@@ -698,8 +698,8 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         [Fact]
         public void CodeAnalysisResultManager_GetSolutionPath_SolutionOpened()
         {
-            string solutionFile = @"C:\github\repo\myproject\src\mysolution.sln";
-            string solutionFolder = @"C:\github\repo\myproject\src";
+            const string solutionFile = @"C:\github\repo\myproject\src\mysolution.sln";
+            const string solutionFolder = @"C:\github\repo\myproject\src";
 
             IVsFolderWorkspaceService workspaceService = null;
             DTE2 dte = SetupSolutionService(solutionFile);


### PR DESCRIPTION
When VS opens a single file, not a folder or solution, it creates temporary solution "Solution1" and its FullName is empty in this case.

The change is to handle this case and not break following Path.GetDirectoryName().