### PR TITLE
Enable expanding/collapsing error list items if with long message

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,5 +1,33 @@
 # SARIF Viewer Visual Studio extension Release History
 
+## To Be Released
+## [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
+* BUGFIX: Error list expando for long message does not work.
+* FEATURE: Generate Popup from Xaml.
+
+## [SARIFER](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifer)
+* Publish official release to marketplace.
+* Enable Spam Analyzer Dynamic Mode.
+
+## **3.0.66.61165** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
+* BUGFIX: Not able to navigate to source file under solution.
+
+## **3.0.59** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
+* BUGFIX: Enable navigation for code flow / thread flow locations.
+
+## **v3.0.42** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
+* BUGFIX: Align suppression logic with SARIF-SDK.
+
+## **v3.0.38** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
+* BUGFIX: Handle empty temporary solution path.
+
+## **v3.0.25** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
+* BUGFIX: Checking if file hash matches.
+
+## **v3.0.16** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
+* Update submodule version.
+* Fix test failure.
+
 ## **v2.1.20** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
 * Implement light bulb fixes for SARIF errors.
 * Build for .NET Framework 4.7.2 rather than 4.6.1. This is in preparation for adding some features which require NuGet packages which support only 4.7.2.

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -5,11 +5,11 @@
 * BUGFIX: Error list expando for long message does not work.
 * FEATURE: Generate Popup from Xaml.
 
-## [SARIFER](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifer)
+## **3.0.73** [SARIFER](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifer)
 * Publish official release to marketplace.
 * Enable Spam Analyzer Dynamic Mode.
 
-## **3.0.66.61165** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
+## **3.0.66** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
 * BUGFIX: Not able to navigate to source file under solution.
 
 ## **3.0.59** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)

--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/SarifResultTableEntry.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/SarifResultTableEntry.cs
@@ -5,10 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
 
 using EnvDTE;
 
 using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.Sarif.Viewer.Controls;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell.TableControl;
 using Microsoft.VisualStudio.Shell.TableManager;
@@ -18,6 +22,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
     internal sealed class SarifResultTableEntry : WpfTableEntryBase, IDisposable
     {
         internal const string SuppressionStateColumnName = "suppression";
+        internal const string FullTextInlinesColumnName = "FullTextInlines";
 
         private bool isDisposed;
 
@@ -113,6 +118,11 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                 ? SdkUIUtilities.GetMessageInlines(this.Error.ShortMessage, this.Error.MessageInlineLink_Click)
                 : null);
 
+            this.columnKeyToContent[FullTextInlinesColumnName] = new Lazy<object>(() =>
+                this.Error.MessageInlines?.Any() == true
+                ? SdkUIUtilities.GetMessageInlines(this.Error.RawMessage, this.Error.MessageInlineLink_Click)
+                : null);
+
             this.columnKeyToContent[StandardTableKeyNames.Text] = new Lazy<object>(() =>
                 SdkUIUtilities.UnescapeBrackets(this.Error.ShortMessage));
 
@@ -147,6 +157,23 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
             content = null;
             return false;
+        }
+
+        public override bool TryCreateDetailsContent(out FrameworkElement expandedContent)
+        {
+            if (this.TryGetValue(FullTextInlinesColumnName, out object content)
+                && content is List<Inline> inlines
+                && inlines?.Any() == true)
+            {
+                expandedContent = new BindableTextBlock()
+                {
+                    TextWrapping = TextWrapping.Wrap,
+                    InlineList = new ObservableCollection<Inline>(inlines),
+                };
+                return true;
+            }
+
+            return base.TryCreateDetailsContent(out expandedContent);
         }
 
         public override bool TrySetValue(string keyName, object content) => false;

