### PR TITLE
Refactor result source plumbing so services can check Options dialog state

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                     VsShellUtilities.ShowMessageBox(ServiceProvider.GlobalProvider,
                                                     Resources.VersionPropertyNotFound_DialogTitle,
                                                     null, // title
-                                                    OLEMSGICON.OLEMSGICON_QUERY,
+                                                    OLEMSGICON.OLEMSGICON_WARNING,
                                                     OLEMSGBUTTON.OLEMSGBUTTON_OK,
                                                     OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST);
                     return;

--- a/src/Sarif.Viewer.VisualStudio.Core/Options/SarifViewerOptions.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/SarifViewerOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 
 using Microsoft.VisualStudio.Shell;
 
@@ -10,6 +11,8 @@ namespace Microsoft.Sarif.Viewer.Options
     internal class SarifViewerOption : ISarifViewerOptions
     {
         private readonly bool shouldMonitorSarifFolderDefaultValue = true;
+
+        private readonly bool isGitHubAdvancedSecurityEnabled = false;
 
         private readonly bool keyEventAdornmentEnabledDefaultValue = true;
 
@@ -26,15 +29,23 @@ namespace Microsoft.Sarif.Viewer.Options
         {
             this.package = package ?? throw new ArgumentNullException(nameof(package));
             this.optionPage = (SarifViewerOptionPage)this.package.GetDialogPage(typeof(SarifViewerOptionPage));
+            this.OptionStates = new Dictionary<string, bool>
+            {
+                { "MonitorSarifFolder", this.ShouldMonitorSarifFolder },
+                { "GitHubAdvancedSecurity", this.IsGitHubAdvancedSecurityEnabled },
+                { "KeyEventAdornment", this.IsKeyEventAdornmentEnabled },
+            };
         }
 
         private SarifViewerOption() { }
 
         public bool ShouldMonitorSarifFolder => this.optionPage?.MonitorSarifFolder ?? this.shouldMonitorSarifFolderDefaultValue;
 
-        public bool IsGitHubAdvancedSecurityEnabled => this.optionPage?.EnableGitHubAdvancedSecurity ?? this.IsGitHubAdvancedSecurityEnabled;
+        public bool IsGitHubAdvancedSecurityEnabled => this.optionPage?.EnableGitHubAdvancedSecurity ?? this.isGitHubAdvancedSecurityEnabled;
 
         public bool IsKeyEventAdornmentEnabled => this.optionPage?.EnableKeyEventAdornment ?? this.keyEventAdornmentEnabledDefaultValue;
+
+        public readonly Dictionary<string, bool> OptionStates;
 
         /// <summary>
         /// Gets the instance of the command.
@@ -57,6 +68,16 @@ namespace Microsoft.Sarif.Viewer.Options
         public static void InitializeForUnitTests()
         {
             Instance = new SarifViewerOption();
+        }
+
+        public bool IsOptionEnabled(string optionName)
+        {
+            if (this.OptionStates.TryGetValue(optionName, out bool state))
+            {
+                return state;
+            }
+
+            return false;
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.Core/SarifViewerPackage.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/SarifViewerPackage.cs
@@ -6,10 +6,8 @@ using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.Configuration;
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
-using System.Threading.Tasks;
 
 using EnvDTE80;
 
@@ -212,14 +210,17 @@ namespace Microsoft.Sarif.Viewer
             if (this.resultSourceHost == null)
             {
                 string solutionPath = GetSolutionDirectoryPath();
-                if (!string.IsNullOrWhiteSpace(solutionPath) && SarifViewerOption.Instance.IsGitHubAdvancedSecurityEnabled)
+                if (!string.IsNullOrWhiteSpace(solutionPath))
                 {
-                    this.resultSourceHost = new ResultSourceHost(solutionPath, this);
+                    this.resultSourceHost = new ResultSourceHost(solutionPath, this, SarifViewerOption.Instance.IsOptionEnabled);
                     this.resultSourceHost.ServiceEvent += this.ResultSourceHost_ServiceEvent;
                 }
             }
 
-            await this.resultSourceHost?.RequestAnalysisResultsAsync();
+            if (this.resultSourceHost != null)
+            {
+                await this.resultSourceHost.RequestAnalysisResultsAsync();
+            }
         }
 
         private object CreateService(IServiceContainer container, Type serviceType)

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.Domain.Core/Services/IResultSourceService.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.Domain.Core/Services/IResultSourceService.cs
@@ -31,6 +31,11 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.Services
         int FirstCommandId { get; set; }
 
         /// <summary>
+        /// Gets or sets the callback method to get the option state for the specified key.
+        /// </summary>
+        Func<string, bool> GetOptionStateCallback { get; set; }
+
+        /// <summary>
         /// Initializes the service instance.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.Core/ResultSourceFactory.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.Core/ResultSourceFactory.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory
     {
         private readonly StandardKernel standardKernel;
         private readonly string solutionRootPath;
+
+        private readonly Func<string, bool> getOptionStateCallback;
         private readonly Dictionary<Type, (int, int)> resultSources = new Dictionary<Type, (int firstMenuId, int firstCommandId)>
         {
             { typeof(GitHubSourceService), (firstMenuId: 0x5000, firstCommandId: 0x8B67) },
@@ -39,9 +41,14 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory
         /// </summary>
         /// <param name="solutionRootPath">The local root path of the current project/solution.</param>
         /// <param name="serviceProvider">The service provider.</param>
-        public ResultSourceFactory(string solutionRootPath, IServiceProvider serviceProvider)
+        /// <param name="getOptionStateCallback">Callback <see cref="Func{T, TResult}"/> to retrieve option state.</param>
+        public ResultSourceFactory(
+            string solutionRootPath,
+            IServiceProvider serviceProvider,
+            Func<string, bool> getOptionStateCallback)
         {
             this.solutionRootPath = solutionRootPath;
+            this.getOptionStateCallback = getOptionStateCallback;
 
             // Set up dependency injection
             this.standardKernel = new StandardKernel();
@@ -60,10 +67,15 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory
         /// </summary>
         /// <param name="solutionRootPath">The local root path of the current project/solution.</param>
         /// <param name="standardKernel">The <see cref="StandardKernel"/>.</param>
-        public ResultSourceFactory(string solutionRootPath, StandardKernel standardKernel)
+        /// <param name="getOptionStateCallback">Callback <see cref="Func{T, TResult}"/> to retrieve option state.</param>
+        public ResultSourceFactory(
+            string solutionRootPath,
+            StandardKernel standardKernel,
+            Func<string, bool> getOptionStateCallback)
         {
             this.solutionRootPath = solutionRootPath;
             this.standardKernel = standardKernel;
+            this.getOptionStateCallback = getOptionStateCallback;
         }
 
         public static bool IsUnitTesting { get; set; } = false;
@@ -71,13 +83,14 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory
         /// <inheritdoc/>
         public async Task<Result<IResultSourceService, ErrorType>> GetResultSourceServiceAsync()
         {
-            var ctorArg = new ConstructorArgument("solutionRootPath", this.solutionRootPath, true);
+            var ctorArg1 = new ConstructorArgument("solutionRootPath", this.solutionRootPath, true);
+            var ctorArg2 = new ConstructorArgument("getOptionStateCallback", this.getOptionStateCallback, true);
             int index = -1;
 
             foreach (KeyValuePair<Type, (int, int)> kvp in this.resultSources)
             {
                 index++;
-                if (this.standardKernel.Get(kvp.Key, ctorArg) is IResultSourceService sourceService)
+                if (this.standardKernel.Get(kvp.Key, ctorArg1, ctorArg2) is IResultSourceService sourceService)
                 {
                     Result result = await sourceService.IsActiveAsync();
 
@@ -87,6 +100,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory
                         {
                             sourceService.FirstMenuId = kvp.Value.Item1;
                             sourceService.FirstCommandId = kvp.Value.Item2;
+                            sourceService.GetOptionStateCallback = this.getOptionStateCallback;
                             return Result.Success<IResultSourceService, ErrorType>(sourceService);
                         }
                         catch (Exception) { }

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.Core/ResultSourceHost.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.Core/ResultSourceHost.cs
@@ -26,11 +26,13 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory
         /// </summary>
         /// <param name="solutionRootPath">The local root path of the current project/solution.</param>
         /// <param name="serviceProvider">The service provider.</param>
+        /// <param name="getOptionStateCallback">Callback <see cref="Func{T, TResult}"/> to retrieve option state.</param>
         public ResultSourceHost(
             string solutionRootPath,
-            IServiceProvider serviceProvider)
+            IServiceProvider serviceProvider,
+            Func<string, bool> getOptionStateCallback)
         {
-            this.resultSourceFactory = new ResultSourceFactory(solutionRootPath, serviceProvider);
+            this.resultSourceFactory = new ResultSourceFactory(solutionRootPath, serviceProvider, getOptionStateCallback);
         }
 
         /// <summary>

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.UnitTests/ResultSourceFactoryTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.UnitTests/ResultSourceFactoryTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory.UnitTests
             standardKernel.Bind<IInfoBarService>().ToConstant(mockInfoBarService.Object);
             standardKernel.Bind<IStatusBarService>().ToConstant(mockStatusBarService.Object);
 
-            var resultSourceFactory = new ResultSourceFactory(path, standardKernel);
+            var resultSourceFactory = new ResultSourceFactory(path, standardKernel, (string key) => true);
             Result<IResultSourceService, ErrorType> result = resultSourceFactory.GetResultSourceServiceAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
             result.IsSuccess.Should().BeTrue();
@@ -101,7 +101,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory.UnitTests
             standardKernel.Bind<IInfoBarService>().ToConstant(mockInfoBarService.Object);
             standardKernel.Bind<IStatusBarService>().ToConstant(mockStatusBarService.Object);
 
-            var resultSourceFactory = new ResultSourceFactory(path, standardKernel);
+            var resultSourceFactory = new ResultSourceFactory(path, standardKernel, (string key) => true);
             Result<IResultSourceService, ErrorType> result = resultSourceFactory.GetResultSourceServiceAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
             result.IsSuccess.Should().BeFalse();

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.GitHubAdvancedSecurity.UnitTests/GitHubSourceServiceTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.GitHubAdvancedSecurity.UnitTests/GitHubSourceServiceTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
             var mockGitExe = new Mock<IGitExe>();
             mockGitExe.Setup(g => g.GetRepoRootAsync()).Returns(new ValueTask<string>(path));
 
-            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), null, null, null, null, null, mockFileSystem.Object, mockGitExe.Object, null, null);
+            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), (string key) => true, null, null, null, null, null, mockFileSystem.Object, mockGitExe.Object, null, null);
             CSharpFunctionalExtensions.Result result = await gitHubSourceService.IsActiveAsync();
             result.IsSuccess.Should().BeTrue();
         }
@@ -59,7 +59,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
             var mockGitExe = new Mock<IGitExe>();
             mockGitExe.Setup(g => g.GetRepoRootAsync()).Returns(new ValueTask<string>(path));
 
-            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), null, null, null, null, null, mockFileSystem.Object, mockGitExe.Object, null, null);
+            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), null, null, null, null, null, null, mockFileSystem.Object, mockGitExe.Object, null, null);
             CSharpFunctionalExtensions.Result result = await gitHubSourceService.IsActiveAsync();
             result.IsSuccess.Should().BeFalse();
         }
