### PR TITLE
Defer loading additional properties

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/SarifErrorListEventProcessor.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/SarifErrorListEventProcessor.cs
@@ -131,6 +131,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             if (this.TryGetSarifResult(entry, out SarifErrorListItem aboutToNavigateItem) &&
                 aboutToNavigateItem?.HasDetails == true)
             {
+                aboutToNavigateItem.PopulateAdditionalPropertiesIfNot();
                 SarifExplorerWindow.Find()?.Show();
             }
         }

--- a/src/Sarif.Viewer.VisualStudio.Core/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Models/SarifErrorListItem.cs
@@ -109,57 +109,6 @@ namespace Microsoft.Sarif.Viewer
                 this.LineNumber = this.Region.StartLine;
                 this.ColumnNumber = this.Region.StartColumn;
             }
-
-            if (result.Locations?.Any() == true)
-            {
-                // Adding in reverse order will make them display in the correct order in the UI.
-                for (int i = result.Locations.Count - 1; i >= 0; --i)
-                {
-                    this.Locations.Add(result.Locations[i].ToLocationModel(run, resultId: this.ResultId, runIndex: this.RunIndex));
-                }
-            }
-
-            if (result.RelatedLocations?.Any() == true)
-            {
-                for (int i = result.RelatedLocations.Count - 1; i >= 0; --i)
-                {
-                    this.RelatedLocations.Add(result.RelatedLocations[i].ToLocationModel(run, resultId: this.ResultId, runIndex: this.RunIndex));
-                }
-            }
-
-            if (result.CodeFlows != null)
-            {
-                foreach (CodeFlow codeFlow in result.CodeFlows)
-                {
-                    var analysisStep = codeFlow.ToAnalysisStep(run, resultId: this.ResultId, runIndex: this.RunIndex);
-                    if (analysisStep != null)
-                    {
-                        this.AnalysisSteps.Add(analysisStep);
-                    }
-                }
-
-                this.AnalysisSteps.Verbosity = 100;
-                this.AnalysisSteps.IntelligentExpand();
-            }
-
-            if (result.Stacks != null)
-            {
-                foreach (Stack stack in result.Stacks)
-                {
-                    this.Stacks.Add(stack.ToStackCollection(resultId: this.ResultId, runIndex: this.RunIndex));
-                }
-            }
-
-            if (result.PropertyNames?.Any() == true)
-            {
-                foreach (string propertyName in result.PropertyNames)
-                {
-                    this.Properties.Add(
-                        new KeyValuePair<string, string>(
-                            propertyName,
-                            result.GetSerializedPropertyValue(propertyName)));
-                }
-            }
         }
 
         /// <summary>
@@ -391,7 +340,11 @@ namespace Microsoft.Sarif.Viewer
         public ObservableCollection<KeyValuePair<string, string>> Properties { get; }
 
         [Browsable(false)]
-        public bool HasDetails => this.Locations.Any() || this.RelatedLocations.Any() || this.AnalysisSteps.Any() || this.Stacks.Any() || this.Fixes.Any();
+        public bool HasDetails => this.SarifResult.Locations?.Any() == true ||
+                                  this.SarifResult.RelatedLocations?.Any() == true ||
+                                  this.SarifResult.CodeFlows?.Any() == true ||
+                                  this.SarifResult.Stacks?.Any() == true ||
+                                  this.SarifResult.Fixes?.Any() == true;
 
         [Browsable(false)]
         public int LocationsCount => this.Locations.Count + this.RelatedLocations.Count;
@@ -613,6 +566,67 @@ namespace Microsoft.Sarif.Viewer
                     {
                         this.Fixes.Add(fix.ToFixModel(this.SarifResult.Run.OriginalUriBaseIds, FileRegionsCache.Instance));
                     }
