### PR TITLE
Renaming the "I fixed this!!!!" menu option.

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListCommand.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListCommand.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             bool visible = e.NewItem != null || (this.selectionService.SelectedItems != null && this.selectionService.SelectedItems.Any());
             this.SetCommandVisibility(ProvideFeedbackCommandId, visible);
             this.SetCommandVisibility(SuppressResultCommandId, visible);
-            this.SetCommandVisibility(IFixedThisCommandId, visible);
+            //this.SetCommandVisibility(IFixedThisCommandId, visible);
         }
 
         private void SetCommandVisibility(int cmdID, bool visible)

--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListCommand.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListCommand.cs
@@ -235,8 +235,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             bool visible = e.NewItem != null || (this.selectionService.SelectedItems != null && this.selectionService.SelectedItems.Any());
             this.SetCommandVisibility(ProvideFeedbackCommandId, visible);
             this.SetCommandVisibility(SuppressResultCommandId, visible);
-
-            // this.SetCommandVisibility(IFixedThisCommandId, visible);
+            this.SetCommandVisibility(IFixedThisCommandId, visible);
         }
 
         private void SetCommandVisibility(int cmdID, bool visible)

--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListCommand.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListCommand.cs
@@ -235,7 +235,8 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             bool visible = e.NewItem != null || (this.selectionService.SelectedItems != null && this.selectionService.SelectedItems.Any());
             this.SetCommandVisibility(ProvideFeedbackCommandId, visible);
             this.SetCommandVisibility(SuppressResultCommandId, visible);
-            //this.SetCommandVisibility(IFixedThisCommandId, visible);
+
+            // this.SetCommandVisibility(IFixedThisCommandId, visible);
         }
 
         private void SetCommandVisibility(int cmdID, bool visible)

--- a/src/Sarif.Viewer.VisualStudio.Core/SarifCommandPackage.vsct
+++ b/src/Sarif.Viewer.VisualStudio.Core/SarifCommandPackage.vsct
@@ -159,14 +159,15 @@
             <ButtonText>Suppress result in SARIF file</ButtonText>
           </Strings>
       </Button>
-      <Button guid="guidSarifErrorListCmdSet" id="cmdidIFixedThisCommand" priority="0x0100" type="Button">
+      <!--Can be used to hide an error list item until the end of the VS session.--> 
+      <!--<Button guid="guidSarifErrorListCmdSet" id="cmdidIFixedThisCommand" priority="0x0100" type="Button">
         <Parent guid="guidSarifErrorListCmdSet" id="ErrorListContextMenuGroup" />
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <ButtonText>I fixed this!!!!!</ButtonText>
         </Strings>
-      </Button>
+      </Button>-->
       
       <!-- Error List result source service #1 menu items -->
       <Button guid="guidSarifErrorListResultSourceServiceCommandSet" id="c4883543-de09-4989-83c2-16e40d105831" priority="0x1000" >
@@ -209,7 +210,7 @@
       <IDSymbol name="cmdidNonShippingCodeResultCommand" value="0x0306"/>
       <IDSymbol name="cmdidOtherResultCommand" value="0x0307"/>
       <IDSymbol name="cmdidSuppressResultCommand" value="0x0308"/>
-      <IDSymbol name="cmdidIFixedThisCommand" value="0x0309"/>
+      <!--<IDSymbol name="cmdidIFixedThisCommand" value="0x0309"/>-->
     </GuidSymbol>
 
     <GuidSymbol name="guidSarifErrorListResultSourceServiceCommandSet" value="{b04424d9-49bc-4e04-9ecc-ad5b68cce4bc}">

--- a/src/Sarif.Viewer.VisualStudio.Core/SarifCommandPackage.vsct
+++ b/src/Sarif.Viewer.VisualStudio.Core/SarifCommandPackage.vsct
@@ -160,14 +160,14 @@
           </Strings>
       </Button>
       <!--Can be used to hide an error list item until the end of the VS session.--> 
-      <!--<Button guid="guidSarifErrorListCmdSet" id="cmdidIFixedThisCommand" priority="0x0100" type="Button">
+      <Button guid="guidSarifErrorListCmdSet" id="cmdidIFixedThisCommand" priority="0x0100" type="Button">
         <Parent guid="guidSarifErrorListCmdSet" id="ErrorListContextMenuGroup" />
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>I fixed this!!!!!</ButtonText>
+          <ButtonText>Hide until end of session.</ButtonText>
         </Strings>
-      </Button>-->
+      </Button>
       
       <!-- Error List result source service #1 menu items -->
       <Button guid="guidSarifErrorListResultSourceServiceCommandSet" id="c4883543-de09-4989-83c2-16e40d105831" priority="0x1000" >
@@ -210,7 +210,7 @@
       <IDSymbol name="cmdidNonShippingCodeResultCommand" value="0x0306"/>
       <IDSymbol name="cmdidOtherResultCommand" value="0x0307"/>
       <IDSymbol name="cmdidSuppressResultCommand" value="0x0308"/>
-      <!--<IDSymbol name="cmdidIFixedThisCommand" value="0x0309"/>-->
+      <IDSymbol name="cmdidIFixedThisCommand" value="0x0309"/>
     </GuidSymbol>
 
     <GuidSymbol name="guidSarifErrorListResultSourceServiceCommandSet" value="{b04424d9-49bc-4e04-9ecc-ad5b68cce4bc}">


### PR DESCRIPTION
Currently the "I fixed this!!!!" menu option is confusing to users as it is unclear about the purpose and seems to do the same thing as the suppression menu item and so this PR hides it in the vsct file.
The "I fixed this!!!!" menu item allows for users to remove an item in the error list temporarily until the end of the VS session, where it will show up again the next time the user opens VS. This user can get similar benefits from the suppression menu item and so we decided to remove for clarity.