### PR TITLE
Add output window pane

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,5 +1,8 @@
 # SARIF Viewer Visual Studio extension Release History
 
+## Unreleased ** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
+* FEATURE: Enable logging to the VS console to support debugging scenarios.
+
 ## **3.0.98** [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=WDGIS.MicrosoftSarifViewer)
 * FEATURE: Result sources platform + GitHub Advanced Security source service
 * FEATURE: Key Event adornments + improved Locations view

--- a/src/Sarif.Viewer.VisualStudio.Core/Constants.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Constants.cs
@@ -32,9 +32,14 @@ namespace Microsoft.Sarif.Viewer
             public const string SendEnhancedData = "Microsoft/SARIF/Viewer/DataService/SendEnhancedData/Failed";
 
             /// <summary>
-            /// Indicates a telemetry write failed.
+            /// Used when writing telemetry event fails.
             /// </summary>
             public const string TelemetryWriteEvent = "Microsoft/SARIF/Viewer/Telemetry/WriteEvent/Failed";
+
+            /// <summary>
+            /// Used when writing log into the output window pane fails.
+            /// </summary>
+            public const string OutputWindowEvent = "Microsoft/SARIF/Viewer/OutputPane/Write/Failed";
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
@@ -95,19 +95,19 @@ namespace Microsoft.Sarif.Viewer.ErrorList
         {
             try
             {
-                Trace.WriteLine($"Processing SARIF log file {filePath}");
+                Trace.WriteLine($"Processing SARIF log file `{filePath}`");
                 await ProcessLogFileCoreAsync(filePath, toolFormat, promptOnLogConversions, cleanErrors, openInEditor);
-                Trace.WriteLine($"SARIF log file {filePath} processed");
+                Trace.WriteLine($"SARIF log file `{filePath}` processed");
             }
             catch (JsonException je)
             {
-                Trace.WriteLine($"An error occurred while processing SARIF log file {filePath} due to error: {je.Message}");
+                Trace.WriteLine($"An error occurred while processing SARIF log file `{filePath}` due to error: `{je.Message}`");
                 RaiseLogProcessed(ExceptionalConditions.InvalidJson);
             }
             catch (Exception ex)
             {
                 // for all other exceptions e.g. IO exception. throw it here will crash VS.
-                Trace.WriteLine($"An error occurred while reading SARIF log file {filePath}. due to error: {ex.Message}");
+                Trace.WriteLine($"An error occurred while reading SARIF log file `{filePath}` due to error: `{ex.Message}`");
             }
         }
 

--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
@@ -95,16 +95,19 @@ namespace Microsoft.Sarif.Viewer.ErrorList
         {
             try
             {
+                Trace.WriteLine($"Processing SARIF log file {filePath}");
                 await ProcessLogFileCoreAsync(filePath, toolFormat, promptOnLogConversions, cleanErrors, openInEditor);
+                Trace.WriteLine($"SARIF log file {filePath} processed");
             }
-            catch (JsonException)
+            catch (JsonException je)
             {
+                Trace.WriteLine($"An error occurred while processing SARIF log file {filePath} due to error: {je.Message}");
                 RaiseLogProcessed(ExceptionalConditions.InvalidJson);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 // for all other exceptions e.g. IO exception. throw it here will crash VS.
-                Trace.Write($"An error occurred while reading SARIF log file {filePath}");
+                Trace.WriteLine($"An error occurred while reading SARIF log file {filePath}. due to error: {ex.Message}");
             }
         }
 
@@ -628,6 +631,8 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
             (dataCache.SarifErrors as List<SarifErrorListItem>).AddRange(sarifErrors);
             SarifTableDataSource.Instance.AddErrors(sarifErrors);
+
+            Trace.WriteLine($"{sarifErrors.Count} results loaded from SARIF log file {logFilePath}");
 
             // This causes already open "text views" to be tagged when SARIF logs are processed after a view is opened.
             SarifLocationTagHelpers.RefreshTags();

--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
@@ -95,19 +95,19 @@ namespace Microsoft.Sarif.Viewer.ErrorList
         {
             try
             {
-                Trace.WriteLine($"Processing SARIF log file `{filePath}`");
+                Trace.WriteLine(string.Format(Resources.TraceLog_ProcessingSarifFile, filePath));
                 await ProcessLogFileCoreAsync(filePath, toolFormat, promptOnLogConversions, cleanErrors, openInEditor);
-                Trace.WriteLine($"SARIF log file `{filePath}` processed");
+                Trace.WriteLine(string.Format(Resources.TraceLog_SarifFileProcessed, filePath));
             }
             catch (JsonException je)
             {
-                Trace.WriteLine($"An error occurred while processing SARIF log file `{filePath}` due to error: `{je.Message}`");
+                Trace.WriteLine(string.Format(Resources.TraceLog_OpenSarifFileException, filePath, je.Message));
                 RaiseLogProcessed(ExceptionalConditions.InvalidJson);
             }
             catch (Exception ex)
             {
                 // for all other exceptions e.g. IO exception. throw it here will crash VS.
-                Trace.WriteLine($"An error occurred while reading SARIF log file `{filePath}` due to error: `{ex.Message}`");
+                Trace.WriteLine(string.Format(Resources.TraceLog_OpenSarifFileException, filePath, ex.Message));
             }
         }
 

