### PR TITLE
Fix Component Governance warning: reference to System.Net.Http 4.3.3

### DIFF
--- a/src/Sarif.Sarifer.UnitTests/Sarif.Sarifer.UnitTests.csproj
+++ b/src/Sarif.Sarifer.UnitTests/Sarif.Sarifer.UnitTests.csproj
@@ -27,6 +27,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="System.Net.Http">
+      <Version>4.3.4</Version>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/src/Sarif.Sarifer/Sarif.Sarifer.csproj
+++ b/src/Sarif.Sarifer/Sarif.Sarifer.csproj
@@ -49,6 +49,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.Net.Http">
+      <Version>4.3.4</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Commands\AnalyzeSolutionCommand.cs" />


### PR DESCRIPTION
Add explicit reference to System.Net.Http 4.3.4 to avoid earlier version introduced by other libraries.