### PR TITLE
Fix an issue cannot navigate to the source file

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/ResultTextMarker.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ResultTextMarker.cs
@@ -402,19 +402,19 @@ namespace Microsoft.Sarif.Viewer
                 return false;
             }
 
-            if (this.fileSystem.FileExists(this.resolvedFullFilePath) &&
-                Uri.TryCreate(this.resolvedFullFilePath, UriKind.Absolute, out Uri uri))
+            if (this.fileSystem.FileExists(this.resolvedFullFilePath))
             {
-                // Fill out the region's properties
-                this.fullyPopulatedRegion = FileRegionsCache.Instance.PopulateTextRegionProperties(this.region, uri, populateSnippet: true);
-            }
-
-            if (this.fileSystem.FileExists(this.resolvedFullFilePath) &&
-                !Path.IsPathRooted(this.resolvedFullFilePath) &&
-                Uri.TryCreate(Path.Combine(this.fileSystem.EnvironmentCurrentDirectory, this.resolvedFullFilePath), UriKind.Absolute, out Uri fullPathUri))
-            {
-                // Fill out the region's properties
-                this.fullyPopulatedRegion = FileRegionsCache.Instance.PopulateTextRegionProperties(this.region, fullPathUri, populateSnippet: true);
+                Uri resolvedUri;
+                if (Uri.TryCreate(this.resolvedFullFilePath, UriKind.Absolute, out resolvedUri) ||
+                    (!Path.IsPathRooted(this.resolvedFullFilePath) &&
+                    Uri.TryCreate(
+                        Path.Combine(this.fileSystem.EnvironmentCurrentDirectory, this.resolvedFullFilePath),
+                        UriKind.Absolute,
+                        out resolvedUri)))
+                {
+                    // Fill out the region's properties
+                    this.fullyPopulatedRegion = FileRegionsCache.Instance.PopulateTextRegionProperties(this.region, resolvedUri, populateSnippet: true);
+                }
             }
 
             this.regionAndFilePathAreFullyPopulated = this.fullyPopulatedRegion != null;

--- a/src/Sarif.Viewer.VisualStudio.Core/ResultTextMarker.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ResultTextMarker.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Sarif.Viewer
         /// Indicates whether a call to <see cref="TryToFullyPopulateRegionAndFilePath"/> has already occurred and what the result
         /// of the remap was.
         /// </summary>
-        private bool? regionAndFilePathAreFullyPopulated;
+        internal bool? regionAndFilePathAreFullyPopulated;
 
         /// <summary>
         /// Contains the file path after a call to <see cref="TryToFullyPopulateRegionAndFilePath"/>.
@@ -73,6 +73,11 @@ namespace Microsoft.Sarif.Viewer
         /// That is as long as they don't modify the document in another editor (say notepad).
         /// </remarks>
         private IPersistentSpan persistentSpan;
+
+        /// <summary>
+        /// The file system used to access files/directories.
+        /// </summary>
+        private readonly IFileSystem fileSystem;
 
         /// <summary>
         /// Gets the fully populated file path.
@@ -145,8 +150,9 @@ namespace Microsoft.Sarif.Viewer
         /// <param name="nonHghlightedColor">The non-highlighted color of the marker.</param>
         /// <param name="highlightedColor">The highlighted color of the marker.</param>
         /// <param name="context">The data context for this result marker.</param>
-        public ResultTextMarker(int runIndex, int resultId, string uriBaseId, Region region, string fullFilePath, string nonHghlightedColor, string highlightedColor, object context)
-            : this(runIndex: runIndex, resultId: resultId, uriBaseId: uriBaseId, region: region, fullFilePath: fullFilePath, nonHighlightedColor: nonHghlightedColor, highlightedColor: highlightedColor, errorType: null, tooltipContent: null, context: context)
+        /// <param name="fileSystem">The file system.</param>
+        public ResultTextMarker(int runIndex, int resultId, string uriBaseId, Region region, string fullFilePath, string nonHghlightedColor, string highlightedColor, object context, IFileSystem fileSystem = null)
+            : this(runIndex: runIndex, resultId: resultId, uriBaseId: uriBaseId, region: region, fullFilePath: fullFilePath, nonHighlightedColor: nonHghlightedColor, highlightedColor: highlightedColor, errorType: null, tooltipContent: null, context: context, fileSystem: fileSystem)
         {
         }
 
