### PR TITLE
Enable navigation for code flow / thread flow locations

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/Models/AnalysisStepNode.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Models/AnalysisStepNode.cs
@@ -9,6 +9,7 @@ using System.Windows;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.Converters;
 using Microsoft.Sarif.Viewer.Sarif;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text.Adornments;
 
 namespace Microsoft.Sarif.Viewer.Models
@@ -24,6 +25,7 @@ namespace Microsoft.Sarif.Viewer.Models
         private Visibility _visbility;
         private int _nestingLevel;
         private Thickness _textMargin;
+        private DelegateCommand _navigateCommand;
 
         public AnalysisStepNode(int resultId, int runIndex)
             : base(resultId, runIndex)
@@ -425,6 +427,26 @@ namespace Microsoft.Sarif.Viewer.Models
                     child.SetVerbosity(importance);
                 }
             }
+        }
+
+        public DelegateCommand NavigateCommand
+        {
+            get
+            {
+                this._navigateCommand ??= new DelegateCommand(this.Navigate);
+                return this._navigateCommand;
+            }
+
+            set
+            {
+                this._navigateCommand = value;
+            }
+        }
+
+        private void Navigate()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            this.NavigateTo(usePreviewPane: true, moveFocusToCaretLocation: false);
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.Core/Views/AnalysisSteps.xaml
+++ b/src/Sarif.Viewer.VisualStudio.Core/Views/AnalysisSteps.xaml
@@ -97,7 +97,7 @@
                                         </Grid.ColumnDefinitions>
                                         <Grid.InputBindings>
                                             <MouseBinding Gesture="LeftDoubleClick"
-                                                                  Command="{Binding NavigateCommand}"/>
+                                                          Command="{Binding NavigateCommand}"/>
                                         </Grid.InputBindings>
                                         <TextBlock Grid.Column="0"
                                                    Text="{Binding Converter={StaticResource AnalysisStepNodeToTextConverter}}"

--- a/src/Sarif.Viewer.VisualStudio.Core/Views/AnalysisSteps.xaml
+++ b/src/Sarif.Viewer.VisualStudio.Core/Views/AnalysisSteps.xaml
@@ -95,6 +95,10 @@
                                             <ColumnDefinition SharedSizeGroup="MessageGroup" />
                                             <ColumnDefinition SharedSizeGroup="LocationGroup" />
                                         </Grid.ColumnDefinitions>
+                                        <Grid.InputBindings>
+                                            <MouseBinding Gesture="LeftDoubleClick"
+                                                                  Command="{Binding NavigateCommand}"/>
+                                        </Grid.InputBindings>
                                         <TextBlock Grid.Column="0"
                                                    Text="{Binding Converter={StaticResource AnalysisStepNodeToTextConverter}}"
                                                    Style="{StaticResource AnalysisStepMessageTextStyle}" />


### PR DESCRIPTION
# Descriptions
Result's codeflow / threadflow locations can have source file location data. User should be able to navigate to the corresponding location by double clicking the item in "Analysis Step" tab (the same behavior to navigate to source file by double clicking error list item). Currently this functionality is not added.

# Fixes
`AnalysisStepNode` (ThreadFlowLocation) is already derived from `CodeLocationObject` base class, resolving file path code already there for `AnalysisStepNode`. Just need to hook up with WPF event trigger.

I don't have a good way to unit test it. Will add Apex UI automation tests for it. Please let me know if any good idea about unit testing it.

Related to #458 