--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/SarifResultTableEntry.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/SarifResultTableEntry.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             // Error.MessageInlines is already binded to an element in SARIF explorer.
             this.columnKeyToContent[StandardTableKeyNames2.TextInlines] = new Lazy<object>(() =>
                 this.Error.MessageInlines?.Any() == true
-                ? SdkUIUtilities.GetMessageInlines(this.Error.RawMessage, this.Error.MessageInlineLink_Click)
+                ? SdkUIUtilities.GetMessageInlines(this.Error.ShortMessage, this.Error.MessageInlineLink_Click)
                 : null);
 
             this.columnKeyToContent[StandardTableKeyNames.Text] = new Lazy<object>(() =>

--- a/src/Sarif.Viewer.VisualStudio.Core/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Models/SarifErrorListItem.cs
@@ -94,8 +94,8 @@ namespace Microsoft.Sarif.Viewer
             this.WorkingDirectory = Path.Combine(Path.GetTempPath(), this.RunIndex.ToString());
             this.HelpLink = this.Rule?.HelpUri;
 
-            this.RawMessage = result.GetMessageText(rule);
-            this.ShortMessage = this.RawMessage;
+            this.RawMessage = result.GetMessageText(rule, concise: false).Trim();
+            this.ShortMessage = result.GetMessageText(rule, concise: true, maxLength: 165).Trim();
             this.Message = this.RawMessage;
 
             string xamlContent = null;
@@ -168,7 +168,7 @@ namespace Microsoft.Sarif.Viewer
 
             run.TryGetRule(ruleId, out ReportingDescriptor rule);
             this.RawMessage = notification.Message.Text?.Trim() ?? string.Empty;
-            this.ShortMessage = this.RawMessage;
+            this.ShortMessage = ExtensionMethods.GetFirstSentence(this.RawMessage);
             this.Message = this.RawMessage;
 
             this.Level = notification.Level;

--- a/src/Sarif.Viewer.VisualStudio.Core/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Models/SarifErrorListItem.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Sarif.Viewer
     internal class SarifErrorListItem : NotifyPropertyChangedObject, IDisposable
     {
         // max length of concise text, 0 indexed
-        internal static int MaxConcisedTextLength = 165;
+        internal static int MaxConcisedTextLength = 150;
         internal static string XamlPropertyName = "Xaml";
 
         // Contains the result Id that will be incremented and assigned to new instances of <see cref="SarifErrorListItem"/>.
@@ -244,7 +244,7 @@ namespace Microsoft.Sarif.Viewer
 
         [Browsable(false)]
         public ObservableCollection<XamlDoc.Inline> MessageInlines => this._messageInlines ??=
-            new ObservableCollection<XamlDoc.Inline>(SdkUIUtilities.GetMessageInlines(this.ShortMessage, this.MessageInlineLink_Click));
+            new ObservableCollection<XamlDoc.Inline>(SdkUIUtilities.GetMessageInlines(this.RawMessage, this.MessageInlineLink_Click));
 
         [Browsable(false)]
         public bool HasEmbeddedLinks => this.MessageInlines.Any();

--- a/src/Sarif.Viewer.VisualStudio.Core/SdkUiUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/SdkUiUtilities.cs
@@ -746,7 +746,7 @@ namespace Microsoft.Sarif.Viewer
                 sb.Length = maxLength;
             }
 
-            // Replace the remaining intact links
+            // Restore the remaining intact links
             foreach (Match match in matches)
             {
                 Group group = match.Groups[hyperlinkGroup];
@@ -754,7 +754,6 @@ namespace Microsoft.Sarif.Viewer
                 {
                     if (maxLength > 0 && match.Index + group.Length <= sb.Length)
                     {
-                        string text = group.Value;
                         sb = sb.Remove(match.Index, group.Length);
                         sb = sb.Insert(match.Index, match.Value);
                         maxLength += match.Value.Length - group.Length;

--- a/src/Sarif.Viewer.VisualStudio.Core/SdkUiUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/SdkUiUtilities.cs
@@ -701,6 +701,89 @@ namespace Microsoft.Sarif.Viewer
             return stringBuilder.ToString();
         }
 
+        internal static (string, string) SplitResultMessage(string input, int maxLength)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                return (input, input);
+            }
+
+            const string ellipsis = "\u2026";
+            const string hyperlinkGroup = "link_text";
+            string pattern = string.Format(@"\[(?<{0}>[\w \.]+)\]\(([\w\.:\/ ]*)\)", hyperlinkGroup);
+
+            MatchCollection matches = Regex.Matches(input, pattern, RegexOptions.Multiline);
+            var sb = new StringBuilder(input);
+
+            // Replace the hyperlinks with only their text
+            for (int i = matches.Count - 1; i >= 0; i--)
+            {
+                Match match = matches[i];
+
+                // match.Groups.TryGetValue only available in .net 5/.net core 3.0 or above
+                Group group = match.Groups[hyperlinkGroup];
+                if (group != null && group.Success)
+                {
+                    string text = group.Value;
+                    sb = sb.Remove(match.Index, match.Length);
+                    sb = sb.Insert(match.Index, text);
+                }
+            }
+
+            // whole string the hyperlinks are replaced with plain texts
+            string plainText = AppendEndPunctuation(sb.ToString());
+
+            string firstSentence = ExtensionMethods.GetFirstSentence(sb.ToString());
+
+            // ExtensionMethods.GetFirstSentence has an issue it appends '.' even the string ends with other punctuations '!' or '?'
+            firstSentence = AppendEndPunctuation(firstSentence.TrimEnd('.'));
+            sb = new StringBuilder(firstSentence);
+
+            bool addEllipsis = maxLength > 0 && sb.Length > maxLength;
+
+            if (addEllipsis)
+            {
+                // Truncate the string
+                sb.Length = maxLength;
+            }
+
+            // Replace the remaining intact links
+            foreach (Match match in matches)
+            {
+                Group group = match.Groups[hyperlinkGroup];
+                if (group != null && group.Success)
+                {
+                    if (maxLength > 0 && match.Index + group.Length <= sb.Length)
+                    {
+                        string text = group.Value;
+                        sb = sb.Remove(match.Index, group.Length);
+                        sb = sb.Insert(match.Index, match.Value);
+                        maxLength += match.Value.Length - group.Length;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+
+            if (addEllipsis)
+            {
+                sb.Append(ellipsis);
+            }
+
+            return (sb.ToString(), plainText);
+        }
+
+        internal static string AppendEndPunctuation(string input)
+        {
+            char[] endChars = { '\r', '\n', ' ', };
+            char[] endPunctuations = { '.', '?', '!' };
+
+            input.TrimEnd(endChars);
+            return endPunctuations.Contains(input.Last()) ? input : input + ".";
+        }
+
         /// <summary>
         /// Removes escape backslashes that were used to suppress embedded linking.
         /// </summary>

--- a/src/Sarif.Viewer.VisualStudio.Core/SdkUiUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/SdkUiUtilities.cs
@@ -710,7 +710,7 @@ namespace Microsoft.Sarif.Viewer
 
             const string ellipsis = "\u2026";
             const string hyperlinkGroup = "link_text";
-            string pattern = string.Format(@"\[(?<{0}>[\w \.]+)\]\(([\w\.:\/ ]*)\)", hyperlinkGroup);
+            string pattern = $"\\[(?<{hyperlinkGroup}>[\\w \\.]+)\\]\\(([\\w\\.:\\/ ]*)\\)";
 
             MatchCollection matches = Regex.Matches(input, pattern, RegexOptions.Multiline);
             var sb = new StringBuilder(input);
@@ -730,8 +730,7 @@ namespace Microsoft.Sarif.Viewer
                 }
             }
 
-            // whole string the hyperlinks are replaced with plain texts
-            string plainText = AppendEndPunctuation(sb.ToString());
+            string fullText = AppendEndPunctuation(input);
 
             string firstSentence = ExtensionMethods.GetFirstSentence(sb.ToString());
 
@@ -772,7 +771,7 @@ namespace Microsoft.Sarif.Viewer
                 sb.Append(ellipsis);
             }
 
-            return (sb.ToString(), plainText);
+            return (sb.ToString(), fullText);
         }
 
         internal static string AppendEndPunctuation(string input)

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         {
             var result = new Result();
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
 
             item.Message.Should().Be(string.Empty);
         }