@@ -163,10 +169,11 @@ namespace Microsoft.Sarif.Viewer
         /// <param name="errorType">The error type as defined by <see cref="Microsoft.VisualStudio.Text.Adornments.PredefinedErrorTypeNames"/>.</param>
         /// <param name="tooltipContent">The tool tip content to display in Visual studio.</param>
         /// <param name="context">The data context for this result marker.</param>
+        /// <param name="fileSystem">The file system.</param>
         /// <remarks>
         /// The tool tip content could be as simple as just a string, or something more complex like a WPF/XAML object.
         /// </remarks>
-        public ResultTextMarker(int runIndex, int resultId, string uriBaseId, Region region, string fullFilePath, string nonHighlightedColor, string highlightedColor, string errorType, object tooltipContent, object context)
+        public ResultTextMarker(int runIndex, int resultId, string uriBaseId, Region region, string fullFilePath, string nonHighlightedColor, string highlightedColor, string errorType, object tooltipContent, object context, IFileSystem fileSystem = null)
         {
             this.ResultId = resultId;
             this.RunIndex = runIndex;
@@ -178,6 +185,7 @@ namespace Microsoft.Sarif.Viewer
             this.ToolTipContent = tooltipContent;
             this.ErrorType = errorType;
             this.Context = context;
+            this.fileSystem = fileSystem ?? new FileSystem();
         }
 
         /// <summary>
@@ -365,9 +373,14 @@ namespace Microsoft.Sarif.Viewer
             return true;
         }
 
-        private bool TryToFullyPopulateRegionAndFilePath()
+        internal bool TryToFullyPopulateRegionAndFilePath()
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
+            if (!SarifViewerPackage.IsUnitTesting)
+            {
+#pragma warning disable VSTHRD108 // Assert thread affinity unconditionally.
+                ThreadHelper.ThrowIfNotOnUIThread();
+#pragma warning restore VSTHRD108 // Assert thread affinity unconditionally.
+            }
 
             if (this.regionAndFilePathAreFullyPopulated.HasValue)
             {
@@ -379,7 +392,7 @@ namespace Microsoft.Sarif.Viewer
                 return false;
             }
 
-            if (File.Exists(this.FullFilePath))
+            if (this.fileSystem.FileExists(this.FullFilePath))
             {
                 this.resolvedFullFilePath = this.FullFilePath;
             }
@@ -389,11 +402,19 @@ namespace Microsoft.Sarif.Viewer
                 return false;
             }
 