@@ -73,7 +73,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
 
             var mockGitExe = new Mock<IGitExe>();
 
-            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), null, null, null, null, null, null, mockGitExe.Object, null, null);
+            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), null, null, null, null, null, null, null, mockGitExe.Object, null, null);
 
             (string Path, string Name) result = gitHubSourceService.ParseBranchString(input);
             result.Path.Should().Be(expectedPath);
@@ -89,7 +89,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
 
             var mockGitExe = new Mock<IGitExe>();
 
-            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), null, null, null, null, null, null, mockGitExe.Object, null, null);
+            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), null, null, null, null, null, null, null, mockGitExe.Object, null, null);
 
             (string Path, string Name) result = gitHubSourceService.ParseBranchString(input);
             result.Path.Should().Be(expectedPath);
@@ -105,7 +105,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
 
             var mockGitExe = new Mock<IGitExe>();
 
-            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), null, null, null, null, null, null, mockGitExe.Object, null, null);
+            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), null, null, null, null, null, null, null, mockGitExe.Object, null, null);
 
             (string Path, string Name) result = gitHubSourceService.ParseBranchString(input);
             result.Path.Should().Be(expectedPath);
@@ -142,6 +142,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
 
             var gitHubSourceService = new GitHubSourceService(
                 path,
+                (string key) => true,
                 mockServiceProvider.Object,
                 mockHttpClientAdapter.Object,
                 mockSecretStoreRepository.Object,
@@ -193,6 +194,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
 
             var gitHubSourceService = new GitHubSourceService(
                 path,
+                (string key) => true,
                 mockServiceProvider.Object,
                 mockHttpClientAdapter.Object,
                 mockSecretStoreRepository.Object,
@@ -239,6 +241,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
 
             var gitHubSourceService = new GitHubSourceService(
                 path,
+                null,
                 mockServiceProvider.Object,
                 mockHttpClientAdapter.Object,
                 mockSecretStoreRepository.Object,
@@ -293,6 +296,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
 
             var gitHubSourceService = new GitHubSourceService(
                 path,
+                null,
                 mockServiceProvider.Object,
                 mockHttpClientAdapter.Object,
                 mockSecretStoreRepository.Object,
@@ -353,6 +357,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
 
             var gitHubSourceService = new GitHubSourceService(
                 path,
+                (string key) => true,
                 mockServiceProvider.Object,
                 mockHttpClientAdapter.Object,
                 mockSecretStoreRepository.Object,
@@ -414,6 +419,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
 
             var gitHubSourceService = new GitHubSourceService(
                 path,
+                (string key) => true,
                 mockServiceProvider.Object,
                 mockHttpClientAdapter.Object,
                 mockSecretStoreRepository.Object,
@@ -458,6 +464,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
 
             var gitHubSourceService = new GitHubSourceService(
                 path,
+                null,
                 mockServiceProvider.Object,
                 mockHttpClientAdapter.Object,
                 mockSecretStoreRepository.Object,
@@ -506,6 +513,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
 
             var gitHubSourceService = new GitHubSourceService(
                 path,
+                null,
                 mockServiceProvider.Object,
                 mockHttpClientAdapter.Object,
                 mockSecretStoreRepository.Object,
@@ -555,6 +563,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
 
             var gitHubSourceService = new GitHubSourceService(
                 path,
+                null,
                 mockServiceProvider.Object,
                 mockHttpClientAdapter.Object,
                 mockSecretStoreRepository.Object,
@@ -603,6 +612,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
 
             var gitHubSourceService = new GitHubSourceService(
                 path,
+                null,
                 mockServiceProvider.Object,
                 mockHttpClientAdapter.Object,
                 mockSecretStoreRepository.Object,
@@ -654,6 +664,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
 
             var gitHubSourceService = new GitHubSourceService(
                 path,
+                null,
                 mockServiceProvider.Object,
                 mockHttpClientAdapter.Object,
                 mockSecretStoreRepository.Object,

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.GitHubAdvancedSecurity.UnitTests/GitHubSourceServiceTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.GitHubAdvancedSecurity.UnitTests/GitHubSourceServiceTests.cs
@@ -65,6 +65,22 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
         }
 
         [Fact]
+        public async Task IsActive_ReturnsFalse_WhenServiceIsDisabled_Async()
+        {
+            string path = @"C:\Git\MyProject";
+
+            var mockFileSystem = new Mock<IFileSystem>();
+            mockFileSystem.Setup(fs => fs.DirectoryExists(It.IsAny<string>())).Returns(true);
+
+            var mockGitExe = new Mock<IGitExe>();
+            mockGitExe.Setup(g => g.GetRepoRootAsync()).Returns(new ValueTask<string>(path));
+
+            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), (string key) => false, null, null, null, null, null, mockFileSystem.Object, mockGitExe.Object, null, null);
+            CSharpFunctionalExtensions.Result result = await gitHubSourceService.IsActiveAsync();
+            result.IsSuccess.Should().BeFalse();
+        }
+
+        [Fact]
         public void ParseBranchString_ReturnsCorrectValue_WhenBranchHContainsNoSlashes()
         {
             string input = "my-branch";


### PR DESCRIPTION
This is clunky but will be fixed once the project restructuring is complete. All this does is pass a delegate from the extension package class through to the result source services.
The entire point is to get rid of the awareness of the GHAS service's option. With the restructuring, the services will be able to check this directly.