### PR TITLE
Fix relative path resolution when SLN is in repo root

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.2022/Sarif.Viewer.VisualStudio.2022.csproj
+++ b/src/Sarif.Viewer.VisualStudio.2022/Sarif.Viewer.VisualStudio.2022.csproj
@@ -7,6 +7,9 @@
   <PropertyGroup>
     <DocumentationFile>..\..\bld\bin\AnyCPU_Debug\Sarif.Viewer.VisualStudio.2022\Microsoft.Sarif.Viewer.2022.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <DeployExtension>True</DeployExtension>
+  </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <!-- Hack: https://github.com/dotnet/Nerdbank.GitVersioning/issues/404, since its a vsix with pages -->
   <Import Project="$(MSBuildProjectExtensionsPath)$(_TargetAssemblyProjectName)$(MSBuildProjectExtension).nuget.g.props" Condition=" '$(_TargetAssemblyProjectName)' != '' and '$(ImportProjectExtensionProps)' != 'false' and exists('$(MSBuildProjectExtensionsPath)$(_TargetAssemblyProjectName)$(MSBuildProjectExtension).nuget.g.props')" />

--- a/src/Sarif.Viewer.VisualStudio.Core/ResultTextMarker.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ResultTextMarker.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 
 using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.Sarif.Viewer.Shell;
 using Microsoft.Sarif.Viewer.Tags;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
@@ -80,6 +81,11 @@ namespace Microsoft.Sarif.Viewer
         private readonly IFileSystem fileSystem;
 
         /// <summary>
+        /// The file system used to access files/directories.
+        /// </summary>
+        private readonly IFileSystem2 fileSystem2;
+
+        /// <summary>
         /// Gets the fully populated file path.
         /// </summary>
         /// <remarks>
@@ -151,8 +157,9 @@ namespace Microsoft.Sarif.Viewer
         /// <param name="highlightedColor">The highlighted color of the marker.</param>
         /// <param name="context">The data context for this result marker.</param>
         /// <param name="fileSystem">The file system.</param>
-        public ResultTextMarker(int runIndex, int resultId, string uriBaseId, Region region, string fullFilePath, string nonHghlightedColor, string highlightedColor, object context, IFileSystem fileSystem = null)
-            : this(runIndex: runIndex, resultId: resultId, uriBaseId: uriBaseId, region: region, fullFilePath: fullFilePath, nonHighlightedColor: nonHghlightedColor, highlightedColor: highlightedColor, errorType: null, tooltipContent: null, context: context, fileSystem: fileSystem)
+        /// <param name="fileSystem2">The file system 2.</param>
+        public ResultTextMarker(int runIndex, int resultId, string uriBaseId, Region region, string fullFilePath, string nonHghlightedColor, string highlightedColor, object context, IFileSystem fileSystem = null, IFileSystem2 fileSystem2 = null)
+            : this(runIndex: runIndex, resultId: resultId, uriBaseId: uriBaseId, region: region, fullFilePath: fullFilePath, nonHighlightedColor: nonHghlightedColor, highlightedColor: highlightedColor, errorType: null, tooltipContent: null, context: context, fileSystem: fileSystem, fileSystem2: fileSystem2)
         {
         }
 
@@ -170,10 +177,11 @@ namespace Microsoft.Sarif.Viewer
         /// <param name="tooltipContent">The tool tip content to display in Visual studio.</param>
         /// <param name="context">The data context for this result marker.</param>
         /// <param name="fileSystem">The file system.</param>
+        /// <param name="fileSystem2">The file system 2.</param>
         /// <remarks>
         /// The tool tip content could be as simple as just a string, or something more complex like a WPF/XAML object.
         /// </remarks>
-        public ResultTextMarker(int runIndex, int resultId, string uriBaseId, Region region, string fullFilePath, string nonHighlightedColor, string highlightedColor, string errorType, object tooltipContent, object context, IFileSystem fileSystem = null)
+        public ResultTextMarker(int runIndex, int resultId, string uriBaseId, Region region, string fullFilePath, string nonHighlightedColor, string highlightedColor, string errorType, object tooltipContent, object context, IFileSystem fileSystem = null, IFileSystem2 fileSystem2 = null)
         {
             this.ResultId = resultId;
             this.RunIndex = runIndex;
@@ -186,6 +194,7 @@ namespace Microsoft.Sarif.Viewer
             this.ErrorType = errorType;
             this.Context = context;
             this.fileSystem = fileSystem ?? new FileSystem();
+            this.fileSystem2 = fileSystem2 ?? new FileSystem2();
         }
 
         /// <summary>
@@ -392,7 +401,7 @@ namespace Microsoft.Sarif.Viewer
                 return false;
             }
 
-            if (Path.IsPathRooted(this.resolvedFullFilePath) && this.fileSystem.FileExists(this.FullFilePath))
+            if (this.fileSystem2.IsPathRooted(this.resolvedFullFilePath) && this.fileSystem.FileExists(this.FullFilePath))
             {
                 this.resolvedFullFilePath = this.FullFilePath;
             }

