### PR TITLE
Support Hyperlinks in SARIF explorer

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/Converters/CollectionToVisibilityConverter.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Converters/CollectionToVisibilityConverter.cs
@@ -30,4 +30,27 @@ namespace Microsoft.Sarif.Viewer.Converters
             return null;
         }
     }
+
+    public class CollectionToInvertedVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            var collection = value as ICollection;
+            int val;
+
+            if (collection != null && int.TryParse(parameter.ToString(), out val))
+            {
+                return collection.Count > val ? Visibility.Collapsed : Visibility.Visible;
+            }
+            else
+            {
+                return Visibility.Visible;
+            }
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return null;
+        }
+    }
 }

--- a/src/Sarif.Viewer.VisualStudio.Core/Converters/CollectionToVisibilityConverter.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Converters/CollectionToVisibilityConverter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
 
@@ -10,7 +11,7 @@ namespace Microsoft.Sarif.Viewer.Converters
 {
     public class CollectionToVisibilityConverter : IValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var collection = value as ICollection;
             int val;
@@ -25,7 +26,7 @@ namespace Microsoft.Sarif.Viewer.Converters
             }
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
             return null;
         }
@@ -33,7 +34,7 @@ namespace Microsoft.Sarif.Viewer.Converters
 
     public class CollectionToInvertedVisibilityConverter : IValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var collection = value as ICollection;
             int val;
@@ -48,7 +49,7 @@ namespace Microsoft.Sarif.Viewer.Converters
             }
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
             return null;
         }

--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/SarifResultTableEntry.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/SarifResultTableEntry.cs
@@ -92,8 +92,9 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             if (this.Error.Rule != null)
             {
                 this.columnKeyToContent[StandardTableKeyNames.ErrorCode] = this.Error.Rule.Id;
-                this.columnKeyToContent[StandardTableKeyNames.ErrorCodeToolTip] = string.IsNullOrEmpty(this.Error.Rule.Name) ?
-                    this.Error.Rule.Id : this.Error.Rule.Id + "." + this.Error.Rule.Name;
+                this.columnKeyToContent[StandardTableKeyNames.ErrorCodeToolTip] = string.IsNullOrEmpty(this.Error.Rule.Name)
+                    ? this.Error.Rule.Id
+                    : this.Error.Rule.Id + "." + this.Error.Rule.Name;
             }
 
             this.columnKeyToContent[StandardTableKeyNames.ProjectName] = this.Error.ProjectName;
@@ -108,22 +109,22 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             // Create duplicated message inline objects for ErrorList table entry since
             // Error.MessageInlines is already binded to an element in SARIF explorer.
             this.columnKeyToContent[StandardTableKeyNames2.TextInlines] = new Lazy<object>(() =>
-                this.Error.MessageInlines?.Any() == true ?
-                SdkUIUtilities.GetMessageInlines(this.Error.RawMessage, this.Error.MessageInlineLink_Click) :
-                null);
+                this.Error.MessageInlines?.Any() == true
+                ? SdkUIUtilities.GetMessageInlines(this.Error.RawMessage, this.Error.MessageInlineLink_Click)
+                : null);
 
             this.columnKeyToContent[StandardTableKeyNames.Text] = new Lazy<object>(() =>
                 SdkUIUtilities.UnescapeBrackets(this.Error.ShortMessage));
 
             this.columnKeyToContent[StandardTableKeyNames.FullText] = new Lazy<object>(() =>
-                this.Error.HasDetailsContent ?
-                SdkUIUtilities.UnescapeBrackets(this.Error.Message) :
-                null);
+                this.Error.HasDetailsContent
+                ? SdkUIUtilities.UnescapeBrackets(this.Error.Message)
+                : null);
 
             this.columnKeyToContent[StandardTableKeyNames.HelpLink] = new Lazy<object>(() =>
-                !string.IsNullOrEmpty(this.Error.HelpLink) ?
-                Uri.EscapeUriString(this.Error.HelpLink) :
-                null);
+                !string.IsNullOrEmpty(this.Error.HelpLink)
+                ? Uri.EscapeUriString(this.Error.HelpLink)
+                : null);
         }
 
         public SarifErrorListItem Error { get; }

