### PR TITLE
Add wrapping and margins to text blocks

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/Models/ScrollViewerWrapper.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Models/ScrollViewerWrapper.cs
@@ -87,7 +87,7 @@ namespace Sarif.Viewer.VisualStudio.Core.Models
                 var stackPanel = new StackPanel();
                 Dictionary<string, int> errorTypeToSeverity = GetRankDictionary();
 
-                IEnumerable<IErrorTag> sortedObjects = this.objectsToWrap.OrderBy(x =>
+                List<IErrorTag> sortedObjects = this.objectsToWrap.OrderBy(x =>
                 {
                     int rank;
                     if (!errorTypeToSeverity.TryGetValue(x.ErrorType, out rank))
@@ -96,11 +96,20 @@ namespace Sarif.Viewer.VisualStudio.Core.Models
                     }
 
                     return rank;
-                });
+                }).ToList();
 
-                foreach (IErrorTag objectToWrap in sortedObjects)
+                for (int i = 0; i < sortedObjects.Count; i++)
                 {
+                    IErrorTag objectToWrap = sortedObjects[i];
                     UIElement tooltip = (UIElement)objectToWrap.ToolTipContent;
+                    if (tooltip is TextBlock textBlock)
+                    {
+                        if (i != 0)
+                        {
+                            textBlock.Margin = new Thickness(0, 20, 0, 0);
+                        }
+                    }
+
                     stackPanel.Children.Add(tooltip);
                 }
 

--- a/src/Sarif.Viewer.VisualStudio.Core/Tags/SarifLocationErrorTag.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Tags/SarifLocationErrorTag.cs
@@ -110,6 +110,7 @@ namespace Microsoft.Sarif.Viewer.Tags
                         TextBlock textblock = new TextBlock() { Text = item.strContent };
                         textblock.FontSize = FontSize;
                         textblock.Foreground = TextBrush;
+                        textblock.TextWrapping = TextWrapping.Wrap;
                         return textblock;
                     }
                     else


### PR DESCRIPTION
Currently plaintext popups have 2 problems
1. They do not properly wrap text, sending it offscreen where it is unreadable
2. They do not have margins between elements, meaning that when scanning it can be difficult to determine where one result starts and another ends.

Some before and after comparisons:
Before:
![image](https://github.com/microsoft/sarif-visualstudio-extension/assets/126511432/70da156c-fe15-4ca2-b22f-17cba5ee7f28)

After:
![image](https://github.com/microsoft/sarif-visualstudio-extension/assets/126511432/ffdcd730-52a4-4d50-a791-3f2e1955b902)