--- a/src/Sarif.Viewer.VisualStudio.Core/ResultTextMarker.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ResultTextMarker.cs
@@ -401,7 +401,7 @@ namespace Microsoft.Sarif.Viewer
                 return false;
             }
 
-            if (this.fileSystem2.IsPathRooted(this.resolvedFullFilePath) && this.fileSystem.FileExists(this.FullFilePath))
+            if (this.fileSystem2.IsPathRooted(this.FullFilePath) && this.fileSystem.FileExists(this.FullFilePath))
             {
                 this.resolvedFullFilePath = this.FullFilePath;
             }

--- a/src/Sarif.Viewer.VisualStudio.Core/ResultTextMarker.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ResultTextMarker.cs
@@ -392,7 +392,7 @@ namespace Microsoft.Sarif.Viewer
                 return false;
             }
 
-            if (this.fileSystem.FileExists(this.FullFilePath))
+            if (Path.IsPathRooted(this.resolvedFullFilePath) && this.fileSystem.FileExists(this.FullFilePath))
             {
                 this.resolvedFullFilePath = this.FullFilePath;
             }

--- a/src/Sarif.Viewer.VisualStudio.Core/SpanHelper.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/SpanHelper.cs
@@ -65,20 +65,29 @@ namespace Microsoft.Sarif.Viewer
                 return false;
             }
 
-            ITextSnapshotLine startTextLine = currentSnapshot.GetLineFromLineNumber(textSpan.iStartLine);
-            ITextSnapshotLine endTextLine = currentSnapshot.GetLineFromLineNumber(textSpan.iEndLine);
-
-            if (textSpan.iStartIndex > startTextLine.Length)
+            try
             {
-                return false;
+                ITextSnapshotLine startTextLine = currentSnapshot.GetLineFromLineNumber(textSpan.iStartLine);
+                ITextSnapshotLine endTextLine = currentSnapshot.GetLineFromLineNumber(textSpan.iEndLine);
+
+                if (textSpan.iStartIndex > startTextLine.Length)
+                {
+                    return false;
+                }
+
+                // If we are highlighting just one line and the end column of the end line is out of scope
+                // or we are highlighting just one line and we reset the start column above, then highlight the entire line.
+                if (textSpan.iEndLine == textSpan.iStartLine && textSpan.iStartIndex > textSpan.iEndIndex)
+                {
+                    textSpan.iStartIndex = 0;
+                    textSpan.iEndIndex = endTextLine.Length - 1;
+                }
             }
-
-            // If we are highlighting just one line and the end column of the end line is out of scope
-            // or we are highlighting just one line and we reset the start column above, then highlight the entire line.
-            if (textSpan.iEndLine == textSpan.iStartLine && textSpan.iStartIndex > textSpan.iEndIndex)
+            catch (ArgumentOutOfRangeException)
             {
-                textSpan.iStartIndex = 0;
-                textSpan.iEndIndex = endTextLine.Length - 1;
+                // This exception can be thrown even though the range check above has passed.
+                // Unknown cause. Net effect is no text highlighting.
+                return false;
             }
 
             return true;

