### PR TITLE
Fixing highlights un necessarily stretching

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/SpanHelper.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/SpanHelper.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Sarif.Viewer
                         startIndex: documentSpan.iStartIndex,
                         endLine: documentSpan.iEndLine,
                         endIndex: documentSpan.iEndIndex,
-                        trackingMode: SpanTrackingMode.EdgeNegative);
+                        trackingMode: SpanTrackingMode.EdgeExclusive);
 
             return true;
         }

--- a/src/Sarif.Viewer.VisualStudio.Core/SpanHelper.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/SpanHelper.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Sarif.Viewer
                         startIndex: documentSpan.iStartIndex,
                         endLine: documentSpan.iEndLine,
                         endIndex: documentSpan.iEndIndex,
-                        trackingMode: SpanTrackingMode.EdgeInclusive);
+                        trackingMode: SpanTrackingMode.EdgeNegative);
 
             return true;
         }

--- a/src/Sarif.Viewer.VisualStudio.Core/Tags/SarifLocationErrorTagger.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Tags/SarifLocationErrorTagger.cs
@@ -65,8 +65,6 @@ namespace Microsoft.Sarif.Viewer.Tags
         {
             if (this.tagsDirty)
             {
-                this.tagsDirty = false;
-
                 IEnumerable<SarifErrorListItem> errorsInCurrentFile = CodeAnalysisResultManager
                     .Instance
                     .RunIndexToRunDataCache
@@ -98,10 +96,10 @@ namespace Microsoft.Sarif.Viewer.Tags
                 yield break;
             }
 
+            var groupedBySpan = new Dictionary<(int start, int end), (List<IErrorTag> tagList, SnapshotSpan snapshotSpan)>();
+
             foreach (SnapshotSpan span in spans)
             {
-                var groupedBySpan = new Dictionary<(int start, int end), (List<IErrorTag> tagList, SnapshotSpan snapshotSpan)>();
-
                 foreach (ISarifLocationTag locationTag in this.currentTags.Where(currentTag => currentTag.PersistentSpan.Span != null))
                 {
                     SnapshotSpan snapshotSpan = locationTag.PersistentSpan.Span.GetSpan(span.Snapshot);
@@ -116,12 +114,12 @@ namespace Microsoft.Sarif.Viewer.Tags
                         groupedBySpan[spanKey].tagList.Add((IErrorTag)locationTag);
                     }
                 }
+            }
 
-                foreach (KeyValuePair<(int start, int end), (List<IErrorTag> tagList, SnapshotSpan snapshotSpan)> groupedTags in groupedBySpan)
-                {
-                    List<IErrorTag> tags = groupedTags.Value.tagList;
-                    yield return new TagSpan<IErrorTag>(span: groupedTags.Value.snapshotSpan, tag: new ScrollViewerWrapper(tags, SarifViewerColorOptions.Instance));
-                }
+            foreach (KeyValuePair<(int start, int end), (List<IErrorTag> tagList, SnapshotSpan snapshotSpan)> groupedTags in groupedBySpan)
+            {
+                List<IErrorTag> tags = groupedTags.Value.tagList;
+                yield return new TagSpan<IErrorTag>(span: groupedTags.Value.snapshotSpan, tag: new ScrollViewerWrapper(tags, SarifViewerColorOptions.Instance));
             }
         }
 

--- a/src/Sarif.Viewer.VisualStudio.Core/Tags/SarifLocationErrorTagger.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Tags/SarifLocationErrorTagger.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Sarif.Viewer.Tags
         {
             if (this.tagsDirty)
             {
+                this.tagsDirty = false;
                 IEnumerable<SarifErrorListItem> errorsInCurrentFile = CodeAnalysisResultManager
                     .Instance
                     .RunIndexToRunDataCache


### PR DESCRIPTION
Some users have experienced a bug where a highlighted span will keep stretching as the user keeps writing on the same line. 
For example if you have a file 
```
line 1;
line 2;
line 3;
line 4;
```
and have a highlight spanning from the start to the end of the first line, if you were to put your cursor on the end of line 1 and press enter to make a new line and starting writing, the new 2nd line would also be highlighted, even though it likely has no relevance to whatever error is on line 1.
<img width="241" alt="before" src="https://github.com/microsoft/sarif-visualstudio-extension/assets/126511432/debdaf4d-de70-4603-807f-9b64f62dfdd5">
Here is an example of what I mean, as the user puts text on the edges of the highlighted span, the highlight will grow past its initial intended range.
This change changes the SpanTrackingMode https://learn.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.text.spantrackingmode?view=visualstudiosdk-2022 to not track. 
As a result, the user is able to write before/after the block of text without flooding the code editor window.
<img width="411" alt="post" src="https://github.com/microsoft/sarif-visualstudio-extension/assets/126511432/1dc79958-4c76-46c2-8805-21956a462b67">
