### PR TITLE
Show Notification exception details in Error List

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Models/SarifErrorListItem.cs
@@ -937,14 +937,16 @@ namespace Microsoft.Sarif.Viewer
         {
             string message = notification.Message.Text?.Trim() ?? string.Empty;
 
-            if (!string.IsNullOrWhiteSpace(notification.Exception?.Kind?.Trim()))
+            string kind = notification.Exception?.Kind?.Trim();
+            if (!string.IsNullOrWhiteSpace(kind))
             {
-                message += Environment.NewLine + $"[Exception type: {notification.Exception.Kind.Trim()}]";
+                message += Environment.NewLine + $"[Exception type: {kind}]";
             }
 
-            if (!string.IsNullOrWhiteSpace(notification.Exception?.Message?.Trim()))
+            string exceptionMessage = notification.Exception?.Message?.Trim();
+            if (!string.IsNullOrWhiteSpace(exceptionMessage))
             {
-                message += Environment.NewLine + $"[Exception message: {notification.Exception.Message.Trim()}]";
+                message += Environment.NewLine + $"[Exception message: {exceptionMessage}]";
             }
 
             return message;

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
@@ -922,23 +922,87 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             item.Properties.First(kv => kv.Key == "nullObj").Value.Should().BeNull();
             item.Properties.First(kv => kv.Key == "object").Value.Should().BeEquivalentTo("{\"foo\":\"bar\"}");
         }
-        private static SarifErrorListItem MakeErrorListItem(Result result)
-        {
-            return MakeErrorListItem(EmptyRun, result);
-        }
 
-        private static SarifErrorListItem MakeErrorListItem(Run run, Result result)
+        [Fact]
+        public void SarifErrorListItem_NotificationWithException()
         {
-            result.Run = run;
-            return new SarifErrorListItem(
-                run,
-                runIndex: 0,
-                result: result,
-                logFilePath: "log.sarif",
-                projectNameCache: new ProjectNameCache(solution: null))
+            var notificationWithoutException = new Notification
             {
-                FileName = FileName,
+                Locations = new List<Location>
+                {
+                    new Location
+                    {
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            ArtifactLocation = new ArtifactLocation
+                            {
+                                Uri = new Uri("file:///Logs/Tests/program.cs")
+                            }
+                        }
+                    }
+                },
+                Message = new Message
+                {
+                    Text = "An exception of type 'TargetInvocationException' was raised analyzing 'program.cs' for check 'DoNotExposePlaintextSecrets/GoogleApiKey' (which has been disabled)."
+                },
+                Level = FailureLevel.Error,
             };
+
+            var notificationWithException = new Notification
+            {
+                Locations = new List<Location>
+                {
+                    new Location
+                    {
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            ArtifactLocation = new ArtifactLocation
+                            {
+                                Uri = new Uri("file:///Logs/Tests/program.cs")
+                            }
+                        }
+                    }
+                },
+                Message = new Message
+                {
+                    Text = "An exception of type 'TargetInvocationException' was raised analyzing 'program.cs' for check 'DoNotExposePlaintextSecrets/GoogleApiKey' (which has been disabled)."
+                },
+                Level = FailureLevel.Error,
+                Exception = new ExceptionData
+                {
+                    Kind = "FileNotFoundException",
+                    Message = "Could not load file or assembly 'Marvin, Version=1.1.0.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844' or one of its dependencies. The system cannot find the file specified."
+                },
+                Descriptor = new ReportingDescriptorReference
+                {
+                    Id = "ERR998.ExceptionInAnalyze"
+                },
+                AssociatedRule = new ReportingDescriptorReference
+                {
+                    Id = "SEC101/003"
+                }
+            };
+
+            CodeAnalysisResultManager.Instance.RunIndexToRunDataCache[0] = new RunDataCache();
+
+            SarifErrorListItem item = TestUtilities.MakeErrorListItem(notificationWithException);
+
+            item.Should().NotBeNull();
+            item.Level.Should().Be(FailureLevel.Error);
+            item.RawMessage.Should().Contain("An exception of type 'TargetInvocationException'");
+            item.RawMessage.Should().Contain("FileNotFoundException");
+            item.RawMessage.Should().Contain("Could not load file or assembly 'Marvin, Version=1.1.0.0");
+            item.FileName.Should().Contain("program.cs");
+            item.Locations.Should().NotBeNullOrEmpty();
+
+            item = TestUtilities.MakeErrorListItem(notificationWithoutException);
+            item.Should().NotBeNull();
+            item.Level.Should().Be(FailureLevel.Error);
+            item.RawMessage.Should().Contain("An exception of type 'TargetInvocationException'");
+            item.RawMessage.Should().NotContain("FileNotFoundException");
+            item.RawMessage.Should().NotContain("Could not load file or assembly 'Marvin, Version=1.1.0.0");
+            item.FileName.Should().Contain("program.cs");
+            item.Locations.Should().NotBeNullOrEmpty();
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/TestUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/TestUtilities.cs
@@ -42,5 +42,15 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 FileName = "file.c",
             };
         }
+
+        internal static SarifErrorListItem MakeErrorListItem(Notification notification)
+        {
+            return new SarifErrorListItem(
+                EmptyRun,
+                runIndex: 0,
+                notification: notification,
+                logFilePath: "log.sarif",
+                projectNameCache: new ProjectNameCache(solution: null));
+        }
     }
 }


### PR DESCRIPTION
# Description

If the Inovation.ToolExecutionNotfication contains ExceptionData, show them in the error list expando.

E.g. below sarif section, the toolExecutionNotification with exception.
```
      "invocations": [
        {
          "startTimeUtc": "2022-11-11T22:53:53.055Z",
          "endTimeUtc": "2022-11-11T22:53:53.615Z",
          "toolExecutionNotifications": [
            {
              "locations": [
                {
                  "physicalLocation": {
                    "artifactLocation": {
                      "uri": "file:///C:/SarifLog/AnalysisTestSolution/AnalysisTestProject1/Class1.cs",
                      "index": 0
                    }
                  }
                }
              ],
              "message": {
                "text": "An exception of type 'TargetInvocationException' was raised analyzing 'Class1.cs' for check 'DoNotExposePlaintextSecrets/GoogleApiKey' (which has been disabled). The exception may have resulted from a problem related to parsing the analysis target, and not specific to the rule, however."
              },
              "level": "error",
              "exception": {
                "kind": "FileNotFoundException",
                "message": "Could not load file or assembly 'Marvin, Version=1.1.0.0, Culture=neutral, PublicKeyToken=21a5e83f6f5bb844' or one of its dependencies. The system cannot find the file specified.",
              },
              "descriptor": {
                "id": "ERR998.ExceptionInAnalyze"
              },
              "associatedRule": {
                "id": "SEC101/003"
              }
            },
```

Add the exception type and message into 'SarifErrorListItem.RawMessage' so in the error list user can see the details.

The screenshot:
![image](https://user-images.githubusercontent.com/76094515/202063816-4e467a53-08e5-4162-9f08-346350431c80.png)
