### PR TITLE
Update DataService interfaces

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/SarifExplorerWindow.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/SarifExplorerWindow.cs
@@ -146,6 +146,12 @@ namespace Microsoft.Sarif.Viewer
             ((IVsWindowFrame)this.Frame).Show();
         }
 
+        public void Close()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            ((IVsWindowFrame)this.Frame).CloseFrame((uint)__FRAMECLOSE.FRAMECLOSE_NoSave);
+        }
+
         public void UpdateSelectionList(params object[] items)
         {
             ThreadHelper.ThrowIfNotOnUIThread();

--- a/src/Sarif.Viewer.VisualStudio.Core/Services/DataService.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Services/DataService.cs
@@ -26,10 +26,18 @@ namespace Microsoft.Sarif.Viewer.Services
     {
         public const string EnhancedResultDataLogName = "EnhancedResultData";
 
-        private readonly IComponentModel componentModel = (IComponentModel)AsyncPackage.GetGlobalService(typeof(SComponentModel));
+        private readonly IComponentModel componentModel;
+
+        private readonly ISarifErrorListEventSelectionService sarifErrorListEventSelectionService;
+
+        public DataService()
+        {
+            this.componentModel = (IComponentModel)AsyncPackage.GetGlobalService(typeof(SComponentModel));
+            this.sarifErrorListEventSelectionService = this.componentModel.GetService<ISarifErrorListEventSelectionService>();
+        }
 
         /// <inheritdoc/>
-        public void SendEnhancedResultData(Stream stream)
+        public int SendEnhancedResultData(Stream stream)
         {
             Assumes.NotNull(stream);
 
@@ -42,28 +50,43 @@ namespace Microsoft.Sarif.Viewer.Services
 
             if (sarifLog != null)
             {
-                this.SendEnhancedResultData(sarifLog);
+                return this.SendEnhancedResultData(sarifLog);
             }
+
+            return -1;
         }
 
         /// <inheritdoc/>
-        public void SendEnhancedResultData(SarifLog sarifLog)
+        public int SendEnhancedResultData(SarifLog sarifLog)
         {
-            SendEnhancedResultDataAsync(sarifLog).FileAndForget(Constants.FileAndForgetFaultEventNames.SendEnhancedData);
+            Assumes.NotNull(sarifLog);
+
+            int cookie = -1;
+
+            ThreadHelper.JoinableTaskFactory.Run(async () => cookie = await this.SendEnhancedResultDataAsync(sarifLog));
+
+            return cookie;
         }
 
-        private async Task SendEnhancedResultDataAsync(SarifLog sarifLog)
+        public void CloseEnhancedResultData(int cookie)
+        {
+            this.CloseEnhancedResultDataAsync(cookie).FileAndForget(Constants.FileAndForgetFaultEventNames.SendEnhancedData);
+        }
+
+        private async System.Threading.Tasks.Task<int> SendEnhancedResultDataAsync(SarifLog sarifLog)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             Assumes.NotNull(sarifLog);
             Assumes.True(sarifLog.Runs?.Count == 1);
 
+            int runIndex = -1;
+
             if (this.componentModel != null)
             {
                 await ErrorListService.CloseSarifLogItemsAsync(new string[] { EnhancedResultDataLogName });
 
-                int runIndex = CodeAnalysisResultManager.Instance.GetNextRunIndex();
+                runIndex = CodeAnalysisResultManager.Instance.GetNextRunIndex();
                 var dataCache = new RunDataCache(runIndex, EnhancedResultDataLogName, sarifLog);
                 CodeAnalysisResultManager.Instance.RunIndexToRunDataCache.Add(runIndex, dataCache);
 
@@ -80,14 +103,27 @@ namespace Microsoft.Sarif.Viewer.Services
                     dataCache.SarifErrors.Add(sarifErrorListItem);
                 }
 
-                ISarifErrorListEventSelectionService sarifErrorListEventSelectionService = componentModel.GetService<ISarifErrorListEventSelectionService>();
-                sarifErrorListEventSelectionService.NavigatedItem = items[0];
-                sarifErrorListEventSelectionService.SelectedItem = items[0];
+                this.sarifErrorListEventSelectionService.NavigatedItem = items[0];
+                this.sarifErrorListEventSelectionService.SelectedItem = items[0];
 
                 items[0].Locations?.FirstOrDefault()?.NavigateTo(usePreviewPane: false, moveFocusToCaretLocation: true);
             }
 
             SarifExplorerWindow.Find()?.Show();
+
+            return runIndex;
+        }
+
+        private async Task CloseEnhancedResultDataAsync(int cookie)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            await ErrorListService.CloseSarifLogItemsAsync(new string[] { EnhancedResultDataLogName });
+
+            this.sarifErrorListEventSelectionService.NavigatedItem = null;
+            this.sarifErrorListEventSelectionService.SelectedItem = null;
+
+            SarifExplorerWindow.Find()?.Close();
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.Core/Services/DataService.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Services/DataService.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Sarif.Viewer.Services
             return cookie;
         }
 