@@ -103,7 +103,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 Tool = new Tool(),
             };
 
-            SarifErrorListItem item = MakeErrorListItem(run, result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(run, result);
 
             item.Message.Should().Be(string.Empty);
         }
@@ -137,7 +137,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
 
-            SarifErrorListItem item = MakeErrorListItem(run, result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(run, result);
 
             item.Message.Should().Be(string.Empty);
         }
@@ -175,7 +175,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
 
-            SarifErrorListItem item = MakeErrorListItem(run, result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(run, result);
 
             item.Message.Should().Be(string.Empty);
         }
@@ -217,7 +217,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
 
-            SarifErrorListItem item = MakeErrorListItem(run, result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(run, result);
 
             item.Message.Should().Be("Hello, Mary!");
         }
@@ -256,7 +256,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
             item.Fixes.Should().BeEmpty();
             item.PopulateFixModelsIfNot();
             item.Fixes.Should().NotBeEmpty();
@@ -288,7 +288,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
 
-            SarifErrorListItem item = MakeErrorListItem(run, result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(run, result);
             item.Fixes.Should().BeEmpty();
             item.PopulateFixModelsIfNot();
             item.Fixes.Should().BeEmpty();
@@ -317,7 +317,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
 
-            SarifErrorListItem item = MakeErrorListItem(run, result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(run, result);
 
             item.Rule.Id.Should().Be("TST0001");
         }
@@ -349,7 +349,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
 
-            SarifErrorListItem item = MakeErrorListItem(run, result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(run, result);
 
             item.Message.Should().Be(string.Empty);
         }
@@ -367,7 +367,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
 
             item.Message.Should().Be($"{s1} {s2}");
             item.ShortMessage.Should().Be($"{s1}");
@@ -385,7 +385,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
             item.Message.Should().Be($"{s1}.");
             item.ShortMessage.Should().Be($"{s1}.");
         }