--- a/src/Sarif.Viewer.VisualStudio.Shell.Core/FileSystem2.cs
+++ b/src/Sarif.Viewer.VisualStudio.Shell.Core/FileSystem2.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+
+namespace Microsoft.Sarif.Viewer.Shell
+{
+    public class FileSystem2 : IFileSystem2
+    {
+        public bool IsPathRooted(string path)
+        {
+            return Path.IsPathRooted(path);
+        }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio.Shell.Core/IFileSystem2.cs
+++ b/src/Sarif.Viewer.VisualStudio.Shell.Core/IFileSystem2.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sarif.Viewer.Shell
+{
+    public interface IFileSystem2
+    {
+        bool IsPathRooted(string path);
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio.Shell.Core/Sarif.Viewer.VisualStudio.Shell.Core.projitems
+++ b/src/Sarif.Viewer.VisualStudio.Shell.Core/Sarif.Viewer.VisualStudio.Shell.Core.projitems
@@ -10,8 +10,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)BrowserService.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FileSystem2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FileWatcher.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitExe.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)IFileSystem2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IFileWatcher.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IGitExe.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IInfoBarService.cs" />

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ResultTextMarkerTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ResultTextMarkerTests.cs
@@ -36,8 +36,11 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             var fileSystemMock = new Mock<IFileSystem>();
             fileSystemMock.Setup(fs => fs.FileExists(It.IsAny<string>())).Returns(false);
 
+            var fileSystem2Mock = new Mock<IFileSystem2>();
+            fileSystem2Mock.Setup(fs => fs.IsPathRooted(It.IsAny<string>())).Returns(true);
+
             string sourceFilePath = Path.Combine(Directory.GetCurrentDirectory(), @"src\view\controller.cs");
-            var textMarker = new ResultTextMarker(runIndex: 1, resultId: 1, uriBaseId: "SRCROOT", region: new Region(), fullFilePath: sourceFilePath, nonHghlightedColor: string.Empty, highlightedColor: string.Empty, context: null, fileSystem: fileSystemMock.Object);
+            var textMarker = new ResultTextMarker(runIndex: 1, resultId: 1, uriBaseId: "SRCROOT", region: new Region(), fullFilePath: sourceFilePath, nonHghlightedColor: string.Empty, highlightedColor: string.Empty, context: null, fileSystem: fileSystemMock.Object, fileSystem2: fileSystem2Mock.Object);
 
             textMarker.TryToFullyPopulateRegionAndFilePath().Should().BeFalse();
             textMarker.regionAndFilePathAreFullyPopulated.Should().BeFalse();

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ResultTextMarkerTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ResultTextMarkerTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 
 using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.Sarif.Viewer.Shell;
 
 using Moq;
 
@@ -48,8 +49,11 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             var fileSystemMock = new Mock<IFileSystem>();
             fileSystemMock.Setup(fs => fs.FileExists(It.IsAny<string>())).Returns(true);
 
+            var fileSystem2Mock = new Mock<IFileSystem2>();
+            fileSystem2Mock.Setup(fs => fs.IsPathRooted(It.IsAny<string>())).Returns(true);
+
             string sourceFilePath = Path.Combine(Directory.GetCurrentDirectory(), @"src\view\controller.cs");
-            var textMarker = new ResultTextMarker(runIndex: 1, resultId: 1, uriBaseId: "SRCROOT", region: new Region(), fullFilePath: sourceFilePath, nonHghlightedColor: string.Empty, highlightedColor: string.Empty, context: null, fileSystem: fileSystemMock.Object);
+            var textMarker = new ResultTextMarker(runIndex: 1, resultId: 1, uriBaseId: "SRCROOT", region: new Region(), fullFilePath: sourceFilePath, nonHghlightedColor: string.Empty, highlightedColor: string.Empty, context: null, fileSystem: fileSystemMock.Object, fileSystem2: fileSystem2Mock.Object);
 
             textMarker.TryToFullyPopulateRegionAndFilePath().Should().BeTrue();
             textMarker.regionAndFilePathAreFullyPopulated.Should().BeTrue();
@@ -62,8 +66,11 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             fileSystemMock.Setup(fs => fs.FileExists(It.IsAny<string>())).Returns(true);
             fileSystemMock.Setup(fs => fs.EnvironmentCurrentDirectory).Returns(Directory.GetCurrentDirectory());
 
+            var fileSystem2Mock = new Mock<IFileSystem2>();
+            fileSystem2Mock.Setup(fs => fs.IsPathRooted(It.IsAny<string>())).Returns(true);
+
             string sourceFilePath = "src/view/controller.cs";
-            var textMarker = new ResultTextMarker(runIndex: 1, resultId: 1, uriBaseId: "SRCROOT", region: new Region(), fullFilePath: sourceFilePath, nonHghlightedColor: string.Empty, highlightedColor: string.Empty, context: null, fileSystem: fileSystemMock.Object);
+            var textMarker = new ResultTextMarker(runIndex: 1, resultId: 1, uriBaseId: "SRCROOT", region: new Region(), fullFilePath: sourceFilePath, nonHghlightedColor: string.Empty, highlightedColor: string.Empty, context: null, fileSystem: fileSystemMock.Object, fileSystem2: fileSystem2Mock.Object);
 
             textMarker.TryToFullyPopulateRegionAndFilePath().Should().BeTrue();
             textMarker.regionAndFilePathAreFullyPopulated.Should().BeTrue();

--- a/src/Sarif.Viewer.VisualStudio.sln
+++ b/src/Sarif.Viewer.VisualStudio.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		build.props = build.props
+		build2022.props = build2022.props
 		..\BuildAndTest.cmd = ..\BuildAndTest.cmd
 		..\scripts\BuildAndTest.ps1 = ..\scripts\BuildAndTest.ps1
 		..\scripts\BuildPackagesFromSigningDirectory.ps1 = ..\scripts\BuildPackagesFromSigningDirectory.ps1

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -7,6 +7,9 @@
   <PropertyGroup>
     <DocumentationFile>..\..\bld\bin\AnyCPU_Debug\Sarif.Viewer.VisualStudio\Microsoft.Sarif.Viewer.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <DeployExtension>True</DeployExtension>
+  </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <!-- Hack: https://github.com/dotnet/Nerdbank.GitVersioning/issues/404, since its a vsix with pages -->
   <Import Project="$(MSBuildProjectExtensionsPath)$(_TargetAssemblyProjectName)$(MSBuildProjectExtension).nuget.g.props" Condition=" '$(_TargetAssemblyProjectName)' != '' and '$(ImportProjectExtensionProps)' != 'false' and exists('$(MSBuildProjectExtensionsPath)$(_TargetAssemblyProjectName)$(MSBuildProjectExtension).nuget.g.props')" />


### PR DESCRIPTION
DevOps bug 2008452
The fix is to check that the FullFilePath is rooted (absolute) before using it as the resolved path. This check is necessary because File.Exists will return true for relative paths under some circumstances.