### PR TITLE
Refresh Error List item if property values change

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/CodeAnalysisResultManager.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/CodeAnalysisResultManager.cs
@@ -20,6 +20,7 @@ using EnvDTE80;
 
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.CodeAnalysis.Sarif.Visitors;
+using Microsoft.Sarif.Viewer.ErrorList;
 using Microsoft.Sarif.Viewer.Models;
 using Microsoft.Sarif.Viewer.Sarif;
 using Microsoft.Sarif.Viewer.Views;
@@ -523,7 +524,13 @@ namespace Microsoft.Sarif.Viewer
             ThreadHelper.ThrowIfNotOnUIThread();
             foreach (SarifErrorListItem sarifError in sarifErrors)
             {
+                int oldIdentity = sarifError.GetIdentity();
                 sarifError.RemapFilePath(originalPath, remappedPath);
+
+                if (sarifError.GetIdentity() != oldIdentity)
+                {
+                    SarifTableDataSource.Instance.UpdateError(oldIdentity, sarifError);
+                }
             }
         }
 

--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/SarifResultTableEntry.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/SarifResultTableEntry.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
         public SarifResultTableEntry(SarifErrorListItem error)
         {
-            this.Identity = error.GetHashCode();
+            this.Identity = error.GetIdentity();
             this.Error = error;
 
             // Set the data that's fast to retrieve into the dictionary of values.

--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/SarifTableDataSource.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/SarifTableDataSource.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             {
                 if (this.logFileToTableEntries.TryGetValue(newItem.LogFilePath, out List<SarifResultTableEntry> entries))
                 {
-                    SarifResultTableEntry entryToRemove = entries.First(entry => (int)entry.Identity == oldItemIdentity);
+                    SarifResultTableEntry entryToRemove = entries.FirstOrDefault(entry => (int)entry.Identity == oldItemIdentity);
 
                     if (entryToRemove != null)
                     {

--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/SarifTableDataSource.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/SarifTableDataSource.cs
@@ -45,10 +45,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
         {
             get
             {
-                if (_instance == null)
-                {
-                    _instance = new SarifTableDataSource();
-                }
+                _instance ??= new SarifTableDataSource();
 
                 return _instance;
             }
@@ -57,6 +54,8 @@ namespace Microsoft.Sarif.Viewer.ErrorList
         public override string Identifier => Guids.GuidVSPackageString;
 
         public override string DisplayName => Resources.ErrorListTableDataSourceDisplayName;
+
+        internal Dictionary<string, List<SarifResultTableEntry>> LogFileToTableEntries => this.logFileToTableEntries;
 
         public override IDisposable Subscribe(ITableDataSink sink)
         {

--- a/src/Sarif.Viewer.VisualStudio.Core/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Models/SarifErrorListItem.cs
@@ -484,6 +484,16 @@ namespace Microsoft.Sarif.Viewer
                 {
                     location.FilePath = remappedPath;
                     location.Region = regionsCache.PopulateTextRegionProperties(location.Region, uri, true);
+
+                    if (this.LineNumber != location.Region.StartLine)
+                    {
+                        this.LineNumber = location.Region.StartLine;
+                    }
+
+                    if (this.ColumnNumber != location.Region.StartColumn)
+                    {
+                        this.ColumnNumber = location.Region.StartColumn;
+                    }
                 }
             }
 
@@ -883,6 +893,34 @@ namespace Microsoft.Sarif.Viewer
 
                 SdkUIUtilities.OpenExternalUrl(uriString);
             }
+        }
+
+        // Generates an unique hash value using the properties affect content of error list item.
+        // If any of these properties changes, needs to refresh error list item.
+        internal int GetIdentity()
+        {
+            int hashCode = -509415362;
+            int hashFactor = -1521134295;
+
+            // ignore FileName because it usally updated to a physical file path during file resolving
+            // but error list only shows file name not the full path
+            // hashCode = (hashCode * hashFactor) + EqualityComparer<string>.Default.GetIdentity(this.FileName);
+
+            hashCode = (hashCode * hashFactor) + EqualityComparer<string>.Default.GetHashCode(this.Category);
+            hashCode = (hashCode * hashFactor) + this.LineNumber.GetHashCode();
+            hashCode = (hashCode * hashFactor) + this.ColumnNumber.GetHashCode();
+            hashCode = (hashCode * hashFactor) + this.Level.GetHashCode();
+            hashCode = (hashCode * hashFactor) + EqualityComparer<string>.Default.GetHashCode(this.ProjectName);
+            hashCode = (hashCode * hashFactor) + this.VSSuppressionState.GetHashCode();
+            hashCode = (hashCode * hashFactor) + EqualityComparer<string>.Default.GetHashCode(this.Message);
+            hashCode = (hashCode * hashFactor) + EqualityComparer<string>.Default.GetHashCode(this.RawMessage);
+            hashCode = (hashCode * hashFactor) + EqualityComparer<string>.Default.GetHashCode(this.ShortMessage);
+            hashCode = (hashCode * hashFactor) + this.HasDetailsContent.GetHashCode();
+            hashCode = (hashCode * hashFactor) + EqualityComparer<string>.Default.GetHashCode(this.HelpLink);
+            hashCode = (hashCode * hashFactor) + EqualityComparer<ToolModel>.Default.GetHashCode(this.Tool);
+            hashCode = (hashCode * hashFactor) + EqualityComparer<RuleModel>.Default.GetHashCode(this.Rule);
+
+            return hashCode;
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifTableDataSourceTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifTableDataSourceTests.cs
@@ -97,6 +97,10 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
 
             oldItemIdentity += 1; // identity does not exist
             SarifTableDataSource.Instance.UpdateError(oldItemIdentity, item);
+
+            item = entries[0].Error;
+            item.LineNumber.Should().Be(5);
+            item.ColumnNumber.Should().Be(6);
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifTableDataSourceTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifTableDataSourceTests.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.Sarif.Viewer.ErrorList;
+
+using Xunit;
+
+namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
+{
+    public class SarifTableDataSourceTests : SarifViewerPackageUnitTests
+    {
+        [Fact]
+        public async Task UpdateError_TestAsync()
+        {
+            string logFile = "testLog.sarif";
+            string artifactPath = "/item1.cpp";
+            var testLog = new SarifLog
+            {
+                Runs = new List<Run>
+                {
+                    new Run
+                    {
+                        Tool = new Tool
+                        {
+                            Driver = new ToolComponent
+                            {
+                                Name = "Test",
+                                SemanticVersion = "1.0",
+                            },
+                        },
+                        Results = new List<Result>
+                        {
+                            new Result
+                            {
+                                RuleId = "TST001",
+                                Message = new Message { Text = "Error 1" },
+                                Locations = new List<Location>
+                                {
+                                    new Location
+                                    {
+                                        PhysicalLocation = new PhysicalLocation
+                                        {
+                                            ArtifactLocation = new ArtifactLocation
+                                            {
+                                                Uri = new Uri($"file://{artifactPath}"),
+                                            },
+                                            Region = new Region
+                                            {
+                                                CharOffset = 194,
+                                                CharLength = 14
+                                            }
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+
+            await ErrorListService.ProcessSarifLogAsync(testLog, logFile, cleanErrors: true, openInEditor: false);
+
+            bool hasError = SarifTableDataSource.Instance.HasErrors("/item1.cpp");
+            hasError.Should().BeTrue();
+
+            SarifTableDataSource.Instance.LogFileToTableEntries.Should().NotBeNull();
+            List<SarifResultTableEntry> entries = SarifTableDataSource.Instance.LogFileToTableEntries[logFile];
+            entries.Should().NotBeNull();
+            entries.Count.Should().Be(1);
+
+            SarifErrorListItem item = entries[0].Error;
+            item.LineNumber.Should().Be(0);
+            item.ColumnNumber.Should().Be(0);
+
+            int oldItemIdentity = item.GetIdentity();
+
+            item.LineNumber = 5;
+            item.ColumnNumber = 6;
+
+            bool idChanged = oldItemIdentity != item.GetIdentity();
+            idChanged.Should().BeTrue();
+
+            SarifTableDataSource.Instance.UpdateError(oldItemIdentity, item);
+
+            item = entries[0].Error;
+            item.LineNumber.Should().Be(5);
+            item.ColumnNumber.Should().Be(6);
+        }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifTableDataSourceTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifTableDataSourceTests.cs
@@ -94,6 +94,9 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             item = entries[0].Error;
             item.LineNumber.Should().Be(5);
             item.ColumnNumber.Should().Be(6);
+
+            oldItemIdentity += 1; // identity does not exist
+            SarifTableDataSource.Instance.UpdateError(oldItemIdentity, item);
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
@@ -55,6 +55,7 @@
     <Compile Include="ErrorList\SarifErrorListItemTests.cs" />
     <Compile Include="ErrorList\SarifFileWithContentsTests.cs" />
     <Compile Include="ErrorList\SarifResultEntryTests.cs" />
+    <Compile Include="ErrorList\SarifTableDataSourceTests.cs" />
     <Compile Include="ExceptionalConditionsCalculatorTests.cs" />
     <Compile Include="FileWatcher\SarifFolderWatcherTests.cs" />
     <Compile Include="Models\AnalysisStepCollectionTests.cs" />


### PR DESCRIPTION
# Description

Some Sarif result defines region using `charOffset` and `charLength`, after Sarif loaded into Error List, the line/column number is 0. When the user navigates to the result, the viewer tries to resolve the source file path and populate the region with line/column numbers. But the Error List still shows 0 line/column number.

# Fix:
Update the `SarifErrorListItem`'s `LineNumber`/`ColumnNumber` after the viewer populated the region related to the result.
Implement a way to "refresh" an entry in the error list so if the entry's property changes, we can update the Error List.