### PR TITLE
Fix build failure after VS 2022 update 17.2.0

### DIFF
--- a/src/Sarif.Sarifer.2022/Sarif.Sarifer.2022.csproj
+++ b/src/Sarif.Sarifer.2022/Sarif.Sarifer.2022.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.31902.203" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.0.5232</Version>
+      <Version>17.2.2186</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Sarif.Sarifer.Core/OutputWindowTracerListener.cs
+++ b/src/Sarif.Sarifer.Core/OutputWindowTracerListener.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
                     _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                       {
                           await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                          this.pane.OutputString(message);
+                          this.pane.OutputStringThreadSafe(message);
                       });
                 }
             }

--- a/src/Sarif.Viewer.VisualStudio.2022/Sarif.Viewer.VisualStudio.2022.csproj
+++ b/src/Sarif.Viewer.VisualStudio.2022/Sarif.Viewer.VisualStudio.2022.csproj
@@ -45,7 +45,7 @@
       <Version>16.3.43</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.0.5232</Version>
+      <Version>17.2.2186</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
# Description

Build failed both local and ADO pipeline after VS 2022 17.2.0 update. 

D:\a\1\s\src\packages\microsoft.vssdk.buildtools\17.0.5232\tools\VSSDK\Microsoft.VsSDK.targets(829,5): error MSB4018: The "GetDeploymentPathFromVsixManifest" task failed unexpectedly. [D:\a\1\s\src\Sarif.Viewer.VisualStudio.2022\Sarif.Viewer.VisualStudio.2022.csproj] 
D:\a\1\s\src\packages\microsoft.vssdk.buildtools\17.0.5232\tools\VSSDK\Microsoft.VsSDK.targets(829,5): error MSB4018: System.TypeLoadException: Method 'get_JoinableTaskFactory' in type 'Microsoft.VisualStudio.Sdk.BuildTasks.ExtensionEngineHost' from assembly 'Microsoft.VisualStudio.Sdk.BuildTasks.17.0, Version=17.0.5232.5239, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' does not have an implementation. 

- Upgraded the version of the VSSDK BuildTools from 17.0.5232 to 17.2.2186 to resolve the build error.
- Replaced a banned API `IVsOutputWindowPane.OutputString(string)` with `'IVsOutputWindowPane.OutputStringThreadSafe(string)'`