### PR TITLE
Fix CodeFlows/ThreadFlows rendering issue

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/CodeFlowToTreeConverter.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/CodeFlowToTreeConverter.cs
@@ -87,12 +87,11 @@ namespace Microsoft.Sarif.Viewer.VisualStudio
                 {
                     ArtifactLocation artifactLocation = location.Location?.PhysicalLocation?.ArtifactLocation;
 
-                    if (artifactLocation != null)
+                    if (artifactLocation != null
+                        && artifactLocation.Uri == null
+                        && artifactLocation.Index > -1)
                     {
-                        if (artifactLocation.Uri == null && artifactLocation.Index > -1)
-                        {
-                            artifactLocation.Uri = run.Artifacts[artifactLocation.Index].Location.Uri;
-                        }
+                        artifactLocation.Uri = run.Artifacts[artifactLocation.Index].Location.Uri;
                     }
 
                     var newNode = new AnalysisStepNode(resultId: resultId, runIndex: runIndex)

--- a/src/Sarif.Viewer.VisualStudio.Core/Converters/AnalysisStepNodeToTextConverter.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Converters/AnalysisStepNodeToTextConverter.cs
@@ -11,8 +11,6 @@ namespace Microsoft.Sarif.Viewer.Converters
 {
     internal class AnalysisStepNodeToTextConverter : IValueConverter
     {
-        internal static readonly char IndentChar = ' ';
-
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
             var node = value as AnalysisStepNode;
@@ -48,12 +46,6 @@ namespace Microsoft.Sarif.Viewer.Converters
                 else
                 {
                     text = Resources.ContinuingAnalysisStepNodeMessage;
-                }
-
-                if (node.NestingLevel >= 0)
-                {
-                    // add indents to beginning of text based on nestingLevel property
-                    text = new string(IndentChar, node.NestingLevel) + text;
                 }
             }
 

--- a/src/Sarif.Viewer.VisualStudio.Core/Converters/AnalysisStepNodeToTextConverter.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Converters/AnalysisStepNodeToTextConverter.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Sarif.Viewer.Converters
 {
     internal class AnalysisStepNodeToTextConverter : IValueConverter
     {
+        internal static readonly char IndentChar = ' ';
+
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
             var node = value as AnalysisStepNode;
@@ -46,6 +48,12 @@ namespace Microsoft.Sarif.Viewer.Converters
                 else
                 {
                     text = Resources.ContinuingAnalysisStepNodeMessage;
+                }
+
+                if (node.NestingLevel >= 0)
+                {
+                    // add indents to beginning of text based on nestingLevel property
+                    text = new string(IndentChar, node.NestingLevel) + text;
                 }
             }
 

--- a/src/Sarif.Viewer.VisualStudio.Core/Models/AnalysisStepNode.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Models/AnalysisStepNode.cs
@@ -174,6 +174,9 @@ namespace Microsoft.Sarif.Viewer.Models
         public List<AnalysisStepNode> Children { get; set; }
 
         [Browsable(false)]
+        public int NestingLevel { get; set; }
+
+        [Browsable(false)]
         public AnalysisStep AnalysisStep
         {
             get

--- a/src/Sarif.Viewer.VisualStudio.Core/Models/AnalysisStepNode.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Models/AnalysisStepNode.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
@@ -16,11 +15,15 @@ namespace Microsoft.Sarif.Viewer.Models
 {
     internal class AnalysisStepNode : CodeLocationObject
     {
+        internal const int IndentWidth = 10; // indent width 10 pixel
+
         private ThreadFlowLocation _location;
         private AnalysisStep _analysisStep;
         private AnalysisStepNode _parent;
         private bool _isExpanded;
         private Visibility _visbility;
+        private int _nestingLevel;
+        private Thickness _textMargin;
 
         public AnalysisStepNode(int resultId, int runIndex)
             : base(resultId, runIndex)
@@ -174,7 +177,18 @@ namespace Microsoft.Sarif.Viewer.Models
         public List<AnalysisStepNode> Children { get; set; }
 
         [Browsable(false)]
-        public int NestingLevel { get; set; }
+        public int NestingLevel
+        {
+            get => this._nestingLevel;
+            set
+            {
+                this._textMargin.Left = IndentWidth * value;
+                this._nestingLevel = value;
+            }
+        }
+
+        [Browsable(false)]
+        public Thickness TextMargin => _textMargin;
 
         [Browsable(false)]
         public AnalysisStep AnalysisStep

--- a/src/Sarif.Viewer.VisualStudio.Core/Sarif/CodeFlow.Extensions.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Sarif/CodeFlow.Extensions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Sarif.Viewer.Sarif
                 return null;
             }
 
-            List<AnalysisStepNode> topLevelNodes = CodeFlowToTreeConverter.Convert(codeFlow, run, resultId, runIndex);
+            List<AnalysisStepNode> topLevelNodes = CodeFlowToTreeConverter.ToFlatList(codeFlow, run, resultId, runIndex);
 
             return new AnalysisStep(topLevelNodes);
         }

--- a/src/Sarif.Viewer.VisualStudio.Core/Themes/AnalysisStepsStyles.xaml
+++ b/src/Sarif.Viewer.VisualStudio.Core/Themes/AnalysisStepsStyles.xaml
@@ -82,6 +82,7 @@
     <Style x:Key="AnalysisStepMessageTextStyle" BasedOn="{StaticResource AnalysisStepTextStyle}" TargetType="TextBlock">
         <Setter Property="Foreground" Value="{DynamicResource {x:Static vs_shell:EnvironmentColors.ToolWindowTextBrushKey}}"/>
         <Setter Property="FontWeight" Value="Normal" />
+        <Setter Property="Margin" Value="{Binding TextMargin}" />
         <Style.Triggers>
             <DataTrigger Binding="{Binding Location.Importance}" Value="Essential">
                 <Setter Property="FontWeight" Value="Bold" />

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Converters/AnalysisStepNodeToTextConverterTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Converters/AnalysisStepNodeToTextConverterTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Globalization;
 
 using FluentAssertions;
@@ -16,8 +15,6 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
 {
     public class AnalysisStepNodeToTextConverterTests
     {
-        private static readonly Random random = new Random();
-
         [Fact]
         public void AnalysisStepNodeToTextConverter_HandlesLocationMessage()
         {
@@ -25,7 +22,6 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
 
             var analysisStepNode = new AnalysisStepNode(resultId: 0, runIndex: 0)
             {
-                NestingLevel = GetRandomLevel(),
                 Location = new ThreadFlowLocation
                 {
                     Location = new Location
@@ -55,7 +51,6 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
 
             var analysisStepNode = new AnalysisStepNode(resultId: 0, runIndex: 0)
             {
-                NestingLevel = GetRandomLevel(),
                 Location = new ThreadFlowLocation
                 {
                     Location = new Location
@@ -83,7 +78,6 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
         {
             var analysisStepNode = new AnalysisStepNode(resultId: 0, runIndex: 0)
             {
-                NestingLevel = GetRandomLevel(),
                 Location = new ThreadFlowLocation
                 {
                     Location = new Location
@@ -110,7 +104,6 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
 
             var analysisStepNode = new AnalysisStepNode(resultId: 0, runIndex: 0)
             {
-                NestingLevel = GetRandomLevel(),
                 Location = new ThreadFlowLocation
                 {
                     Location = new Location
@@ -145,7 +138,6 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
 
             var analysisStepNode = new AnalysisStepNode(resultId: 0, runIndex: 0)
             {
-                // NestingLevel = 0
                 Location = new ThreadFlowLocation
                 {
                     Location = new Location
@@ -172,59 +164,13 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
             VerifyConversion(analysisStepNode, snippet.Trim());
         }
 
-        [Fact]
-        public void AnalysisStepNodeToTextConverter_HandlesNestingLevelIndents()
-        {
-            const string message = "my_function";
-
-            var analysisStepNode = new AnalysisStepNode(resultId: 0, runIndex: 0)
-            {
-                NestingLevel = GetRandomLevel(),
-                Location = new ThreadFlowLocation
-                {
-                    Location = new Location
-                    {
-                        Message = new Message
-                        {
-                            Text = message,
-                        },
-                        PhysicalLocation = new PhysicalLocation
-                        {
-                            Region = new Region
-                            {
-                                StartLine = 42,
-                            },
-                        },
-                    },
-                },
-            };
-
-            VerifyConversion(analysisStepNode, message);
-        }
-
-        private static int GetRandomLevel(int minLevel = 0, int maxLevel = 30)
-        {
-            return random.Next(minLevel, maxLevel); // [min, max)
-        }
-
         private static void VerifyConversion(AnalysisStepNode analysisStepNode, string expectedText)
         {
             var converter = new AnalysisStepNodeToTextConverter();
 
             string text = (string)converter.Convert(analysisStepNode, typeof(string), null, CultureInfo.CurrentCulture);
 
-            if (analysisStepNode.NestingLevel > 0)
-            {
-                string prefix = new string(AnalysisStepNodeToTextConverter.IndentChar, analysisStepNode.NestingLevel);
-
-                text.StartsWith(prefix).Should().BeTrue();
-
-                (prefix + expectedText).Should().Be(text);
-            }
-            else
-            {
-                text.Should().Be(expectedText);
-            }
+            text.Should().Be(expectedText);
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Converters/AnalysisStepNodeToTextConverterTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Converters/AnalysisStepNodeToTextConverterTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Globalization;
 
 using FluentAssertions;
@@ -15,6 +16,8 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
 {
     public class AnalysisStepNodeToTextConverterTests
     {
+        private static readonly Random random = new Random();
+
         [Fact]
         public void AnalysisStepNodeToTextConverter_HandlesLocationMessage()
         {
@@ -22,6 +25,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
 
             var analysisStepNode = new AnalysisStepNode(resultId: 0, runIndex: 0)
             {
+                NestingLevel = GetRandomLevel(),
                 Location = new ThreadFlowLocation
                 {
                     Location = new Location
@@ -51,6 +55,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
 
             var analysisStepNode = new AnalysisStepNode(resultId: 0, runIndex: 0)
             {
+                NestingLevel = GetRandomLevel(),
                 Location = new ThreadFlowLocation
                 {
                     Location = new Location
@@ -78,6 +83,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
         {
             var analysisStepNode = new AnalysisStepNode(resultId: 0, runIndex: 0)
             {
+                NestingLevel = GetRandomLevel(),
                 Location = new ThreadFlowLocation
                 {
                     Location = new Location
@@ -104,6 +110,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
 
             var analysisStepNode = new AnalysisStepNode(resultId: 0, runIndex: 0)
             {
+                NestingLevel = GetRandomLevel(),
                 Location = new ThreadFlowLocation
                 {
                     Location = new Location
@@ -138,6 +145,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
 
             var analysisStepNode = new AnalysisStepNode(resultId: 0, runIndex: 0)
             {
+                // NestingLevel = 0
                 Location = new ThreadFlowLocation
                 {
                     Location = new Location
@@ -164,13 +172,59 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
             VerifyConversion(analysisStepNode, snippet.Trim());
         }
 
+        [Fact]
+        public void AnalysisStepNodeToTextConverter_HandlesNestingLevelIndents()
+        {
+            const string message = "my_function";
+
+            var analysisStepNode = new AnalysisStepNode(resultId: 0, runIndex: 0)
+            {
+                NestingLevel = GetRandomLevel(),
+                Location = new ThreadFlowLocation
+                {
+                    Location = new Location
+                    {
+                        Message = new Message
+                        {
+                            Text = message,
+                        },
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            Region = new Region
+                            {
+                                StartLine = 42,
+                            },
+                        },
+                    },
+                },
+            };
+
+            VerifyConversion(analysisStepNode, message);
+        }
+
+        private static int GetRandomLevel(int minLevel = 0, int maxLevel = 30)
+        {
+            return random.Next(minLevel, maxLevel); // [min, max)
+        }
+
         private static void VerifyConversion(AnalysisStepNode analysisStepNode, string expectedText)
         {
             var converter = new AnalysisStepNodeToTextConverter();
 
             string text = (string)converter.Convert(analysisStepNode, typeof(string), null, CultureInfo.CurrentCulture);
 
-            text.Should().Be(expectedText);
+            if (analysisStepNode.NestingLevel > 0)
+            {
+                string prefix = new string(AnalysisStepNodeToTextConverter.IndentChar, analysisStepNode.NestingLevel);
+
+                text.StartsWith(prefix).Should().BeTrue();
+
+                (prefix + expectedText).Should().Be(text);
+            }
+            else
+            {
+                text.Should().Be(expectedText);
+            }
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Models/AnalysisStepNodeTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Models/AnalysisStepNodeTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Sarif.Viewer.Models
 {
     public class AnalysisStepNodeTests
     {
-        private static readonly Random random = new Random();
+        private static readonly Random s_random = new Random();
 
         [Fact]
         public void AnalysisStepNode_DefaultHighlightColor()
@@ -57,7 +57,7 @@ namespace Microsoft.Sarif.Viewer.Models
             analysisStepNode.TextMargin.Top.Should().Be(0);
             analysisStepNode.TextMargin.Bottom.Should().Be(0);
 
-            analysisStepNode.NestingLevel = random.Next(0, 30);
+            analysisStepNode.NestingLevel = s_random.Next(0, 30);
 
             analysisStepNode.TextMargin.Left.Should().Be(AnalysisStepNode.IndentWidth * analysisStepNode.NestingLevel);
             analysisStepNode.TextMargin.Right.Should().Be(0);

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Models/AnalysisStepNodeTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Models/AnalysisStepNodeTests.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Windows;
+
 using FluentAssertions;
 
 using Microsoft.CodeAnalysis.Sarif;
@@ -11,6 +14,8 @@ namespace Microsoft.Sarif.Viewer.Models
 {
     public class AnalysisStepNodeTests
     {
+        private static readonly Random random = new Random();
+
         [Fact]
         public void AnalysisStepNode_DefaultHighlightColor()
         {
@@ -39,6 +44,25 @@ namespace Microsoft.Sarif.Viewer.Models
 
             analysisStepNode.Location.Importance = ThreadFlowLocationImportance.Essential;
             analysisStepNode.SelectedSourceHighlightColor.Should().Be("CodeAnalysisCurrentStatementSelection");
+        }
+
+        [Fact]
+        public void AnalysisStepNode_TextMargin()
+        {
+            var analysisStepNode = new AnalysisStepNode(resultId: 0, runIndex: 0);
+
+            analysisStepNode.TextMargin.Should().NotBeNull();
+            analysisStepNode.TextMargin.Left.Should().Be(0);
+            analysisStepNode.TextMargin.Right.Should().Be(0);
+            analysisStepNode.TextMargin.Top.Should().Be(0);
+            analysisStepNode.TextMargin.Bottom.Should().Be(0);
+
+            analysisStepNode.NestingLevel = random.Next(0, 30);
+
+            analysisStepNode.TextMargin.Left.Should().Be(AnalysisStepNode.IndentWidth * analysisStepNode.NestingLevel);
+            analysisStepNode.TextMargin.Right.Should().Be(0);
+            analysisStepNode.TextMargin.Top.Should().Be(0);
+            analysisStepNode.TextMargin.Bottom.Should().Be(0);
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ThreadFlowToTreeConverterTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ThreadFlowToTreeConverterTests.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using FluentAssertions;
 
@@ -17,7 +19,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         [Fact]
         public void CanConvertCodeFlowToTree()
         {
-            var codeFlow = SarifUtilities.CreateSingleThreadedCodeFlow(new[]
+            CodeFlow codeFlow = SarifUtilities.CreateSingleThreadedCodeFlow(new[]
             {
                 new ThreadFlowLocation
                 {
@@ -125,12 +127,15 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             topLevelNodes[0].Children[3].Parent.Location.Location.Message.Text.Should().Be("first parent");
             topLevelNodes[1].Parent.Should().Be(null);
             topLevelNodes[1].Children[0].Parent.Location.Location.Message.Text.Should().Be("fifth parent");
+
+            List<AnalysisStepNode> flatNodes = CodeFlowToTreeConverter.ToFlatList(codeFlow, run: null, resultId: 0, runIndex: 0);
+            VerifyCodeFlowFlatList(flatNodes, codeFlow, run: null);
         }
 
         [Fact]
         public void CanConvertCodeFlowToTreeNonCallOrReturn()
         {
-            var codeFlow = SarifUtilities.CreateSingleThreadedCodeFlow(new[]
+            CodeFlow codeFlow = SarifUtilities.CreateSingleThreadedCodeFlow(new[]
             {
                 new ThreadFlowLocation
                 {
@@ -207,12 +212,15 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             topLevelNodes[1].Children[0].Parent.Location.Location.Message.Text.Should().Be("second parent");
             topLevelNodes[1].Children[1].Parent.Location.Location.Message.Text.Should().Be("second parent");
             topLevelNodes[1].Children[2].Parent.Location.Location.Message.Text.Should().Be("second parent");
+
+            List<AnalysisStepNode> flatNodes = CodeFlowToTreeConverter.ToFlatList(codeFlow, run: null, resultId: 0, runIndex: 0);
+            VerifyCodeFlowFlatList(flatNodes, codeFlow, run: null);
         }
 
         [Fact]
         public void CanConvertCodeFlowToTreeOnlyDeclarations()
         {
-            var codeFlow = SarifUtilities.CreateSingleThreadedCodeFlow(new[]
+            CodeFlow codeFlow = SarifUtilities.CreateSingleThreadedCodeFlow(new[]
             {
                 new ThreadFlowLocation
                 {
@@ -242,6 +250,314 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             topLevelNodes[0].Parent.Should().Be(null);
             topLevelNodes[1].Parent.Should().Be(null);
             topLevelNodes[2].Parent.Should().Be(null);
+
+            List<AnalysisStepNode> flatNodes = CodeFlowToTreeConverter.ToFlatList(codeFlow, run: null, resultId: 0, runIndex: 0);
+            VerifyCodeFlowFlatList(flatNodes, codeFlow, run: null);
+        }
+
+        [Fact]
+        public void CanConvertCodeFlowToFlatListZeroBasedLevel()
+        {
+            CodeFlow codeFlow = SarifUtilities.CreateSingleThreadedCodeFlow(new[]
+            {
+                new ThreadFlowLocation
+                {
+                    NestingLevel = 0,
+                    Location = new Location
+                    {
+                        Message = new Message
+                        {
+                            Text = "location level 0",
+                        },
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            ArtifactLocation = new ArtifactLocation
+                            {
+                                Uri = new Uri("path/to/file.cpp", UriKind.Relative),
+                            }
+                        },
+                    },
+                },
+                new ThreadFlowLocation
+                {
+                    NestingLevel = 1,
+                    Location = new Location
+                    {
+                        Message = new Message
+                        {
+                            Text = "location level 1",
+                        },
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            ArtifactLocation = new ArtifactLocation
+                            {
+                                Uri = new Uri("path/to/file.cpp", UriKind.Relative),
+                            }
+                        },
+                    },
+                },
+                new ThreadFlowLocation
+                {
+                    NestingLevel = 2,
+                },
+                new ThreadFlowLocation
+                {
+                    NestingLevel = 1,
+                    Location = new Location
+                    {
+                        Message = new Message
+                        {
+                            Text = "location level 1",
+                        },
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            ArtifactLocation = new ArtifactLocation
+                            {
+                                Uri = new Uri("path/to/file.cpp", UriKind.Relative),
+                            }
+                        },
+                    },
+                },
+                new ThreadFlowLocation
+                {
+                    NestingLevel = 2,
+                },
+                new ThreadFlowLocation
+                {
+                    NestingLevel = 1,
+                    Location = new Location
+                    {
+                        Message = new Message
+                        {
+                            Text = "location level 1",
+                        },
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            ArtifactLocation = new ArtifactLocation
+                            {
+                                Uri = new Uri("path/to/file.cpp", UriKind.Relative),
+                            }
+                        },
+                    },
+                },
+                new ThreadFlowLocation
+                {
+                    NestingLevel = 2,
+                },
+                new ThreadFlowLocation
+                {
+                    NestingLevel = 1,
+                },
+                new ThreadFlowLocation
+                {
+                    NestingLevel = 0,
+                    Location = new Location
+                    {
+                        Message = new Message
+                        {
+                            Text = "location level 0",
+                        },
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            ArtifactLocation = new ArtifactLocation
+                            {
+                                Uri = new Uri("path/to/file.cpp", UriKind.Relative),
+                            }
+                        },
+                    },
+                },
+                new ThreadFlowLocation
+                {
+                    NestingLevel = 1,
+                },
+            });
+
+            List<AnalysisStepNode> nodes = CodeFlowToTreeConverter.ToFlatList(codeFlow, run: null, resultId: 0, runIndex: 0);
+            VerifyCodeFlowFlatList(nodes, codeFlow, run: null);
+        }
+
+        [Fact]
+        public void CanConvertCodeFlowToFlatListNonZeroBasedLevel()
+        {
+            CodeFlow codeFlow = SarifUtilities.CreateSingleThreadedCodeFlow(new[]
+            {
+                new ThreadFlowLocation
+                {
+                    NestingLevel = 5,
+                    Location = new Location
+                    {
+                        Message = new Message
+                        {
+                            Text = "location level 5",
+                        },
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            ArtifactLocation = new ArtifactLocation
+                            {
+                                Index = 0,
+                            }
+                        },
+                    },
+                },
+                new ThreadFlowLocation
+                {
+                    NestingLevel = 6,
+                    Location = new Location
+                    {
+                        Message = new Message
+                        {
+                            Text = "location level 6",
+                        },
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            ArtifactLocation = new ArtifactLocation
+                            {
+                                Index = 0,
+                            }
+                        },
+                    },
+                },
+                new ThreadFlowLocation
+                {
+                    NestingLevel = 7,
+                    Location = new Location
+                    {
+                        Message = new Message
+                        {
+                            Text = "location level 7",
+                        },
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            ArtifactLocation = new ArtifactLocation
+                            {
+                                Index = 0,
+                            }
+                        },
+                    },
+                },
+                new ThreadFlowLocation
+                {
+                    NestingLevel = 8,
+                    Location = new Location
+                    {
+                        Message = new Message
+                        {
+                            Text = "location level 8",
+                        },
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            ArtifactLocation = new ArtifactLocation
+                            {
+                                Index = 0,
+                            }
+                        },
+                    },
+                },
+                new ThreadFlowLocation
+                {
+                    NestingLevel = 7,
+                },
+                new ThreadFlowLocation
+                {
+                    NestingLevel = 6,
+                },
+                new ThreadFlowLocation
+                {
+                    NestingLevel = 5,
+                },
+                new ThreadFlowLocation
+                {
+                    NestingLevel = 5,
+                    Location = new Location
+                    {
+                        Message = new Message
+                        {
+                            Text = "location level 5",
+                        },
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            ArtifactLocation = new ArtifactLocation
+                            {
+                                Index = 1
+                            }
+                        },
+                    },
+                },
+                new ThreadFlowLocation
+                {
+                    NestingLevel = 5,
+                    Location = new Location
+                    {
+                        Message = new Message
+                        {
+                            Text = "location level 5",
+                        },
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            ArtifactLocation = new ArtifactLocation
+                            {
+                                Index = 2
+                            }
+                        },
+                    },
+                },
+            });
+
+            var run = new Run
+            {
+                Artifacts = new[]
+                {
+                    new Artifact { Location = new ArtifactLocation { Uri = new Uri("path/to/file1.cpp", UriKind.Relative), } },
+                    new Artifact { Location = new ArtifactLocation { Uri = new Uri("path/to/file2.cpp", UriKind.Relative), } },
+                    new Artifact { Location = new ArtifactLocation { Uri = new Uri("path/to/file3.cpp", UriKind.Relative), } },
+                },
+            };
+            List<AnalysisStepNode> nodes = CodeFlowToTreeConverter.ToFlatList(codeFlow, run, resultId: 0, runIndex: 0);
+            VerifyCodeFlowFlatList(nodes, codeFlow, run: null);
+        }
+
+        private void VerifyCodeFlowFlatList(IList<AnalysisStepNode> analysisStepNodes, CodeFlow codeFlow, Run run)
+        {
+            ThreadFlow threadFlow = codeFlow?.ThreadFlows?[0];
+            if (threadFlow != null)
+            {
+                analysisStepNodes.Should().NotBeEmpty();
+                analysisStepNodes.Count.Should().Be(threadFlow.Locations.Count);
+
+                int minLevel = threadFlow.Locations.Min(l => l.NestingLevel);
+
+                for (int i = 0; i < analysisStepNodes.Count; i++)
+                {
+                    AnalysisStepNode node = analysisStepNodes[i];
+                    ThreadFlowLocation location = threadFlow.Locations[i];
+
+                    node.Parent.Should().BeNull(); // flat list item doesn't have parent
+
+                    ArtifactLocation artifactLocation = location.Location?.PhysicalLocation?.ArtifactLocation;
+                    if (artifactLocation != null)
+                    {
+                        if (artifactLocation.Uri == null)
+                        {
+                            if (artifactLocation.Index > -1 && run?.Artifacts != null)
+                            {
+                                node.Location.Location.PhysicalLocation.ArtifactLocation.Uri
+                                    .Should()
+                                    .Be(run.Artifacts[artifactLocation.Index].Location.Uri);
+                            }
+                        }
+                        else
+                        {
+                            node.Location.Location.PhysicalLocation.ArtifactLocation.Uri.Should().Be(artifactLocation.Uri);
+                        }
+                    }
+
+                    node.NestingLevel.Should().Be(location.NestingLevel - minLevel);
+                }
+            }
+            else
+            {
+                analysisStepNodes.Should().BeEmpty();
+            }
         }
     }
 }


### PR DESCRIPTION
# Description

The viewer fails to render code/thread flows in SARIF explorer in certain scenarios even it is a valid SARIF file, e.g. the first element of thread flow locations has nesting level does not start at 0. 
This is due to the code logic builds thread flow location list into parent/child hierarchy based on nesting level, it assumes first element should be root node and nesting level always starts with 0.


# Fixes

After discussing with team, the customers don't have a requirement to see the code/thread flows in parent/child hierarchy.
Also, to be consistent with VS code viewer's UX, decided to change current way rendering code/thread flows in tree view, to the way rendering them in flat list. And adding indents before the list item label to present the nesting level.

screenshot:
![image](https://user-images.githubusercontent.com/76094515/149401407-39273d03-a330-4264-ae7f-54e497756c85.png)

related to #449 