### PR TITLE
Fix adornments displaying issues

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/Services/DataService.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Services/DataService.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Sarif.Viewer.Services
     /// <inheritdoc/>
     public class DataService : SDataService, IDataService
     {
-        private const string EnhancedResultDataLogName = "EnhancedResultData";
+        public const string EnhancedResultDataLogName = "EnhancedResultData";
 
         private readonly IComponentModel componentModel = (IComponentModel)AsyncPackage.GetGlobalService(typeof(SComponentModel));
 


### PR DESCRIPTION
- Key event data is not removed after the VS editor is closed. When the same file re-opened the adornments appear without VS sending the key event data.

- Switch between 2 errors in the same file the adornments are not refreshed.
-- The adornments refresh only when text view layout changes. If switch to another error within same viewport, the layoutChanged event will not be fired.
