### PR TITLE
Lower Sarif.SDK version in the Interop assembly

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Interop/Sarif.Viewer.VisualStudio.Interop.csproj
+++ b/src/Sarif.Viewer.VisualStudio.Interop/Sarif.Viewer.VisualStudio.Interop.csproj
@@ -35,7 +35,7 @@
     <!-- Necessary to resolve version conflict on Newtonsoft.Json: -->
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Sarif.Sdk">
-      <Version>2.4.15</Version>
+      <Version>2.4.13</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>


### PR DESCRIPTION
# Description

In order to make Sarifer extension works for VS 2019, it has to reference Sarif.PatternMatcher 1.9.0, which has a compatible NewtonSoft.Json 12.0.3 for VS 2019.

Sarif.PatternMatcher 1.9.0 references to Sarif.SDK 2.4.13 but current Interop references to 2.4.15. This caused an build error in Sarifer:
```
Restoring NuGet packages for Sarif.Sarifer.2022...
Restoring NuGet packages for Sarif.Sarifer...
NU1605: Detected package downgrade: Sarif.Sdk from 2.4.15 to 2.4.13. Reference the package directly from the project to select a different version.
 Microsoft.Sarif.Sarifer -> Sarif.Viewer.VisualStudio.Interop -> Sarif.Sdk (>= 2.4.15)
 Microsoft.Sarif.Sarifer -> Sarif.Sdk (>= 2.4.13)
Errors in C:\GitHub.com\sarifer\src\Sarif.Sarifer\Sarif.Sarifer.csproj
    NU1605: Detected package downgrade: Sarif.Sdk from 2.4.15 to 2.4.13. Reference the package directly from the project to select a different version.
     Microsoft.Sarif.Sarifer -> Sarif.Viewer.VisualStudio.Interop -> Sarif.Sdk (>= 2.4.15)
     Microsoft.Sarif.Sarifer -> Sarif.Sdk (>= 2.4.13)
BuildAndTest: NuGet restore failed for Sarif.Sarifer.
BuildAndTest FAILED.
```

The fix is to lower the Sarif.SDK version in the Interop project.