@@ -402,7 +402,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
             int breakPoistion = SarifErrorListItem.MaxConcisedTextLength;
             item.ShortMessage.Length.Should().Be(breakPoistion + 1); // horizontal ellipsis chars is added at end "\u2026"
             item.ShortMessage.Last().ToString().Should().Be("\u2026");
@@ -423,7 +423,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
             int breakPoistion = SarifErrorListItem.MaxConcisedTextLength;
             item.ShortMessage.Length.Should().Be(breakPoistion + 1); // add ellipsis
             item.Message.Length.Should().Be(200 + 1); // add end punctuation
@@ -442,7 +442,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
             int breakPoistion = 165; // 0 indexed
             item.ShortMessage.Length.Should().Be(breakPoistion + 2); // 2 chars is added at end " \u2026"
             item.ShortMessage.Substring(0, breakPoistion).Should().Be(s1.Substring(0, breakPoistion));
@@ -463,7 +463,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
             int breakPoistion = 159; // 0 indexed
             item.ShortMessage.Length.Should().Be(breakPoistion + 2); // the space break the text will be removed
             item.Message.Length.Should().Be(200 - breakPoistion - 2); // last space is trimmed
@@ -483,7 +483,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
             item.Message.Should().Be(s0);
             item.ShortMessage.Should().Be(s0);
         }
@@ -500,7 +500,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
 
             // short message should be the first sentence "The quick brown fox."
             item.HasEmbeddedLinks.Should().BeTrue();
@@ -523,7 +523,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
             item.HasEmbeddedLinks.Should().BeTrue();
 
             // "The quick ", "brown", " fox.", "Jumps over the ", "lazy", " dog."
@@ -571,7 +571,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
 
-            SarifErrorListItem item = MakeErrorListItem(run, result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(run, result);
 
             item.HelpLink.Should().NotBeNull();
             item.HelpLink.Should().BeEquivalentTo(link);
@@ -594,7 +594,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
 
-            item = MakeErrorListItem(run, result);
+            item = TestUtilities.MakeErrorListItem(run, result);
             item.HelpLink.Should().BeNull();
         }
 
@@ -607,7 +607,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 Level = FailureLevel.None,
             };
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
             item.Level.Should().Be(FailureLevel.Note);
         }
 
@@ -620,7 +620,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 Level = FailureLevel.None,
             };
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
             item.Level.Should().Be(FailureLevel.Note);
         }
 
@@ -633,7 +633,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 Level = FailureLevel.None,
             };
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
             item.Level.Should().Be(FailureLevel.Note);
         }
 
@@ -646,7 +646,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 Level = FailureLevel.None,
             };
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
             item.Level.Should().Be(FailureLevel.Warning);
         }
 
@@ -659,7 +659,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 Level = FailureLevel.None,
             };
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
             item.Level.Should().Be(FailureLevel.Warning);
         }
 
@@ -672,7 +672,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 Kind = ResultKind.Fail,
             };
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
             item.Level.Should().Be(FailureLevel.Error);
         }
 
@@ -681,7 +681,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         {
             var result = new Result();
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
 
             item.IsFixable().Should().BeFalse();
         }