--- a/src/Sarif.Viewer.VisualStudio.Core/OutputWindowTracerListener.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/OutputWindowTracerListener.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.Sarif.Viewer
+{
+    public class OutputWindowTracerListener : TraceListener
+    {
+        private const string OutputWindowEvent = "Microsoft/SARIF/Viewer/WriteToOutputPane/Failed";
+
+        private readonly string _name;
+        private readonly IVsOutputWindow _outputWindowService;
+
+        private IVsOutputWindowPane pane;
+
+        public OutputWindowTracerListener(IVsOutputWindow outputWindowService, string name)
+        {
+            this._outputWindowService = outputWindowService;
+            this._name = name;
+            Trace.Listeners.Add(this);
+        }
+
+        public override void Write(string message)
+        {
+            if (this.EnsurePane())
+            {
+                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                {
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    this.pane.OutputStringThreadSafe(message);
+                }).FileAndForget(OutputWindowEvent);
+            }
+        }
+
+        public override void WriteLine(string message)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            this.Write(Environment.NewLine + message);
+        }
+
+        private bool EnsurePane()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (this.pane == null)
+            {
+                var guid = Guid.NewGuid();
+                this._outputWindowService.CreatePane(ref guid, this._name, fInitVisible: 1, fClearWithSolution: 1);
+                this._outputWindowService.GetPane(ref guid, out this.pane);
+            }
+
+            return this.pane != null;
+        }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio.Core/OutputWindowTracerListener.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/OutputWindowTracerListener.cs
@@ -27,26 +27,50 @@ namespace Microsoft.Sarif.Viewer
 
         public override void Write(string message)
         {
+            if (!SarifViewerPackage.IsUnitTesting)
+            {
+#pragma warning disable VSTHRD108 // Assert thread affinity unconditionally
+                ThreadHelper.ThrowIfNotOnUIThread();
+#pragma warning restore VSTHRD108
+            }
+
             if (this.EnsurePane())
             {
-                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                if (!SarifViewerPackage.IsUnitTesting)
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                    {
+                        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                        this.pane.OutputStringThreadSafe(message);
+                    }).FileAndForget(OutputWindowEvent);
+                }
+                else
+                {
                     this.pane.OutputStringThreadSafe(message);
-                }).FileAndForget(OutputWindowEvent);
+                }
             }
         }
 
         public override void WriteLine(string message)
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
+            if (!SarifViewerPackage.IsUnitTesting)
+            {
+#pragma warning disable VSTHRD108 // Assert thread affinity unconditionally
+                ThreadHelper.ThrowIfNotOnUIThread();
+#pragma warning restore VSTHRD108
+            }
 
             this.Write(Environment.NewLine + message);
         }
 
         private bool EnsurePane()
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
+            if (!SarifViewerPackage.IsUnitTesting)
+            {
+#pragma warning disable VSTHRD108 // Assert thread affinity unconditionally
+                ThreadHelper.ThrowIfNotOnUIThread();
+#pragma warning restore VSTHRD108
+            }
 
             if (this.pane == null)
             {

--- a/src/Sarif.Viewer.VisualStudio.Core/OutputWindowTracerListener.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/OutputWindowTracerListener.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -12,15 +11,15 @@ namespace Microsoft.Sarif.Viewer
 {
     public class OutputWindowTracerListener : TraceListener
     {
-        private readonly string _name;
-        private readonly IVsOutputWindow _outputWindowService;
+        private readonly string paneName;
+        private readonly IVsOutputWindow outputWindowService;
 
         private IVsOutputWindowPane pane;
 
         public OutputWindowTracerListener(IVsOutputWindow outputWindowService, string name)
         {
-            this._outputWindowService = outputWindowService;
-            this._name = name;
+            this.outputWindowService = outputWindowService;
+            this.paneName = name;
             Trace.Listeners.Add(this);
         }
 
@@ -64,8 +63,8 @@ namespace Microsoft.Sarif.Viewer
                 }
 
                 var guid = Guid.NewGuid();
-                this._outputWindowService.CreatePane(ref guid, this._name, fInitVisible: 1, fClearWithSolution: 1);
-                this._outputWindowService.GetPane(ref guid, out this.pane);
+                this.outputWindowService.CreatePane(ref guid, this.paneName, fInitVisible: 1, fClearWithSolution: 1);
+                this.outputWindowService.GetPane(ref guid, out this.pane);
             }
 
             return this.pane != null;

--- a/src/Sarif.Viewer.VisualStudio.Core/OutputWindowTracerListener.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/OutputWindowTracerListener.cs
@@ -11,8 +11,6 @@ namespace Microsoft.Sarif.Viewer
 {
     public class OutputWindowTracerListener : TraceListener
     {
-        private const string OutputWindowEvent = "Microsoft/SARIF/Viewer/WriteToOutputPane/Failed";
-
         private readonly string _name;
         private readonly IVsOutputWindow _outputWindowService;
 
@@ -42,7 +40,7 @@ namespace Microsoft.Sarif.Viewer
                     {
                         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                         this.pane.OutputStringThreadSafe(message);
-                    }).FileAndForget(OutputWindowEvent);
+                    }).FileAndForget(Constants.FileAndForgetFaultEventNames.OutputWindowEvent);
                 }
                 else
                 {

--- a/src/Sarif.Viewer.VisualStudio.Core/Resources.Designer.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Resources.Designer.cs
@@ -762,7 +762,40 @@ namespace Microsoft.Sarif.Viewer {
                 return ResourceManager.GetString("SendFeedbackSucceeded", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to An error occurred while processing SARIF log file `{0}` due to error: `{1}`..
+        /// </summary>
+        public static string TraceLog_OpenSarifFileException
+        {
+            get
+            {
+                return ResourceManager.GetString("TraceLog_OpenSarifFileException", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Processing SARIF log file `{0}`.
+        /// </summary>
+        public static string TraceLog_ProcessingSarifFile
+        {
+            get
+            {
+                return ResourceManager.GetString("TraceLog_ProcessingSarifFile", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The SARIF log file `{0}` processed.
+        /// </summary>
+        public static string TraceLog_SarifFileProcessed
+        {
+            get
+            {
+                return ResourceManager.GetString("TraceLog_SarifFileProcessed", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The log file you have opened conforms to a pre-release SARIF version 2 schema. This file will be automatically transformed to SARIF version {0}. Would you like to save the transformed file?.
         /// </summary>

--- a/src/Sarif.Viewer.VisualStudio.Core/Resources.resx
+++ b/src/Sarif.Viewer.VisualStudio.Core/Resources.resx
@@ -396,4 +396,13 @@ Do you want to open this file in Visual Studio?</value>
   <data name="ConfirmOpenBinaryFileDialog_Title" xml:space="preserve">
     <value>Confirm Open Binary File</value>
   </data>
+  <data name="TraceLog_OpenSarifFileException" xml:space="preserve">
+    <value>An error occurred while processing SARIF log file `{0}` due to error: `{1}`.</value>
+  </data>
+  <data name="TraceLog_ProcessingSarifFile" xml:space="preserve">
+    <value>Processing the SARIF log file `{0}`.</value>
+  </data>
+  <data name="TraceLog_SarifFileProcessed" xml:space="preserve">
+    <value>The SARIF log file `{0}` processed.</value>
+  </data>
 </root>

--- a/src/Sarif.Viewer.VisualStudio.Core/Sarif.Viewer.VisualStudio.Core.projitems
+++ b/src/Sarif.Viewer.VisualStudio.Core/Sarif.Viewer.VisualStudio.Core.projitems
@@ -108,6 +108,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Options\SarifViewerOptionsControl.xaml.cs">
       <DependentUpon>SarifViewerOptionsControl.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)OutputWindowTracerListener.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ProjectHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ProjectKind.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ProjectNameCache.cs" />

--- a/src/Sarif.Viewer.VisualStudio.Core/SarifViewerPackage.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/SarifViewerPackage.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Sarif.Viewer
     public sealed class SarifViewerPackage : AsyncPackage
     {
         private ResultSourceHost resultSourceHost;
+        private OutputWindowTracerListener outputWindowTraceListener;
 
         /// <summary>
         /// OpenSarifFileCommandPackage GUID string.
@@ -57,6 +58,7 @@ namespace Microsoft.Sarif.Viewer
         public const string PackageGuidString = "b97edb99-282e-444c-8f53-7de237f2ec5e";
         public const string OptionCategoryName = "SARIF Viewer";
         public const string OptionPageName = "General";
+        public const string OutputPaneName = "SARIF Viewer";
         public static readonly Guid PackageGuid = new Guid(PackageGuidString);
 
         public static bool IsUnitTesting { get; set; } = false;
@@ -145,6 +147,11 @@ namespace Microsoft.Sarif.Viewer
 
             // initialize Option first since other componments may depends on options.
             await SarifViewerOption.InitializeAsync(this).ConfigureAwait(false);
+
+            if (await this.GetServiceAsync(typeof(SVsOutputWindow)).ConfigureAwait(continueOnCapturedContext: true) is IVsOutputWindow output)
+            {
+                this.outputWindowTraceListener = new OutputWindowTracerListener(output, OutputPaneName);
+            }
 
             OpenLogFileCommands.Initialize(this);
             CodeAnalysisResultManager.Instance.Register();

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/OutputWindowTracerListenerTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/OutputWindowTracerListenerTests.cs
@@ -36,20 +36,20 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             var mockOutputWindow = new Mock<IVsOutputWindow>();
             mockOutputWindow.Setup(o => o.CreatePane(ref It.Ref<Guid>.IsAny, It.IsAny<string>(), 1, 1)).Returns(0);
             mockOutputWindow.Setup(o => o.GetPane(ref It.Ref<Guid>.IsAny, out pane));
+            string expectedLogString = "Test log";
 
-            // act
+            // act..assert
             var outputWindowTraceListener = new OutputWindowTracerListener(mockOutputWindow.Object, "TestPane");
 
-            Trace.Write("Test log");
+            Trace.Write(expectedLogString);
 
-            // assert
             mockPane.Verify(p => p.OutputStringThreadSafe(It.IsAny<string>()), Times.Once);
-            currentOutputString.Should().Be("Test log");
+            currentOutputString.Should().Be(expectedLogString);
 
-            Trace.WriteLine("More test logs");
+            Trace.WriteLine(expectedLogString);
 
             mockPane.Verify(p => p.OutputStringThreadSafe(It.IsAny<string>()), Times.Exactly(2));
-            currentOutputString.Should().Be(Environment.NewLine + "More test logs");
+            currentOutputString.Should().Be(Environment.NewLine + expectedLogString);
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/OutputWindowTracerListenerTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/OutputWindowTracerListenerTests.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Text;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.VisualStudio.Shell.Interop;
+
+using Moq;
+
+using Xunit;
+
+namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
+{
+    public class OutputWindowTracerListenerTests : SarifViewerPackageUnitTests
+    {
+        [Fact]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD010:Invoke single-threaded types on Main thread", Justification = "For unit tests")]
+        public void OutputWindowTracerListener_WriteTests()
+        {
+            // arrange
+            string currentOutputString = null;
+
+            var mockPane = new Mock<IVsOutputWindowPane>();
+            IVsOutputWindowPane pane = mockPane.Object;
+            mockPane
+                .Setup(p => p.OutputStringThreadSafe(It.IsAny<string>()))
+                .Callback((string outputString) => currentOutputString = outputString);
+
+            var mockOutputWindow = new Mock<IVsOutputWindow>();
+            mockOutputWindow.Setup(o => o.CreatePane(ref It.Ref<Guid>.IsAny, It.IsAny<string>(), 1, 1)).Returns(0);
+            mockOutputWindow.Setup(o => o.GetPane(ref It.Ref<Guid>.IsAny, out pane));
+
+            // act
+            var outputWindowTraceListener = new OutputWindowTracerListener(mockOutputWindow.Object, "TestPane");
+
+            Trace.Write("Test log");
+
+            // assert
+            mockPane.Verify(p => p.OutputStringThreadSafe(It.IsAny<string>()), Times.Once);
+            currentOutputString.Should().Be("Test log");
+
+            Trace.WriteLine("More test logs");
+
+            mockPane.Verify(p => p.OutputStringThreadSafe(It.IsAny<string>()), Times.Exactly(2));
+            currentOutputString.Should().Be(Environment.NewLine + "More test logs");
+        }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Models\ReplacementModelTests.cs" />
     <Compile Include="Models\RuleModelTests.cs" />
     <Compile Include="Models\SarifErrorListItemTests.cs" />
+    <Compile Include="OutputWindowTracerListenerTests.cs" />
     <Compile Include="ProjectNameCacheTests.cs" />
     <Compile Include="ResourceExtractor.cs" />
     <Compile Include="SarifTextViewCreationListenerTests.cs" />


### PR DESCRIPTION
# Description

Add a dedicated output window pane for SARIF viewer, can log viewer's own debug information into the pane by calling `Trace.WriteLine`

![image](https://user-images.githubusercontent.com/76094515/191415502-437c7a06-9fe6-456e-8ab1-c39c1b893669.png)
