### PR TITLE
Ignoring component governance submodules

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,3 +21,5 @@ steps:
     filePath: ./scripts/BuildAndTest.ps1
 
 - task: ComponentGovernanceComponentDetection@0
+  inputs:
+    ignoreDirectories: 'src\sarif-pattern-matcher'


### PR DESCRIPTION
This change will ignore any issues in the sarif-pattern-matcher submodules.
This will prevent component governance from generating double issues: one in the submodule and one in this repository.

No tests were added since no product code was changed.
No release change was updated since it does not affect customers.