### PR TITLE
Fixing the bug of error list not populating on re-open

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/SarifViewerPackage.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/SarifViewerPackage.cs
@@ -183,9 +183,18 @@ namespace Microsoft.Sarif.Viewer
             SolutionEvents.OnBeforeCloseSolution += this.SolutionEvents_OnBeforeCloseSolution;
             SolutionEvents.OnAfterCloseSolution += this.SolutionEvents_OnAfterCloseSolution;
             SolutionEvents.OnAfterBackgroundSolutionLoadComplete += this.SolutionEvents_OnAfterBackgroundSolutionLoadComplete;
+            SolutionEvents.OnBeforeOpenProject += this.SolutionEvents_OnBeforeOpenProject;
 
             await this.InitializeResultSourceHostAsync();
             return;
+        }
+
+        private void SolutionEvents_OnBeforeOpenProject(object sender, EventArgs e)
+        {
+            // start watcher when the solution is opened.
+            this.sarifFolderMonitor?.StartWatch();
+
+            this.JoinableTaskFactory.Run(async () => await InitializeResultSourceHostAsync());
         }
 
         private void SolutionEvents_OnAfterCloseSolution(object sender, EventArgs e)


### PR DESCRIPTION
There is a bug where opening a folder after the first open does not cause the error list to populate.
This will re-start the folder monitor when opening a new project is opening, letting the error list and other parts populate and be usable.