### PR TITLE
Key Event bug fixes

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
@@ -27,7 +27,6 @@ using Microsoft.Sarif.Viewer.Controls;
 using Microsoft.Sarif.Viewer.FileMonitor;
 using Microsoft.Sarif.Viewer.Models;
 using Microsoft.Sarif.Viewer.Sarif;
-using Microsoft.Sarif.Viewer.Services;
 using Microsoft.Sarif.Viewer.Tags;
 using Microsoft.Sarif.Viewer.Telemetry;
 using Microsoft.VisualStudio.PlatformUI;

--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
@@ -27,6 +27,7 @@ using Microsoft.Sarif.Viewer.Controls;
 using Microsoft.Sarif.Viewer.FileMonitor;
 using Microsoft.Sarif.Viewer.Models;
 using Microsoft.Sarif.Viewer.Sarif;
+using Microsoft.Sarif.Viewer.Services;
 using Microsoft.Sarif.Viewer.Tags;
 using Microsoft.Sarif.Viewer.Telemetry;
 using Microsoft.VisualStudio.PlatformUI;
@@ -538,6 +539,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             SarifTableDataSource.Instance.CleanAllErrors();
             CodeAnalysisResultManager.Instance.RunIndexToRunDataCache.Clear();
             SarifLocationTagHelpers.RefreshTags();
+            new DataService().CloseEnhancedResultData(0);
         }
 
         public static void SendFeedback(FeedbackModel feedback)

--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
@@ -539,7 +539,6 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             SarifTableDataSource.Instance.CleanAllErrors();
             CodeAnalysisResultManager.Instance.RunIndexToRunDataCache.Clear();
             SarifLocationTagHelpers.RefreshTags();
-            new DataService().CloseEnhancedResultData(0);
         }
 
         public static void SendFeedback(FeedbackModel feedback)

--- a/src/Sarif.Viewer.VisualStudio.Core/OpenLogFileCommands.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/OpenLogFileCommands.cs
@@ -14,6 +14,7 @@ using System.Windows.Forms;
 
 using Microsoft.CodeAnalysis.Sarif.Converters;
 using Microsoft.Sarif.Viewer.ErrorList;
+using Microsoft.Sarif.Viewer.Services;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -258,6 +259,7 @@ namespace Microsoft.Sarif.Viewer
             try
             {
                 await ErrorListService.ProcessLogFileAsync(logFile, toolFormat, promptOnLogConversions: true, cleanErrors: true, openInEditor: true).ConfigureAwait(continueOnCapturedContext: false);
+                new DataService().CloseEnhancedResultData(0);
             }
             catch (InvalidOperationException)
             {

--- a/src/Sarif.Viewer.VisualStudio.Core/Tags/KeyEventAdornmentManager.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Tags/KeyEventAdornmentManager.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Sarif.Viewer.Tags
 
                 // Get length of the longest line.
                 int maxSpaceChar = linesContainsKeyEvent.Any() ?
-                    linesContainsKeyEvent.Keys.Max(line => line.End.Position - line.Start.Position) :
+                    linesContainsKeyEvent.Keys.Max(line => this.NormalizeTextLength(line)) :
                     0;
 
                 foreach (KeyValuePair<IWpfTextViewLine, IList<ITextMarkerTag>> line in linesContainsKeyEvent)
@@ -213,13 +213,13 @@ namespace Microsoft.Sarif.Viewer.Tags
         /// Create TextBlock control at end of the given lines.
         /// </summary>
         /// <param name="line">Line to add the adornments.</param>
-        private void CreateVisuals(ITextViewLine line, IList<ITextMarkerTag> tags, int maxSpaceChar)
+        private void CreateVisuals(IWpfTextViewLine line, IList<ITextMarkerTag> tags, int maxSpaceChar)
         {
             SnapshotSpan extent = line.Extent;
             Geometry geometry = this.view.TextViewLines.GetMarkerGeometry(extent);
             if (geometry != null)
             {
-                int charLength = line.End.Position - line.Start.Position;
+                int charLength = this.NormalizeTextLength(line);
                 int numberOfSpace = maxSpaceChar - charLength;
 
                 UIElement tagGraphic = new KeyEventAdornment(
@@ -242,6 +242,20 @@ namespace Microsoft.Sarif.Viewer.Tags
                         null);
                 }
             }
+        }
+
+        private int NormalizeTextLength(IWpfTextViewLine line)
+        {
+            int tabWidth = 4;
+            string text;
+
+            if (line == null || (text = line.Extent.GetText()) == null)
+            {
+                return 0;
+            }
+
+            int tabCount = text.Count(c => c == '\t');
+            return (tabCount * (tabWidth - 1)) + text.Length;
         }
     }
 }


### PR DESCRIPTION
## Issue 1
After key event enhanced data sent to viewer, the tags/adornments show in editor and sarif explorer show details. Now if open a Sarif log file, VS open the file in a new editor window, but the Sarif explorer is not cleared still showing key event data of previous selected error/warning, 

## Issue 2
The key event adornment texts are not aligned when the lines contain tab indents and space indents mixed.
Before:
![image](https://user-images.githubusercontent.com/76094515/188059629-084b969f-2ea2-49c9-82ef-c01118f54692.png)

After:
![image](https://user-images.githubusercontent.com/76094515/188059544-e273e841-58ec-4bde-924e-e810fece5425.png)
