### PR TITLE
Fix an issue TextMarkerTags for related locations/analysis steps not updated at right time

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/Tags/SarifLocationTextMarkerTagger.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Tags/SarifLocationTextMarkerTagger.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Sarif.Viewer.Tags
             // so we can properly filter the tags being shown in the editor
             // to the currently selected item.
             this.sarifErrorListEventSelectionService.SelectedItemChanged += this.SelectedSarifItemChanged;
+            this.sarifErrorListEventSelectionService.NavigatedItemChanged += this.SelectedSarifItemChanged;
 
             // Subscribe to the caret position so we can send enter and exit notifications
             // to the tags so they can decide potentially change their colors.


### PR DESCRIPTION
# Description

This issue does not impact the VC++ CA key event integration, only occurs if you open a Sarif file contains key event data using Sarif Viewer.

'ISarifErrorListEventSelectionService' has 2 events:
- `SelectedItemChanged` when user single clicks on an item in error list.
- `NavigatedItemChanged` when user double clicks on an item in error list.

The additional properties of `SarifErrorListItem` only got populated after `NavigatedItemChanged` since navigating may produce popup windows etc needs user interactions.

SarifLocationTextMarkerTagger only register `SelectedItemChanged' and set `tagsDirty` to true. When next `NavigatedItemChanged` happens it doesn't refresh tags since `tagsDirty` is not updated.