### PR TITLE
Key event interop intergration fix

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
@@ -470,7 +470,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             }
         }
 
-        internal static async Task ProcessSarifLogAsync(SarifLog sarifLog, string logFilePath, bool cleanErrors, bool openInEditor, bool monitorSarifFile = true)
+        internal static async Task ProcessSarifLogAsync(SarifLog sarifLog, string logFilePath, bool cleanErrors, bool openInEditor)
         {
             // The creation of the data models must be done on the UI thread (for now).
             // VS's table data source constructs are indeed thread safe.
@@ -528,10 +528,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                 }
             }
 
-            if (monitorSarifFile)
-            {
-                SarifLogsMonitor.Instance.StartWatch(logFilePath);
-            }
+            SarifLogsMonitor.Instance.StartWatch(logFilePath);
 
             RaiseLogProcessed(ExceptionalConditionsCalculator.Calculate(sarifLog));
         }

--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
@@ -470,7 +470,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             }
         }
 
-        internal static async Task ProcessSarifLogAsync(SarifLog sarifLog, string logFilePath, bool cleanErrors, bool openInEditor)
+        internal static async Task ProcessSarifLogAsync(SarifLog sarifLog, string logFilePath, bool cleanErrors, bool openInEditor, bool monitorSarifFile = true)
         {
             // The creation of the data models must be done on the UI thread (for now).
             // VS's table data source constructs are indeed thread safe.
@@ -528,7 +528,10 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                 }
             }
 
-            SarifLogsMonitor.Instance.StartWatch(logFilePath);
+            if (monitorSarifFile)
+            {
+                SarifLogsMonitor.Instance.StartWatch(logFilePath);
+            }
 
             RaiseLogProcessed(ExceptionalConditionsCalculator.Calculate(sarifLog));
         }

--- a/src/Sarif.Viewer.VisualStudio.Core/Services/DataService.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Services/DataService.cs
@@ -61,7 +61,14 @@ namespace Microsoft.Sarif.Viewer.Services
 
             await ErrorListService.ProcessSarifLogAsync(sarifLog, logPath, cleanErrors: false, openInEditor: false, monitorSarifFile: false);
 
-            SarifErrorListItem sarifItem = CodeAnalysisResultManager.Instance.CurrentRunDataCache.SarifErrors?[0];
+            SarifErrorListItem sarifItem = null;
+            IList<SarifErrorListItem> sarifErrorListItems = CodeAnalysisResultManager.Instance.CurrentRunDataCache.SarifErrors;
+
+            if (sarifErrorListItems?.Any() == true)
+            {
+                sarifErrorListItems.ToList().ForEach(item => item?.PopulateAdditionalPropertiesIfNot());
+                sarifItem = sarifErrorListItems.First();
+            }
 
             if (sarifItem != null)
             {

--- a/src/Sarif.Viewer.VisualStudio.Core/Services/DataService.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Services/DataService.cs
@@ -57,10 +57,13 @@ namespace Microsoft.Sarif.Viewer.Services
             Assumes.NotNull(sarifLog);
             Assumes.True(sarifLog.Runs?.Count == 1);
 
+            string enhancedResultDataLogName = "EnhancedResultData";
+
             if (this.componentModel != null)
             {
+                await ErrorListService.CloseSarifLogItemsAsync(new string[] { enhancedResultDataLogName });
                 int runIndex = CodeAnalysisResultManager.Instance.GetNextRunIndex();
-                var dataCache = new RunDataCache(runIndex, "EnhancedResultData", sarifLog);
+                var dataCache = new RunDataCache(runIndex, enhancedResultDataLogName, sarifLog);
                 CodeAnalysisResultManager.Instance.RunIndexToRunDataCache.Add(runIndex, dataCache);
 
                 var dte = Package.GetGlobalService(typeof(DTE)) as DTE2;


### PR DESCRIPTION
- Utilize existing `ErrorListService.ProcessSarifLogAsync` method to load the Sarif log. It calls `WriteRunToErrorList` and build caches required by extension.
- Another option is build key event's own logic around `WriteRunToErrorList`