+        /// <inheritdoc/>
         public void CloseEnhancedResultData(int cookie)
         {
             this.CloseEnhancedResultDataAsync(cookie).FileAndForget(Constants.FileAndForgetFaultEventNames.SendEnhancedData);

--- a/src/Sarif.Viewer.VisualStudio.Core/Services/IDataService.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Services/IDataService.cs
@@ -16,12 +16,20 @@ namespace Microsoft.Sarif.Viewer.Services
         /// Sends enhanced SARIF result data.
         /// </summary>
         /// <param name="stream">A <see cref="Stream"/> containing the enhanced result data.</param>
-        void SendEnhancedResultData(Stream stream);
+        /// <returns>The cookie value of the enhanced result data.</returns>
+        int SendEnhancedResultData(Stream stream);
 
         /// <summary>
         /// Sends enhanced SARIF result data.
         /// </summary>
         /// <param name="sarifLog">A <see cref="SarifLog"/> containing the enhanced result data.</param>
-        void SendEnhancedResultData(SarifLog sarifLog);
+        /// <returns>The cookie value of the enhanced result data.</returns>
+        int SendEnhancedResultData(SarifLog sarifLog);
+
+        /// <summary>
+        /// Cleans up enhanced SARIF result data.
+        /// </summary>
+        /// <param name="cookie">The cookie value of the enhanced result data.</param>
+        void CloseEnhancedResultData(int cookie);
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.Interop/SarifViewerInterop.cs
+++ b/src/Sarif.Viewer.VisualStudio.Interop/SarifViewerInterop.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.VisualStudio.Debugger.Evaluation.IL;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -281,13 +282,17 @@ namespace Microsoft.Sarif.Viewer.Interop
         /// </summary>
         /// <param name="sarifLog">The SARIF log containing the enhanced result data.</param>
         /// <returns>A <see cref="System.Threading.Tasks.Task"/> containing true if the operation succeeded; otherwise, false.</returns>
-        public Task<bool> SendEnhancedResultDataAsync(SarifLog sarifLog)
+        public async Task<int> SendEnhancedResultDataAsync(SarifLog sarifLog)
         {
-            return this.CallServiceApiAsync(ViewerDataServiceInterfaceName, (service) =>
+            int cookie = -1;
+
+            bool result = await this.CallServiceApiAsync(ViewerDataServiceInterfaceName, (service) =>
             {
-                service.SendEnhancedResultData(sarifLog);
+                cookie = service.SendEnhancedResultData(sarifLog);
                 return true;
             });
+
+            return result ? cookie : -1;
         }
 
         /// <summary>
@@ -295,13 +300,17 @@ namespace Microsoft.Sarif.Viewer.Interop
         /// </summary>
         /// <param name="stream">The stream containing the enhanced result data.</param>
         /// <returns>A <see cref="System.Threading.Tasks.Task"/> containing true if the operation succeeded; otherwise, false.</returns>
-        public Task<bool> SendEnhancedResultDataAsync(Stream stream)
+        public async Task<int> SendEnhancedResultDataAsync(Stream stream)
         {
-            return this.CallServiceApiAsync(ViewerDataServiceInterfaceName, (service) =>
+            int cookie = -1;
+
+            bool result = await this.CallServiceApiAsync(ViewerDataServiceInterfaceName, (service) =>
             {
-                service.SendEnhancedResultData(stream);
+                cookie = service.SendEnhancedResultData(stream);
                 return true;
             });
+
+            return result ? cookie : -1;
         }
 
         /// <summary>

--- a/src/Sarif.Viewer.VisualStudio.Interop/SarifViewerInterop.cs
+++ b/src/Sarif.Viewer.VisualStudio.Interop/SarifViewerInterop.cs
@@ -304,6 +304,20 @@ namespace Microsoft.Sarif.Viewer.Interop
             });
         }
 
+        /// <summary>
+        /// Sends enhanced result data to the SARIF extension.
+        /// </summary>
+        /// <param name="cookie">The cookie value of the enhanced result data.</param>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> containing true if the operation succeeded; otherwise, false.</returns>
+        public Task<bool> CloseEnhancedResultDataAsync(int cookie)
+        {
+            return this.CallServiceApiAsync(ViewerDataServiceInterfaceName, (service) =>
+            {
+                service.CloseEnhancedResultData(cookie);
+                return true;
+            });
+        }
+
         private async Task<bool> CallServiceApiAsync(string serviceInterfaceName, Func<dynamic, bool> action)
         {
             if (!this.IsViewerExtensionInstalled || (this.IsViewerExtensionLoaded && this.LoadViewerExtension() == null))


### PR DESCRIPTION
# Description

According to discussion, upodate the DataService interop APIs with 2 changes:
- `SendEnhancedResultData` returns a unique int cookie value for each Sarif log sent.
- Add a new `CloseEnhancedResultData` accept the cookie value as a parameter to cleanup tags/adornments and close Sarif explorer window.