@@ -738,7 +738,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
             CodeAnalysisResultManager.Instance.RunIndexToRunDataCache.Add(item.RunIndex, new RunDataCache());
             item.Fixes.Should().BeEmpty();
             item.PopulateFixModelsIfNot();
@@ -798,7 +798,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
 
             item.IsFixable().Should().BeFalse();
         }
@@ -808,7 +808,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
         {
             var result = new Result();
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
 
             item.Properties.Should().NotBeNull();
             item.Properties.Should().BeEmpty();
@@ -881,7 +881,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 },
             };
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
             item.Locations.Should().BeEmpty();
             item.RelatedLocations.Should().BeEmpty();
             item.Stacks.Should().BeEmpty();
@@ -910,7 +910,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             result.SetProperty<object>("nullObj", null);
             result.SetProperty<dynamic>("object", new { foo = "bar" });
 
-            SarifErrorListItem item = MakeErrorListItem(result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(result);
             item.Properties.Should().BeEmpty();
 
             item.PopulateAdditionalPropertiesIfNot();
@@ -958,32 +958,13 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 Tool = new Tool(),
             };
 
-            SarifErrorListItem item = MakeErrorListItem(run, result);
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(run, result);
             item.Message.Should().Be(result.Message.Text);
             item.XamlMessage.Should().Be(ValidXamlWithHyperlink);
 
             ResultTextMarker lineMarker = item.LineMarker;
             lineMarker.ToolTipContent.Should().Be(result.Message.Text);
             lineMarker.ToolTipXamlString.Should().Be(ValidXamlWithHyperlink);
-        }
-
-        private static SarifErrorListItem MakeErrorListItem(Result result)
-        {
-            return MakeErrorListItem(EmptyRun, result);
-        }
-
-        private static SarifErrorListItem MakeErrorListItem(Run run, Result result)
-        {
-            result.Run = run;
-            return new SarifErrorListItem(
-                run,
-                runIndex: 0,
-                result: result,
-                logFilePath: "log.sarif",
-                projectNameCache: new ProjectNameCache(solution: null))
-            {
-                FileName = FileName,
-            };
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
@@ -369,9 +369,8 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
 
             SarifErrorListItem item = MakeErrorListItem(result);
 
-            // with the change related to #360, message is not separated by sentence.
             item.Message.Should().Be($"{s1} {s2}");
-            item.ShortMessage.Should().Be($"{s1} {s2}");
+            item.ShortMessage.Should().Be($"{s1}");
         }
 
         [Fact]
@@ -388,7 +387,27 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
 
             SarifErrorListItem item = MakeErrorListItem(result);
             item.Message.Should().Be(s1);
-            item.ShortMessage.Should().Be(s1);
+            item.ShortMessage.Should().Be($"{s1}.");
+        }
+
+        [Fact]
+        public void SarifErrorListItem_ResultMessageFormat_LongTextShouldBreak()
+        {
+            const string s1 = "In httplib2 before version 0.18.0, an attacker controlling unescaped part of uri for `httplib2.Http.request()` could change request headers and body, send additional hidden requests to same server. This vulnerability impacts software that uses httplib2 with uri constructed by string concatenation, as opposed to proper urllib building with escaping. This has been fixed in 0.18.0.";
+            var result = new Result
+            {
+                Message = new Message()
+                {
+                    Text = s1,
+                },
+            };
+
+            SarifErrorListItem item = MakeErrorListItem(result);
+            int breakPoistion = 165; // max length of concise text is 165, 0 indexed
+            item.ShortMessage.Length.Should().Be(breakPoistion + 1); // horizontal ellipsis chars is added at end "\u2026"
+            item.ShortMessage.Last().ToString().Should().Be("\u2026");
+            item.ShortMessage.Substring(0, breakPoistion).Should().Be(s1.Substring(0, breakPoistion));
+            item.Message.Should().Be(s1);
         }
 
         [Fact(Skip = "Obsoleted since in latest update extension does not truncate message anymore")]

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifResultEntryTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifResultEntryTests.cs
@@ -3,11 +3,16 @@
 
 using System;
 using System.Collections.Generic;
+using System.Web.ModelBinding;
 using System.Windows.Documents;
 
 using FluentAssertions;
 
+using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.ErrorList;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Shell.TableManager;
+using Microsoft.VisualStudio.TextManager.Interop;
 
 using Xunit;
 
