### PR TITLE
Dismiss SARIF Explorer window when close/open solution.

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/SarifViewerPackage.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/SarifViewerPackage.cs
@@ -164,8 +164,16 @@ namespace Microsoft.Sarif.Viewer
             }
 
             SolutionEvents.OnBeforeCloseSolution += this.SolutionEvents_OnBeforeCloseSolution;
+            SolutionEvents.OnAfterCloseSolution += this.SolutionEvents_OnAfterCloseSolution;
             SolutionEvents.OnAfterBackgroundSolutionLoadComplete += this.SolutionEvents_OnAfterBackgroundSolutionLoadComplete;
             return;
+        }
+
+        private void SolutionEvents_OnAfterCloseSolution(object sender, EventArgs e)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            SarifExplorerWindow.Find()?.Close();
         }
 
         private async Task InitializeResultSourceHostAsync()
@@ -192,10 +200,8 @@ namespace Microsoft.Sarif.Viewer
             get
             {
                 ThreadHelper.ThrowIfNotOnUIThread();
-                if (vsShell == null)
-                {
-                    vsShell = Package.GetGlobalService(typeof(SVsShell)) as IVsShell;
-                }
+
+                vsShell ??= Package.GetGlobalService(typeof(SVsShell)) as IVsShell;
 
                 return vsShell;
             }


### PR DESCRIPTION
# Description

After navigating to an SARIF result item in the Error List window, the SARIF Explorer windows shows detailed information of current selected item.

If closing the solution or re-opening another solution when the SARIF Explorer window is opened showing information of selected SARIF result, the Error List is cleaned up, but SARIF Explorer window remains the same content.

The fix is to dimiss SARIF Explorer window whenever user closes current solution or re-opens another solution.