### PR TITLE
Expose internal types to Apex test project

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.2022/Properties/AssemblyInfo.cs
+++ b/src/Sarif.Viewer.VisualStudio.2022/Properties/AssemblyInfo.cs
@@ -12,3 +12,4 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 [assembly: InternalsVisibleTo("Sarif.Viewer.VisualStudio.UnitTests")]
+[assembly: InternalsVisibleTo("Sarif.Viewer.VisualStudio.Tests.Apex")]

--- a/src/Sarif.Viewer.VisualStudio/Properties/AssemblyInfo.cs
+++ b/src/Sarif.Viewer.VisualStudio/Properties/AssemblyInfo.cs
@@ -12,3 +12,4 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 [assembly: InternalsVisibleTo("Sarif.Viewer.VisualStudio.UnitTests")]
+[assembly: InternalsVisibleTo("Sarif.Viewer.VisualStudio.Tests.Apex")]


### PR DESCRIPTION
# Description

The Apex test project needs to access some internal members of the visual studio extension classes. Added back the "InternalsVisibleTo" attribute for the apex test project.