--- a/src/Sarif.Viewer.VisualStudio.Core/Models/RuleModel.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Models/RuleModel.cs
@@ -164,9 +164,9 @@ namespace Microsoft.Sarif.Viewer.Models
             get
             {
                 return this._descriptionInlines ??=
-                    string.IsNullOrWhiteSpace(this.Description) ?
-                    null :
-                    new ObservableCollection<XamlDoc.Inline>(SdkUIUtilities.GetMessageInlines(this.Description, this.InlineLink_Click));
+                    string.IsNullOrWhiteSpace(this.Description)
+                    ? null
+                    : new ObservableCollection<XamlDoc.Inline>(SdkUIUtilities.GetMessageInlines(this.Description, this.InlineLink_Click));
             }
         }
 

--- a/src/Sarif.Viewer.VisualStudio.Core/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Models/SarifErrorListItem.cs
@@ -8,15 +8,18 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Windows;
 
 using EnvDTE;
 
 using EnvDTE80;
 
 using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.Sarif.Viewer.ErrorList;
 using Microsoft.Sarif.Viewer.Models;
 using Microsoft.Sarif.Viewer.Sarif;
 using Microsoft.Sarif.Viewer.Tags;
+using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
@@ -284,8 +287,8 @@ namespace Microsoft.Sarif.Viewer
                                       this.RawMessage;
 
         [Browsable(false)]
-        public ObservableCollection<XamlDoc.Inline> MessageInlines => this._messageInlines
-            ?? (this._messageInlines = new ObservableCollection<XamlDoc.Inline>(SdkUIUtilities.GetInlinesForErrorMessage(this.RawMessage)));
+        public ObservableCollection<XamlDoc.Inline> MessageInlines => this._messageInlines ??=
+            new ObservableCollection<XamlDoc.Inline>(SdkUIUtilities.GetMessageInlines(this.RawMessage, this.MessageInlineLink_Click));
 
         [Browsable(false)]
         public bool HasEmbeddedLinks => this.MessageInlines.Any();
@@ -763,6 +766,70 @@ namespace Microsoft.Sarif.Viewer
             }
 
             return (text.TrimEnd(endChars), restText.TrimEnd(endChars));
+        }
+
+        internal void MessageInlineLink_Click(object sender, RoutedEventArgs e)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            if (!(sender is XamlDoc.Hyperlink hyperLink))
+            {
+                return;
+            }
+
+            if (hyperLink.Tag is int id)
+            {
+                // The user clicked an in-line link with an integer target. Look for a Location object
+                // whose Id property matches that integer. The spec says that might be _any_ Location
+                // object under the current result. At present, we only support Location objects that
+                // occur in Result.Locations or Result.RelatedLocations. So, for example, we don't
+                // look in Result.CodeFlows or Result.Stacks.
+                LocationModel location =
+                    this.RelatedLocations.
+                    Concat(this.Locations).
+                    FirstOrDefault(l => l.Id == id);
+
+                if (location == null)
+                {
+                    return;
+                }
+
+                // If a location is found, then we will show this error in the explorer window
+                // by setting the navigated item to the error related to this error entry,
+                // but... we will navigate the editor to the found location, which for example
+                // may be a related location.
+                if (this.HasDetails)
+                {
+                    var componentModel = (IComponentModel)Package.GetGlobalService(typeof(SComponentModel));
+                    if (componentModel != null)
+                    {
+                        ISarifErrorListEventSelectionService sarifSelectionService = componentModel.GetService<ISarifErrorListEventSelectionService>();
+                        if (sarifSelectionService != null)
+                        {
+                            sarifSelectionService.NavigatedItem = this;
+                        }
+                    }
+                }
+
+                location.NavigateTo(usePreviewPane: false, moveFocusToCaretLocation: true);
+            }
+
+            // This is super dangerous! We are launching URIs for SARIF logs
+            // that can point to anything.
+            // https://github.com/microsoft/sarif-visualstudio-extension/issues/171
+            else
+            {
+                string uriString = null;
+                if (hyperLink.Tag is string uriAsString)
+                {
+                    uriString = uriAsString;
+                }
+                else if (hyperLink.Tag is Uri uri)
+                {
+                    uriString = uri.ToString();
+                }
+
+                SdkUIUtilities.OpenExternalUrl(uriString);
+            }
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.Core/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Models/SarifErrorListItem.cs
@@ -783,10 +783,8 @@ namespace Microsoft.Sarif.Viewer
                 // object under the current result. At present, we only support Location objects that
                 // occur in Result.Locations or Result.RelatedLocations. So, for example, we don't
                 // look in Result.CodeFlows or Result.Stacks.
