### PR TITLE
Dismiss key event adornments after Sarif Explorer window closed

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/Options/SarifViewerOptionPage.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/SarifViewerOptionPage.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Sarif.Viewer.Options
 
         public bool EnableGitHubAdvancedSecurity { get; set; } = false;
 
-        public bool EnableKeyEventAdornment { get; set; } = false;
+        public bool EnableKeyEventAdornment { get; set; } = true;
 
         /// <summary>
         /// Gets the Windows Presentation Foundation (WPF) child element to be hosted inside the Options dialog page.

--- a/src/Sarif.Viewer.VisualStudio.Core/Options/SarifViewerOptions.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/SarifViewerOptions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Sarif.Viewer.Options
     {
         private readonly bool shouldMonitorSarifFolderDefaultValue = true;
 
-        private readonly bool keyEventAdornmentEnabledDefaultValue = false;
+        private readonly bool keyEventAdornmentEnabledDefaultValue = true;
 
         private readonly AsyncPackage package;
 

--- a/src/Sarif.Viewer.VisualStudio.Core/SarifExplorerWindow.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/SarifExplorerWindow.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Sarif.Viewer
     /// </para>
     /// </remarks>
     [Guid("ab561bcc-e01d-4781-8c2e-95a9170bfdd5")]
-    public class SarifExplorerWindow : ToolWindowPane, IToolWindow
+    public class SarifExplorerWindow : ToolWindowPane, IToolWindow, IVsWindowFrameNotify3
     {
         /// <summary>
         /// Track selection is for development (design time) only. It has no impact on runtime.
@@ -234,5 +234,39 @@ namespace Microsoft.Sarif.Viewer
 
             return vsPackage.FindToolWindow(typeof(SarifExplorerWindow), 0, true) as SarifExplorerWindow;
         }
+
+        // start of IVsWindowFrameNotify3 interfaces
+        public int OnClose(ref uint pgrfSaveOptions)
+        {
+            if (this.sarifErrorListEventSelectionService != null)
+            {
+                this.sarifErrorListEventSelectionService.SelectedItem = null;
+                this.sarifErrorListEventSelectionService.NavigatedItem = null;
+            }
+
+            return Microsoft.VisualStudio.VSConstants.S_OK;
+        }
+
+        public int OnDockableChange(int fDockable, int x, int y, int w, int h)
+        {
+            return Microsoft.VisualStudio.VSConstants.S_OK;
+        }
+
+        public int OnMove(int x, int y, int w, int h)
+        {
+            return Microsoft.VisualStudio.VSConstants.S_OK;
+        }
+
+        public int OnShow(int fShow)
+        {
+            return Microsoft.VisualStudio.VSConstants.S_OK;
+        }
+
+        public int OnSize(int x, int y, int w, int h)
+        {
+            return Microsoft.VisualStudio.VSConstants.S_OK;
+        }
+
+        // end of IVsWindowFrameNotify3 interfaces
     }
 }


### PR DESCRIPTION
# Description

As requested, listen to ToolWindow's OnClose event, clean up selected item, the tags/adornments are removed.

Also updated the "enable key event text adornments in VS editor" option's default value to true as requested.