+                }
+            }
+        }
+
+        internal void PopulateAdditionalPropertiesIfNot()
+        {
+            if (!SarifViewerPackage.IsUnitTesting)
+            {
+#pragma warning disable VSTHRD108 // Assert thread affinity unconditionally
+                ThreadHelper.ThrowIfNotOnUIThread();
+#pragma warning restore VSTHRD108
+            }
+
+            if (this.SarifResult.Locations?.Any() == true && this.Locations?.Any() == false)
+            {
+                // Adding in reverse order will make them display in the correct order in the UI.
+                for (int i = this.SarifResult.Locations.Count - 1; i >= 0; --i)
+                {
+                    this.Locations.Add(this.SarifResult.Locations[i].ToLocationModel(this.SarifResult.Run, resultId: this.ResultId, runIndex: this.RunIndex));
+                }
+            }
+
+            if (this.SarifResult.RelatedLocations?.Any() == true && this.RelatedLocations?.Any() == false)
+            {
+                for (int i = this.SarifResult.RelatedLocations.Count - 1; i >= 0; --i)
+                {
+                    this.RelatedLocations.Add(this.SarifResult.RelatedLocations[i].ToLocationModel(this.SarifResult.Run, resultId: this.ResultId, runIndex: this.RunIndex));
+                }
+            }
+
+            if (this.SarifResult.Stacks?.Any() == true && this.Stacks?.Any() == false)
+            {
+                foreach (Stack stack in this.SarifResult.Stacks)
+                {
+                    this.Stacks.Add(stack.ToStackCollection(resultId: this.ResultId, runIndex: this.RunIndex));
+                }
+            }
+
+            if (this.SarifResult.CodeFlows?.Any() == true && this.AnalysisSteps?.Any() == false)
+            {
+                foreach (CodeFlow codeFlow in this.SarifResult.CodeFlows)
+                {
+                    var analysisStep = codeFlow.ToAnalysisStep(this.SarifResult.Run, resultId: this.ResultId, runIndex: this.RunIndex);
+                    if (analysisStep != null)
+                    {
+                        this.AnalysisSteps.Add(analysisStep);
+                    }
+                }
+
+                this.AnalysisSteps.Verbosity = 100;
+                this.AnalysisSteps.IntelligentExpand();
+            }
+
+            if (this.SarifResult.PropertyNames?.Any() == true && this.Properties?.Any() == false)
+            {
+                foreach (string propertyName in this.SarifResult.PropertyNames)
+                {
+                    this.Properties.Add(
+                        new KeyValuePair<string, string>(
+                            propertyName,
+                            this.SarifResult.GetSerializedPropertyValue(propertyName)));
                 }
             }
         }

--- a/src/Sarif.Viewer.VisualStudio.Core/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Models/SarifErrorListItem.cs
@@ -340,11 +340,11 @@ namespace Microsoft.Sarif.Viewer
         public ObservableCollection<KeyValuePair<string, string>> Properties { get; }
 
         [Browsable(false)]
-        public bool HasDetails => this.SarifResult.Locations?.Any() == true ||
-                                  this.SarifResult.RelatedLocations?.Any() == true ||
-                                  this.SarifResult.CodeFlows?.Any() == true ||
+        public bool HasDetails => this.SarifResult.Fixes?.Any() == true ||
                                   this.SarifResult.Stacks?.Any() == true ||
-                                  this.SarifResult.Fixes?.Any() == true;
+                                  this.SarifResult.CodeFlows?.Any() == true ||
+                                  this.SarifResult.Locations?.Any() == true ||
+                                  this.SarifResult.RelatedLocations?.Any() == true;
 
         [Browsable(false)]
         public int LocationsCount => this.Locations.Count + this.RelatedLocations.Count;

--- a/src/Sarif.Viewer.VisualStudio.Core/Sarif.Viewer.VisualStudio.Core.projitems
+++ b/src/Sarif.Viewer.VisualStudio.Core/Sarif.Viewer.VisualStudio.Core.projitems
@@ -302,7 +302,4 @@
       <SubType>Designer</SubType>
     </Page>
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="$(MSBuildThisFileDirectory)License.txt" />
-  </ItemGroup>
 </Project>