-                LocationModel location =
-                    this.RelatedLocations.
-                    Concat(this.Locations).
-                    FirstOrDefault(l => l.Id == id);
+                LocationModel location = this.RelatedLocations.Concat(this.Locations)
+                                                              .FirstOrDefault(l => l.Id == id);
 
                 if (location == null)
                 {

--- a/src/Sarif.Viewer.VisualStudio.Core/Themes/DefaultStyles.xaml
+++ b/src/Sarif.Viewer.VisualStudio.Core/Themes/DefaultStyles.xaml
@@ -11,6 +11,7 @@
     <converters:CollectionToBooleanConverter x:Key="CollectionToBooleanConverter" />
     <converters:CollectionToCountConverter x:Key="CollectionToCountConverter" />
     <converters:CollectionToVisibilityConverter x:Key="CollectionToVisibilityConverter" />
+    <converters:CollectionToInvertedVisibilityConverter x:Key="CollectionToInvertedVisibilityConverter" />
     <converters:MultipleStringsToVisibilityConverter x:Key="MultipleStringsToVisibilityConverter" />
     <converters:FileExistsToBooleanConverter x:Key="FileExistsToBooleanConverter" />
 

--- a/src/Sarif.Viewer.VisualStudio.Core/Views/Information.xaml
+++ b/src/Sarif.Viewer.VisualStudio.Core/Views/Information.xaml
@@ -70,9 +70,15 @@
                 <TextBlock Grid.Row="4"
                            Grid.Column="0"
                            Grid.ColumnSpan="2"
-                           Visibility="{Binding Rule.Description, Converter={StaticResource StringToVisibilityConverter}}"
+                           Visibility="{Binding Rule.ShowPlainDescription, Converter={StaticResource BooleanToVisiblityConverter}}"
                            Text="{Binding Rule.Description}"
                            Style="{StaticResource RuleDescriptionTextStyle}" />
+                <controls:BindableTextBlock Grid.Row="4"
+                                            Grid.Column="0"
+                                            Grid.ColumnSpan="2"
+                                            Visibility="{Binding Rule.DescriptionInlines, Converter={StaticResource CollectionToVisibilityConverter}, ConverterParameter=0}"
+                                            InlineList="{Binding Rule.DescriptionInlines}"
+                                            Style="{StaticResource RuleDescriptionTextStyle}"/>
                 <Separator Grid.Row="5"
                            Grid.Column="0"
                            Grid.ColumnSpan="2"

--- a/src/Sarif.Viewer.VisualStudio.Core/Views/SarifViewerControl.xaml
+++ b/src/Sarif.Viewer.VisualStudio.Core/Views/SarifViewerControl.xaml
@@ -58,6 +58,7 @@
                                                 TabIndex="1"
                                                 Style="{StaticResource RuleIdHyperlinkStyle}"/>
                     <TextBlock Text="{Binding Rule.Name, Mode=OneTime}"
+                               Visibility="{Binding Rule.DisplayName, Converter={StaticResource StringToVisibilityConverter}}"
                                AutomationProperties.Name="{Binding Rule.Name, Mode=OneTime, StringFormat=Rule name: {0}}"
                                Style="{StaticResource HeaderTextStyle}"/>
                     <TextBlock Text="|"
@@ -93,7 +94,12 @@
                     </DockPanel>
                 </DockPanel>
             </Border>
+            <TextBlock Grid.Row="2"
+                       Text="{Binding ShortMessage}"
+                       Visibility="{Binding MessageInlines, Converter={StaticResource CollectionToInvertedVisibilityConverter}, ConverterParameter=0}"
+                       Style="{StaticResource HeaderMessageTextStyle}" />
             <controls:BindableTextBlock Grid.Row="2"
+                                        Visibility="{Binding MessageInlines, Converter={StaticResource CollectionToVisibilityConverter}, ConverterParameter=0}"
                                         InlineList="{Binding MessageInlines}"
                                         Style="{StaticResource HeaderMessageTextStyle}"/>
         </Grid>

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Converters/CollectionToVisibilityConverterTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Converters/CollectionToVisibilityConverterTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
         [Fact]
         public void CollectionToVisibilityConverter_CollectionHasElements()
         {
-            List<int> testList = new List<int>();
+            var testList = new List<int>();
             testList.Add(1);
             int threshold = 0;
 
@@ -34,7 +34,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
         [Fact]
         public void CollectionToVisibilityConverter_CompareToThreshold()
         {
-            List<int> testList = new List<int>() { 1, 2, 3 };
+            var testList = new List<int>() { 1, 2, 3 };
             int threshold = 5;
 
             VerifyConversion(testList, threshold, Visibility.Collapsed);
@@ -61,7 +61,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
         [Fact]
         public void CollectionToVisibilityConverter_InvalidThreshold()
         {
-            List<int> testList = new List<int>() { 1, 2, 3 };
+            var testList = new List<int>() { 1, 2, 3 };
             bool threshold = false;
 
             VerifyConversion(testList, threshold, Visibility.Collapsed);
@@ -70,7 +70,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
         private static void VerifyConversion(IEnumerable<int> list, object threshold, Visibility expectedResult)
         {
             var converter = new CollectionToVisibilityConverter();
-            Visibility result = (Visibility)converter.Convert(list, typeof(List<int>), threshold, CultureInfo.CurrentCulture);
+            var result = (Visibility)converter.Convert(list, typeof(List<int>), threshold, CultureInfo.CurrentCulture);
             result.Should().Be(expectedResult);
 
             Visibility revertedResult = expectedResult switch

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Converters/CollectionToVisibilityConverterTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Converters/CollectionToVisibilityConverterTests.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Windows;
+
+using FluentAssertions;
+
+using Microsoft.Sarif.Viewer.Converters;
+
+using Xunit;
+
+namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
+{
+    public class CollectionToVisibilityConverterTests
+    {
+        [Fact]
+        public void CollectionToVisibilityConverter_CollectionHasElements()
+        {
+            List<int> testList = new List<int>();
+            testList.Add(1);
+            int threshold = 0;
+
+            VerifyConversion(testList, threshold, Visibility.Visible);
+
+            testList.Add(2);
+            testList.Add(3);
+            VerifyConversion(testList, threshold, Visibility.Visible);
+        }
+
+        [Fact]
+        public void CollectionToVisibilityConverter_CompareToThreshold()
+        {
+            List<int> testList = new List<int>() { 1, 2, 3 };
+            int threshold = 5;
+
+            VerifyConversion(testList, threshold, Visibility.Collapsed);
+
+            threshold = 3;
+            VerifyConversion(testList, threshold, Visibility.Collapsed);
+
+            threshold = 2;
+            VerifyConversion(testList, threshold, Visibility.Visible);
+        }
+
+        [Fact]
+        public void CollectionToVisibilityConverter_NonEmptyCollection()
+        {
+            IEnumerable<int> testList = null;
+            int threshold = 0;
+
+            VerifyConversion(testList, threshold, Visibility.Collapsed);
+
+            testList = Enumerable.Empty<int>();
+            VerifyConversion(testList, threshold, Visibility.Collapsed);
+        }
+
+        [Fact]
+        public void CollectionToVisibilityConverter_InvalidThreshold()
+        {
+            List<int> testList = new List<int>() { 1, 2, 3 };
+            bool threshold = false;
+
+            VerifyConversion(testList, threshold, Visibility.Collapsed);
+        }
+
+        private static void VerifyConversion(IEnumerable<int> list, object threshold, Visibility expectedResult)
+        {
+            var converter = new CollectionToVisibilityConverter();
+            Visibility result = (Visibility)converter.Convert(list, typeof(List<int>), threshold, CultureInfo.CurrentCulture);
+            result.Should().Be(expectedResult);
+
+            Visibility revertedResult = expectedResult switch
+            {
+                Visibility.Visible => Visibility.Collapsed,
+                Visibility.Collapsed => Visibility.Visible,
+                _ => throw new Exception(),
+            };
+            var revertedConverter = new CollectionToInvertedVisibilityConverter();
+            result = (Visibility)revertedConverter.Convert(list, typeof(List<int>), threshold, CultureInfo.CurrentCulture);
+            result.Should().Be(revertedResult);
+        }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
@@ -486,7 +486,9 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             item.MessageInlines.Count.Should().Be(2);
             item.MessageInlines[0].ContentStart.GetTextInRun(XamlDoc.LogicalDirection.Forward)
                 .Should().BeEquivalentTo("The quick brown fox. Jumps over the lazy dog. Reference to ");
-            item.MessageInlines[1].ContentStart.GetTextInRun(XamlDoc.LogicalDirection.Forward)
+
+            var hyperlink = item.MessageInlines[1] as XamlDoc.Hyperlink;
+            hyperlink.Inlines.First().ContentStart.GetTextInRun(XamlDoc.LogicalDirection.Forward)
                 .Should().BeEquivalentTo("docs");
         }
 
@@ -509,9 +511,11 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             // "The quick ", "brown", " fox. Jumps over the ", "lazy", " dog."
             item.MessageInlines.Count.Should().Be(5);
             item.MessageInlines[0].ContentStart.GetTextInRun(XamlDoc.LogicalDirection.Forward).Should().BeEquivalentTo("The quick ");
-            item.MessageInlines[1].ContentStart.GetTextInRun(XamlDoc.LogicalDirection.Forward).Should().BeEquivalentTo("brown");
+            var hyperlink = item.MessageInlines[1] as XamlDoc.Hyperlink;
+            hyperlink.Inlines.First().ContentStart.GetTextInRun(XamlDoc.LogicalDirection.Forward).Should().BeEquivalentTo("brown");
             item.MessageInlines[2].ContentStart.GetTextInRun(XamlDoc.LogicalDirection.Forward).Should().BeEquivalentTo(" fox. Jumps over the ");
-            item.MessageInlines[3].ContentStart.GetTextInRun(XamlDoc.LogicalDirection.Forward).Should().BeEquivalentTo("lazy");
+            hyperlink = item.MessageInlines[3] as XamlDoc.Hyperlink;
+            hyperlink.Inlines.First().ContentStart.GetTextInRun(XamlDoc.LogicalDirection.Forward).Should().BeEquivalentTo("lazy");
             item.MessageInlines[4].ContentStart.GetTextInRun(XamlDoc.LogicalDirection.Forward).Should().BeEquivalentTo(" dog.");
 
         }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
@@ -46,6 +46,7 @@
   <ItemGroup>
     <Compile Include="CodeAnalysisResultManagerTests.cs" />
     <Compile Include="ConverterResourceTests.cs" />
+    <Compile Include="Converters\CollectionToVisibilityConverterTests.cs" />
     <Compile Include="ErrorList\ErrorListServiceTests.cs" />
     <Compile Include="ErrorList\MultipleRunsPerSarifTests.cs" />
     <Compile Include="ErrorList\SarifErrorListItemTests.cs" />


### PR DESCRIPTION
Current extension display SARIF result's message and rule description text in SARIF explorer. If the text contains markdown hyperlinks, it either displays the raw markdown text or the hyperlink does not work.

The change is to support display clickable hyperlink text in SARIF explorer, the hyperlink will work the same way as in error lists.

Below are screenshots show difference before/after the change.
![image](https://user-images.githubusercontent.com/76094515/144536173-0c9006b1-ce7c-4fe0-8669-090a62dd7e2f.png)