-            if (File.Exists(this.resolvedFullFilePath) &&
+            if (this.fileSystem.FileExists(this.resolvedFullFilePath) &&
                 Uri.TryCreate(this.resolvedFullFilePath, UriKind.Absolute, out Uri uri))
             {
                 // Fill out the region's properties
                 this.fullyPopulatedRegion = FileRegionsCache.Instance.PopulateTextRegionProperties(this.region, uri, populateSnippet: true);
+            }
+
+            if (this.fileSystem.FileExists(this.resolvedFullFilePath) &&
+                !Path.IsPathRooted(this.resolvedFullFilePath) &&
+                Uri.TryCreate(Path.Combine(this.fileSystem.EnvironmentCurrentDirectory, this.resolvedFullFilePath), UriKind.Absolute, out Uri fullPathUri))
+            {
+                // Fill out the region's properties
+                this.fullyPopulatedRegion = FileRegionsCache.Instance.PopulateTextRegionProperties(this.region, fullPathUri, populateSnippet: true);
             }
 
             this.regionAndFilePathAreFullyPopulated = this.fullyPopulatedRegion != null;

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ResultTextMarkerTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ResultTextMarkerTests.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.Sarif;
+
+using Moq;
+
+using Xunit;
+
+namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
+{
+    public class ResultTextMarkerTests : SarifViewerPackageUnitTests
+    {
+        [Fact]
+        public void TryToFullyPopulateRegionAndFilePath_EmptyFullFilePath_ShouldFail()
+        {
+            var textMarker = new ResultTextMarker(runIndex: 1, resultId: 1, uriBaseId: "SRCROOT", region: new Region(), fullFilePath: string.Empty, nonHghlightedColor: string.Empty, highlightedColor: string.Empty, context: null, fileSystem: null);
+
+            textMarker.TryToFullyPopulateRegionAndFilePath().Should().BeFalse();
+            textMarker.regionAndFilePathAreFullyPopulated.Should().BeNull();
+        }
+
+        [Fact]
+        public void TryToFullyPopulateRegionAndFilePath_FullFilePathDoesNotExist_ShouldFail()
+        {
+            var fileSystemMock = new Mock<IFileSystem>();
+            fileSystemMock.Setup(fs => fs.FileExists(It.IsAny<string>())).Returns(false);
+
+            string sourceFilePath = Path.Combine(Directory.GetCurrentDirectory(), @"src\view\controller.cs");
+            var textMarker = new ResultTextMarker(runIndex: 1, resultId: 1, uriBaseId: "SRCROOT", region: new Region(), fullFilePath: sourceFilePath, nonHghlightedColor: string.Empty, highlightedColor: string.Empty, context: null, fileSystem: fileSystemMock.Object);
+
+            textMarker.TryToFullyPopulateRegionAndFilePath().Should().BeFalse();
+            textMarker.regionAndFilePathAreFullyPopulated.Should().BeFalse();
+        }
+
+        [Fact]
+        public void TryToFullyPopulateRegionAndFilePath_FullFilePathExists_ShouldSucceed()
+        {
+            var fileSystemMock = new Mock<IFileSystem>();
+            fileSystemMock.Setup(fs => fs.FileExists(It.IsAny<string>())).Returns(true);
+
+            string sourceFilePath = Path.Combine(Directory.GetCurrentDirectory(), @"src\view\controller.cs");
+            var textMarker = new ResultTextMarker(runIndex: 1, resultId: 1, uriBaseId: "SRCROOT", region: new Region(), fullFilePath: sourceFilePath, nonHghlightedColor: string.Empty, highlightedColor: string.Empty, context: null, fileSystem: fileSystemMock.Object);
+
+            textMarker.TryToFullyPopulateRegionAndFilePath().Should().BeTrue();
+            textMarker.regionAndFilePathAreFullyPopulated.Should().BeTrue();
+        }
+
+        [Fact]
+        public void TryToFullyPopulateRegionAndFilePath_RelativeFilePath_InWorkingDirectory_ShouldSucceed()
+        {
+            var fileSystemMock = new Mock<IFileSystem>();
+            fileSystemMock.Setup(fs => fs.FileExists(It.IsAny<string>())).Returns(true);
+            fileSystemMock.Setup(fs => fs.EnvironmentCurrentDirectory).Returns(Directory.GetCurrentDirectory());
+
+            string sourceFilePath = "src/view/controller.cs";
+            var textMarker = new ResultTextMarker(runIndex: 1, resultId: 1, uriBaseId: "SRCROOT", region: new Region(), fullFilePath: sourceFilePath, nonHghlightedColor: string.Empty, highlightedColor: string.Empty, context: null, fileSystem: fileSystemMock.Object);
+
+            textMarker.TryToFullyPopulateRegionAndFilePath().Should().BeTrue();
+            textMarker.regionAndFilePathAreFullyPopulated.Should().BeTrue();
+        }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="OutputWindowTracerListenerTests.cs" />
     <Compile Include="ProjectNameCacheTests.cs" />
     <Compile Include="ResourceExtractor.cs" />
+    <Compile Include="ResultTextMarkerTests.cs" />
     <Compile Include="SarifTextViewCreationListenerTests.cs" />
     <Compile Include="SarifViewerPackageUnitTests.cs" />
     <Compile Include="Sarif\ArtifactChangeExtensionsTests.cs" />


### PR DESCRIPTION
# Description

When the user launches Visual Studio using command line at the repo's root directory, to open the folder view in VS. E.g.
`C:\repos\devcanvas\devenv.exe .`

The current working directory is set to the repo's root directory. The File.Exists() check for a relative path under this directory now returns true. E.g. File.Exists("client/Console/InsightConsole/FileFetcher.cs") is false if current working directory is not the repo root, but its true if current working directory is set to repo root.

Fix the issue in the code assumes File.Exists() return true only for the full file path.

Fix for #453