### PR TITLE
Update build pipeline scan target and artifacts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ extends:
                 submodules: recursive
               outputs:
               - output: pipelineArtifact
-                targetPath: $(System.DefaultWorkingDirectory)
+                targetPath: $(System.DefaultWorkingDirectory)/bld/bin
             
               breakGlass:
                 justification: Because of the batch script task below


### PR DESCRIPTION
Change the scanning target path/artifact path to be just the bin folder. Currently it's the entire repo