### PR TITLE
Fix bug not able to navigate to source file under solution

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/CodeAnalysisResultManager.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/CodeAnalysisResultManager.cs
@@ -442,7 +442,7 @@ namespace Microsoft.Sarif.Viewer
 
             var sourceUri = new Uri(fileUrl);
             string relativeLocalPath = localRelativeFilePath ?? sourceUri.LocalPath;
-            relativeLocalPath = relativeLocalPath.Replace('/', '\\').TrimStart('\\');
+            relativeLocalPath = NormalizeFilePath(relativeLocalPath).TrimStart('\\');
 
             string destinationFile = Path.Combine(workingDirectory, relativeLocalPath);
             string destinationDirectory = Path.GetDirectoryName(destinationFile);
@@ -789,7 +789,7 @@ namespace Microsoft.Sarif.Viewer
                     return false;
                 }
 
-                pathFromLogFile = pathFromLogFile.Replace('/', '\\');
+                pathFromLogFile = NormalizeFilePath(pathFromLogFile);
                 string fileToSearch = Path.GetFileName(pathFromLogFile);
                 IEnumerable<string> searchResults = fileSystem.DirectoryEnumerateFiles(solutionPath, fileToSearch, SearchOption.AllDirectories);
                 searchResults = searchResults.Where(path => path.EndsWith(pathFromLogFile, StringComparison.OrdinalIgnoreCase));
@@ -862,6 +862,7 @@ namespace Microsoft.Sarif.Viewer
 
             // Traverse our remappings and see if we can
             // make rebaseline from existing data
+            pathFromLogFile = NormalizeFilePath(pathFromLogFile);
             foreach (Tuple<string, string> remapping in dataCache.RemappedPathPrefixes)
             {
                 string remapped;
@@ -958,7 +959,7 @@ namespace Microsoft.Sarif.Viewer
                 }
             }
 
-            string commonSuffix = GetCommonSuffix(pathFromLogFile.Replace("/", @"\"), resolvedPath);
+            string commonSuffix = GetCommonSuffix(NormalizeFilePath(pathFromLogFile), resolvedPath);
             if (commonSuffix == null)
             {
                 return false;
@@ -969,7 +970,7 @@ namespace Microsoft.Sarif.Viewer
             string originalPrefix = pathFromLogFile.Substring(0, pathFromLogFile.Length - commonSuffix.Length);
             string resolvedPrefix = resolvedPath.Substring(0, resolvedPath.Length - commonSuffix.Length);
 
-            int uriBaseIdEndIndex = resolvedPath.IndexOf(originalPath.Replace("/", @"\"));
+            int uriBaseIdEndIndex = resolvedPath.IndexOf(NormalizeFilePath(originalPath));
 
             if (!string.IsNullOrEmpty(uriBaseId) && relativeUri != null && uriBaseIdEndIndex >= 0)
             {
@@ -1049,6 +1050,11 @@ namespace Microsoft.Sarif.Viewer
             {
                 return HashHelper.GenerateHash(stream);
             }
+        }
+
+        private static string NormalizeFilePath(string path)
+        {
+            return path?.Replace('/', Path.DirectorySeparatorChar);
         }
 
         internal static string GetSolutionPath(DTE2 dte, IVsFolderWorkspaceService workspaceService)

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/CodeAnalysisResultManagerTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/CodeAnalysisResultManagerTests.cs
@@ -283,7 +283,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             const string ResultArtifactPath1 = @"Sarif/Notes.cs";
             const string ResultArtifactPath2 = @"Sarif/OffsetInfo.cs";
             const string SolutionPath = @"D:\Users\John\source\sarif-sdk\src";
-            string ExpectedResolvedPath1 = Path.Combine(SolutionPath, "Sarif","Notes.cs");
+            string ExpectedResolvedPath1 = Path.Combine(SolutionPath, "Sarif", "Notes.cs");
             string ExpectedResolvedPath2 = Path.Combine(SolutionPath, "Sarif", "OffsetInfo.cs");
             this.existingFiles.Add(ExpectedResolvedPath1);
             this.existingFiles.Add(ExpectedResolvedPath2);

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/CodeAnalysisResultManagerTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/CodeAnalysisResultManagerTests.cs
@@ -283,8 +283,8 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             const string ResultArtifactPath1 = @"Sarif/Notes.cs";
             const string ResultArtifactPath2 = @"Sarif/OffsetInfo.cs";
             const string SolutionPath = @"D:\Users\John\source\sarif-sdk\src";
-            const string ExpectedResolvedPath1 = SolutionPath + @"\Sarif\Notes.cs";
-            const string ExpectedResolvedPath2 = SolutionPath + @"\Sarif\OffsetInfo.cs";
+            string ExpectedResolvedPath1 = Path.Combine(SolutionPath, "Sarif","Notes.cs");
+            string ExpectedResolvedPath2 = Path.Combine(SolutionPath, "Sarif", "OffsetInfo.cs");
             this.existingFiles.Add(ExpectedResolvedPath1);
             this.existingFiles.Add(ExpectedResolvedPath2);
 


### PR DESCRIPTION
# Description

When users open a Sarif log file with the solution opened in VS, they cannot navigate to the source file except the first result they double clicked. The inline hyper-links only work for the first result they clicked.

Below is the root cause analysis:
1. When first time navigate to an error list item (Sarif result), the extension tries to resolve the result's file location.
2. The matched file is found in the solution folder and the extension navigates to the file. It also caches the solution path in a remapping table.
3. If navigate to another result the extension checks if any existing path in the remapping table and try to use the cached path to find the matched file. 
The result's file path is in URI format "src/sarif-sdk/src/Sarif/Autogenerated/AddressEqualityComparer.cs"
The cached solution path is in file system format "C:\\repo\\github.com\\binskim"
And the combined path is "C:\\repo\\github.com\\binskim\\src/sarif-sdk/src/Sarif/Autogenerated/AddressEqualityComparer.cs", which causes issue in the following code.
4. Hyperlinks doesn't work due to the same issue.

# Fixes:
In the function `TryResolveFilePathFromRemappings` called in the step 3 above, change the file path to file system format before combines with cached path.