--- a/src/Sarif.Viewer.VisualStudio.Core/Sarif/CodeFlow.Extensions.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Sarif/CodeFlow.Extensions.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Sarif.Viewer.Sarif
 
         public static AnalysisStep ToAnalysisStep(this CodeFlow codeFlow, Run run, int resultId, int runIndex)
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
+            // ThreadHelper.ThrowIfNotOnUIThread();
 
             if (codeFlow.ThreadFlows?[0]?.Locations?.Count == 0)
             {

--- a/src/Sarif.Viewer.VisualStudio.Core/Sarif/CodeFlow.Extensions.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Sarif/CodeFlow.Extensions.cs
@@ -39,8 +39,6 @@ namespace Microsoft.Sarif.Viewer.Sarif
 
         public static AnalysisStep ToAnalysisStep(this CodeFlow codeFlow, Run run, int resultId, int runIndex)
         {
-            // ThreadHelper.ThrowIfNotOnUIThread();
-
             if (codeFlow.ThreadFlows?[0]?.Locations?.Count == 0)
             {
                 return null;

--- a/src/Sarif.Viewer.VisualStudio.Core/Sarif/StackFrame.Extensions.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Sarif/StackFrame.Extensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Sarif.Viewer.Sarif
         {
             var model = new StackFrameModel(resultId, runIndex);
 
-            model.FullyQualifiedLogicalName = stackFrame.Location.LogicalLocation.FullyQualifiedName;
+            model.FullyQualifiedLogicalName = stackFrame.Location?.LogicalLocation?.FullyQualifiedName;
             model.Message = stackFrame.Location?.Message?.Text;
             model.Module = stackFrame.Module;
 

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
@@ -791,6 +791,91 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         }
 
         [Fact]
+        public void SarifErrorListItem_WithAdditionalProperties_ShouldDeferLoading()
+        {
+            string moduleName = "Microsoft.CodeAnalysis.Sarif.PatternMatcher.AnalyzeCommand";
+            string relatedLocationString = "location related to the issue";
+            var result = new Result
+            {
+                Locations = new List<Location>
+                {
+                    new Location
+                    {
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            ArtifactLocation = new ArtifactLocation { Uri = new Uri("path/to/file", UriKind.Relative) },
+                        },
+                    },
+                },
+                RelatedLocations = new List<Location>
+                {
+                    new Location
+                    {
+                        Message = new Message { Text = relatedLocationString },
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            ArtifactLocation = new ArtifactLocation { Description = new Message { Text = relatedLocationString } },
+                        },
+                    },
+                    new Location
+                    {
+                        Message = new Message { Text = relatedLocationString },
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            ArtifactLocation = new ArtifactLocation { Description = new Message { Text = relatedLocationString } },
+                        },
+                    },
+                    new Location
+                    {
+                        Message = new Message { Text = relatedLocationString },
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            ArtifactLocation = new ArtifactLocation { Description = new Message { Text = relatedLocationString } },
+                        },
+                    },
+                },
+                Stacks = new List<Stack>
+                {
+                    new Stack
+                    {
+                        Frames = new List<StackFrame>
+                        {
+                            new StackFrame { Module = moduleName },
+                        },
+                    },
+                },
+                CodeFlows = new List<CodeFlow>
+                {
+                    new CodeFlow
+                    {
+                        Message = new Message { Text = "'*Temp_value_#8086' is not initialized" },
+                    },
+                    new CodeFlow
+                    {
+                        Message = new Message { Text = "'*Temp_value_#8086' is used, but may not have been initialized" },
+                    },
+                },
+            };
+
+            SarifErrorListItem item = MakeErrorListItem(result);
+            item.Locations.Should().BeEmpty();
+            item.RelatedLocations.Should().BeEmpty();
+            item.Stacks.Should().BeEmpty();
+            item.AnalysisSteps.Should().BeEmpty();
+
+            item.PopulateAdditionalPropertiesIfNot();
+
+            item.Locations.Count.Should().Be(1);
+            item.Locations.First().FilePath.Should().BeEquivalentTo("path/to/file");
+            item.RelatedLocations.Count.Should().Be(3);
+            item.RelatedLocations.First().Message.Should().BeEquivalentTo(relatedLocationString);
+            item.Stacks.Count.Should().Be(1);
+            item.Stacks.First().First().Module.Should().BeEquivalentTo(moduleName);
+            item.AnalysisSteps.Count.Should().Be(2);
+            item.AnalysisSteps.Verbosity.Should().Be(100);
+        }
+
+        [Fact]
         public void SarifErrorListItem_WithPropertyBags_HasProperties()
         {
             var result = new Result();
@@ -802,6 +887,9 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             result.SetProperty<dynamic>("object", new { foo = "bar" });
 
             SarifErrorListItem item = MakeErrorListItem(result);
+            item.Properties.Should().BeEmpty();
+
+            item.PopulateAdditionalPropertiesIfNot();
 
             item.Properties.Should().NotBeNull();
             item.Properties.Count.Should().Be(6);

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Sarif\LocationExtensionsTest.cs" />
     <Compile Include="Sarif\ReplacementExtensionsTests.cs" />
     <Compile Include="Sarif\RunExtensionsTests.cs" />
+    <Compile Include="Sarif\StackFrameExtensionsTests.cs" />
     <Compile Include="SdkUIUtilitiesTests.cs" />
     <Compile Include="StringBuilderFileStreamMock.cs" />
     <Compile Include="SuppressionTests.cs" />

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif/StackFrameExtensionsTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif/StackFrameExtensionsTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 Location = new Location
                 {
                     Message = new Message { Text = "stack frame location 1" },
-                    LogicalLocation = new LogicalLocation 
+                    LogicalLocation = new LogicalLocation
                     {
                         FullyQualifiedName = @"\root\FQDN\path-to\file.ext",
                     },

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif/StackFrameExtensionsTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif/StackFrameExtensionsTests.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.Sarif.Viewer.Sarif;
+
+using Xunit;
+
+namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
+{
+    public class StackFrameExtensionsTests
+    {
+        [Fact]
+        public void StackFrameExtensions_HasNoLocation_ShouldNotThrowException()
+        {
+            int resultId = 1;
+            int runIndex = 0;
+            string moduleName = "Test.Module";
+            var stackFrame = new StackFrame
+            {
+                Module = moduleName,
+            };
+
+            var stackFrameModel = stackFrame.ToStackFrameModel(resultId, runIndex);
+            stackFrameModel.Should().NotBeNull();
+            stackFrameModel.ResultId.Should().Be(resultId);
+            stackFrameModel.RunIndex.Should().Be(runIndex);
+            stackFrameModel.Module.Should().BeEquivalentTo(moduleName);
+            stackFrameModel.Message.Should().BeNull();
+            stackFrameModel.FullyQualifiedLogicalName.Should().BeNull();
+            stackFrameModel.FilePath.Should().BeNull();
+            stackFrameModel.Region.Should().BeNull();
+            stackFrameModel.Address.Should().Be(0);
+            stackFrameModel.Line.Should().Be(0);
+            stackFrameModel.Column.Should().Be(0);
+            stackFrameModel.Offset.Should().Be(0);
+        }
+
+        [Fact]
+        public void StackFrameExtensions_HasLocation()
+        {
+            int resultId = 1;
+            int runIndex = 0;
+            var stackFrame = new StackFrame
+            {
+                Location = new Location
+                {
+                    Message = new Message { Text = "stack frame location 1" },
+                    LogicalLocation = new LogicalLocation 
+                    {
+                        FullyQualifiedName = @"\root\FQDN\path-to\file.ext",
+                    },
+                    PhysicalLocation = new PhysicalLocation
+                    {
+                        Address = new Address
+                        {
+                            AbsoluteAddress = 0xFF,
+                            OffsetFromParent = 128,
+                        },
+                        ArtifactLocation = new ArtifactLocation
+                        {
+                            Uri = new Uri("path/to/file.cpp", UriKind.Relative),
+                        },
+                        Region = new Region
+                        {
+                            StartLine = 10,
+                            StartColumn = 5,
+                        },
+                    }
+                }
+            };
+
+            var stackFrameModel = stackFrame.ToStackFrameModel(resultId, runIndex);
+            stackFrameModel.Should().NotBeNull();
+            stackFrameModel.ResultId.Should().Be(resultId);
+            stackFrameModel.RunIndex.Should().Be(runIndex);
+            stackFrameModel.Module.Should().BeNull();
+            stackFrameModel.Message.Should().BeEquivalentTo("stack frame location 1");
+            stackFrameModel.FullyQualifiedLogicalName.Should().BeEquivalentTo(@"\root\FQDN\path-to\file.ext");
+            stackFrameModel.FilePath.Should().BeEquivalentTo("path/to/file.cpp");
+            stackFrameModel.Region.Should().NotBeNull();
+            stackFrameModel.Region.StartLine.Should().Be(10);
+            stackFrameModel.Region.StartColumn.Should().Be(5);
+            stackFrameModel.Address.Should().Be(0xFF);
+            stackFrameModel.Line.Should().Be(10);
+            stackFrameModel.Column.Should().Be(5);
+            stackFrameModel.Offset.Should().Be(128);
+        }
+
+    }
+}


### PR DESCRIPTION
The properties of SARIF results: Locations/RelatedLocations/Stacks/CodeFlows(AnalysisSteps)/PropertyBags are not needed when loading SARIF results into Error List. They can be populated when the data are needed, like before SARIF explorer display result details.
