### PR TITLE
Update Microsoft.VisualStudio.SDK package version

### DIFF
--- a/src/Sarif.Sarifer.UnitTests/Sarif.Sarifer.UnitTests.csproj
+++ b/src/Sarif.Sarifer.UnitTests/Sarif.Sarifer.UnitTests.csproj
@@ -25,7 +25,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="15.0.1" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />

--- a/src/Sarif.Sarifer/Sarif.Sarifer.csproj
+++ b/src/Sarif.Sarifer/Sarif.Sarifer.csproj
@@ -35,9 +35,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="15.0.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.7.27703" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="15.8.525" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" />
     <PackageReference Include="Newtonsoft.Json">
       <Version>12.0.3</Version>
     </PackageReference>

--- a/src/Sarif.Viewer.VisualStudio.2022/Sarif.Viewer.VisualStudio.2022.csproj
+++ b/src/Sarif.Viewer.VisualStudio.2022/Sarif.Viewer.VisualStudio.2022.csproj
@@ -40,7 +40,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-3-31605-261" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.31902.203" />
     <PackageReference Include="Microsoft.VisualStudio.Workspace.VSIntegration">
       <Version>16.3.43</Version>
     </PackageReference>
@@ -54,7 +54,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Sarif.Viewer.VisualStudio.Interop/Sarif.Viewer.VisualStudio.Interop.csproj
+++ b/src/Sarif.Viewer.VisualStudio.Interop/Sarif.Viewer.VisualStudio.Interop.csproj
@@ -25,7 +25,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="15.0.1" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" />
     <PackageReference Include="Nerdbank.GitVersioning">
       <Version>3.3.37</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Update Microsoft.VisualStudio.SDK version from 17.0-preview to official 17.0 for VS 2022 VSIX project.
- Update Microsoft.VisualStudio.SDK version from 15.0 to 16.0 for Sarifer & Sarifer.UnitTest projects to be same as Sarif.Viewer's SDK verison.
- Passed Apex tests