@@ -114,6 +119,246 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
 
             tableEntry.TryGetValue("fullText", out object fullText).Should().Be(true);
             fullText.Should().BeNull();
+        }
+
+        [Fact]
+        public void SarifResultEntry_MessagesTests()
+        {
+            string ellipsis = "\u2026";
+            var testCases = new[]
+            {
+                new
+                {
+                    MaxTextLength = 40,
+                    RawMessage = "",
+                    ShortMessage = "",
+                    FullMessage = "",
+                    ContainsHyperlink = false,
+                    ShortPlainText = (string)null,
+                    FullPlainText = (string)null,
+                },
+                new
+                {
+                    MaxTextLength = 40,
+                    RawMessage = "   ",
+                    ShortMessage = "",
+                    FullMessage = "",
+                    ContainsHyperlink = false,
+                    ShortPlainText = (string)null,
+                    FullPlainText = (string)null,
+                },
+                new
+                {
+                    MaxTextLength = 40,
+                    RawMessage = "A short sentence",
+                    ShortMessage = "A short sentence.",
+                    FullMessage = "A short sentence.",
+                    ContainsHyperlink = false,
+                    ShortPlainText = (string)null,
+                    FullPlainText = (string)null,
+                },
+                new
+                {
+                    MaxTextLength = 40,
+                    RawMessage = "A short sentence.",
+                    ShortMessage = "A short sentence.",
+                    FullMessage = "A short sentence.",
+                    ContainsHyperlink = false,
+                    ShortPlainText = (string)null,
+                    FullPlainText = (string)null,
+                },
+                new
+                {
+                    MaxTextLength = 40,
+                    RawMessage = "A short sentence!",
+                    ShortMessage = "A short sentence!",
+                    FullMessage = "A short sentence!",
+                    ContainsHyperlink = false,
+                    ShortPlainText = (string)null,
+                    FullPlainText = (string)null,
+                },
+                new
+                {
+                    MaxTextLength = 15,
+                    RawMessage = "A short sentence",
+                    ShortMessage = "A short sentenc" + ellipsis,
+                    FullMessage = "A short sentence.",
+                    ContainsHyperlink = false,
+                    ShortPlainText = (string)null,
+                    FullPlainText = (string)null,
+                },
+                new
+                {
+                    MaxTextLength = 16,
+                    RawMessage = "A short sentence",
+                    ShortMessage = "A short sentence" + ellipsis,
+                    FullMessage = "A short sentence.",
+                    ContainsHyperlink = false,
+                    ShortPlainText = (string)null,
+                    FullPlainText = (string)null,
+                },
+                new
+                {
+                    MaxTextLength = 17,
+                    RawMessage = "A short sentence",
+                    ShortMessage = "A short sentence.",
+                    FullMessage = "A short sentence.",
+                    ContainsHyperlink = false,
+                    ShortPlainText = (string)null,
+                    FullPlainText = (string)null,
+                },
+                new
+                {
+                    MaxTextLength = 100,
+                    RawMessage = "A short sentence? The second sentence",
+                    ShortMessage = "A short sentence?",
+                    FullMessage = "A short sentence? The second sentence.",
+                    ContainsHyperlink = false,
+                    ShortPlainText = (string)null,
+                    FullPlainText = (string)null,
+                },
+                new
+                {
+                    MaxTextLength = 100,
+                    RawMessage = "A short sentence\r\n The second sentence",
+                    ShortMessage = "A short sentence.",
+                    FullMessage = "A short sentence\r\n The second sentence.",
+                    ContainsHyperlink = false,
+                    ShortPlainText = (string)null,
+                    FullPlainText = (string)null,
+                },
+                new
+                {
+                    MaxTextLength = 18,
+                    RawMessage = "The [quick brown fox](https://www.quickfox.com) jumps over the [lazy dog](http://lazy.dog.com).",
+                    ShortMessage = "The quick brown fo" + ellipsis,
+                    FullMessage = "The [quick brown fox](https://www.quickfox.com) jumps over the [lazy dog](http://lazy.dog.com).",
+                    ContainsHyperlink = true,
+                    ShortPlainText = (string)null,
+                    FullPlainText = "The quick brown fox jumps over the lazy dog.",
+                },
+                new
+                {
+                    MaxTextLength = 19,
+                    RawMessage = "The [quick brown fox](https://www.quickfox.com) jumps over the [lazy dog](http://lazy.dog.com).",
+                    ShortMessage = "The [quick brown fox](https://www.quickfox.com)" + ellipsis,
+                    FullMessage = "The [quick brown fox](https://www.quickfox.com) jumps over the [lazy dog](http://lazy.dog.com).",
+                    ContainsHyperlink = true,
+                    ShortPlainText = "The quick brown fox" + ellipsis,
+                    FullPlainText = "The quick brown fox jumps over the lazy dog.",
+                },
+                new
+                {
+                    MaxTextLength = 20,
+                    RawMessage = "The [quick brown fox](https://www.quickfox.com) jumps over the [lazy dog](http://lazy.dog.com).",
+                    ShortMessage = "The [quick brown fox](https://www.quickfox.com) " + ellipsis,
+                    FullMessage = "The [quick brown fox](https://www.quickfox.com) jumps over the [lazy dog](http://lazy.dog.com).",
+                    ContainsHyperlink = true,
+                    ShortPlainText = "The quick brown fox " + ellipsis,
+                    FullPlainText = "The quick brown fox jumps over the lazy dog.",
+                },
+                new
+                {
+                    MaxTextLength = 21,
+                    RawMessage = "The [quick brown fox](https://www.quickfox.com) jumps over the [lazy dog](http://lazy.dog.com).",
+                    ShortMessage = "The [quick brown fox](https://www.quickfox.com) j" + ellipsis,
+                    FullMessage = "The [quick brown fox](https://www.quickfox.com) jumps over the [lazy dog](http://lazy.dog.com).",
+                    ContainsHyperlink = true,
+                    ShortPlainText = "The quick brown fox j" + ellipsis,
+                    FullPlainText = "The quick brown fox jumps over the lazy dog.",
+                },
+                new
+                {
+                    MaxTextLength = 42,
+                    RawMessage = "The [quick brown fox](https://www.quickfox.com) jumps over the [lazy dog](http://lazy.dog.com).",
+                    ShortMessage = "The [quick brown fox](https://www.quickfox.com) jumps over the lazy do" + ellipsis,
+                    FullMessage = "The [quick brown fox](https://www.quickfox.com) jumps over the [lazy dog](http://lazy.dog.com).",
+                    ContainsHyperlink = true,
+                    ShortPlainText = "The quick brown fox jumps over the lazy do" + ellipsis,
+                    FullPlainText = "The quick brown fox jumps over the lazy dog.",
+                },
+                new
+                {
+                    MaxTextLength = 43,
+                    RawMessage = "The [quick brown fox](https://www.quickfox.com) jumps over the [lazy dog](http://lazy.dog.com).",
+                    ShortMessage = "The [quick brown fox](https://www.quickfox.com) jumps over the [lazy dog](http://lazy.dog.com)" + ellipsis,
+                    FullMessage = "The [quick brown fox](https://www.quickfox.com) jumps over the [lazy dog](http://lazy.dog.com).",
+                    ContainsHyperlink = true,
+                    ShortPlainText = "The quick brown fox jumps over the lazy dog" + ellipsis,
+                    FullPlainText = "The quick brown fox jumps over the lazy dog.",
+                },
+                new
+                {
+                    MaxTextLength = 44,
+                    RawMessage = "The [quick brown fox](https://www.quickfox.com) jumps over the [lazy dog](http://lazy.dog.com).",
+                    ShortMessage = "The [quick brown fox](https://www.quickfox.com) jumps over the [lazy dog](http://lazy.dog.com).",
+                    FullMessage = "The [quick brown fox](https://www.quickfox.com) jumps over the [lazy dog](http://lazy.dog.com).",
+                    ContainsHyperlink = true,
+                    ShortPlainText = "The quick brown fox jumps over the lazy dog.",
+                    FullPlainText = "The quick brown fox jumps over the lazy dog.",
+                },
+                new
+                {
+                    MaxTextLength = 160,
+                    RawMessage = "The [quick brown fox](https://www.quickfox.com) jumps over the [lazy dog](http://lazy.dog.com).",
+                    ShortMessage = "The [quick brown fox](https://www.quickfox.com) jumps over the [lazy dog](http://lazy.dog.com).",
+                    FullMessage = "The [quick brown fox](https://www.quickfox.com) jumps over the [lazy dog](http://lazy.dog.com).",
+                    ContainsHyperlink = true,
+                    ShortPlainText = "The quick brown fox jumps over the lazy dog.",
+                    FullPlainText = "The quick brown fox jumps over the lazy dog.",
+                }
+
+            };
+
+            int originalMax = SarifErrorListItem.MaxConcisedTextLength;
+            foreach (var test in testCases)
+            {
+                SarifErrorListItem.MaxConcisedTextLength = test.MaxTextLength;
+                var result = new Result
+                {
+                    Message = new Message()
+                    {
+                        Text = test.RawMessage,
+                    },
+                };
+                SarifErrorListItem error = TestUtilities.MakeErrorListItem(result);
+                SarifResultTableEntry entry = new SarifResultTableEntry(error);
+
+                VerifyErrorListItemEntry(error, entry, test);
+            }
+            SarifErrorListItem.MaxConcisedTextLength = originalMax;
+        }
+
+        private static void VerifyErrorListItemEntry(SarifErrorListItem error, SarifResultTableEntry entry, dynamic test)
+        {
+            error.ShortMessage.Should().Be(test.ShortMessage);
+            error.Message.Should().Be(test.FullMessage);
+            error.RawMessage.Should().Be(test.RawMessage.Trim());
+            error.HasEmbeddedLinks.Should().Be(test.ContainsHyperlink);
+
+            entry.TryGetValue(StandardTableKeyNames.Text, out object textColumn).Should().BeTrue();
+            entry.TryGetValue(StandardTableKeyNames.FullText, out object fullTextColumn).Should().BeTrue();
+            entry.TryGetValue(StandardTableKeyNames2.TextInlines, out object textInlinesColumn).Should().BeTrue();
+            entry.TryGetValue(SarifResultTableEntry.FullTextInlinesColumnName, out object fullTextInlinesColumn).Should().BeTrue();
+
+            ((string)textColumn).Should().Be(test.ShortMessage);
+            ((string)fullTextColumn).Should().Be(error.HasDetailsContent ? test.FullMessage : null);
+
+            if (test.ContainsHyperlink)
+            {
+                var textInlines = textInlinesColumn as List<Inline>;
+                textInlines.Should().NotBeNull();
+                SdkUIUtilities.GetPlainText(textInlines).Should().Be(test.ShortPlainText);
+
+                var fullTextInlines = fullTextInlinesColumn as List<Inline>;
+                fullTextInlines.Should().NotBeNull();
+                SdkUIUtilities.GetPlainText(fullTextInlines).Should().Be(test.FullPlainText);
+            }
+            else
+            {
+                textInlinesColumn.Should().BeNull();
+                fullTextInlinesColumn.Should().BeNull();
+            }
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/TestUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/TestUtilities.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
 {
     public static class TestUtilities
     {
+        private static readonly Run EmptyRun = new Run();
+
         public static void InitializeTestEnvironment()
         {
             SarifViewerPackage.IsUnitTesting = true;
@@ -20,6 +22,25 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             InitializeTestEnvironment();
 
             await ErrorListService.ProcessSarifLogAsync(sarifLog, logFile, cleanErrors: cleanErrors, openInEditor: false);
+        }
+
+        internal static SarifErrorListItem MakeErrorListItem(Result result)
+        {
+            return MakeErrorListItem(EmptyRun, result);
+        }
+
+        internal static SarifErrorListItem MakeErrorListItem(Run run, Result result)
+        {
+            result.Run = run;
+            return new SarifErrorListItem(
+                run,
+                runIndex: 0,
+                result: result,
+                logFilePath: "log.sarif",
+                projectNameCache: new ProjectNameCache(solution: null))
+            {
+                FileName = "file.c",
+            };
         }
     }
 }


### PR DESCRIPTION
# Description

Enable error list row expando by setting its columns `StandardTableKeyNames.Text` and `StandardTableKeyNames.FullText` with short and full message texts separately
- When the original message contains line-breaker or end-of-sentence punctation chars in the middle.
- Extract first sentence as short message.
  - if first sentence does not end with a punctation, append a dot (.) at the end.
  - if first sentence length is greater than specific max length (165 in this case), it will be truncated to 165 and append a horizontal ellipsis char (…)
- The original message as full message.
- Support hyperlink in error list item and expanded panel.

Add test cases in Apex UI tests: https://github.com/microsoft/sarif-internal/issues/22