### PR TITLE
log out button functionality

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptions.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 
 using Microsoft.Sarif.Viewer.ResultSources.Domain.Models;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.Sarif.Viewer.Options
 {
@@ -67,6 +68,8 @@ namespace Microsoft.Sarif.Viewer.Options
         /// </summary>
         public bool? DevCanvasLoggedIn => this.optionPage?.DevCanvasLoggedIn;
 
+        public bool? RefusedLogin;
+
         public Dictionary<string, object> OptionStates => new Dictionary<string, object>
             {
                 { "MonitorSarifFolder", this.ShouldMonitorSarifFolder },
@@ -74,6 +77,7 @@ namespace Microsoft.Sarif.Viewer.Options
                 { "KeyEventAdornment", this.IsKeyEventAdornmentEnabled },
                 { "DevCanvasServer", this.DevCanvasServerIndex },
                 { DevCanvasLoggedInKey, this.DevCanvasLoggedIn },
+                { "RefusedLogin", this.RefusedLogin },
             };
 
         /// <summary>

--- a/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptions.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptions.cs
@@ -4,9 +4,8 @@
 using System;
 using System.Collections.Generic;
 
+using Microsoft.Sarif.Viewer.ResultSources.Domain.Models;
 using Microsoft.VisualStudio.Shell;
-
-using Sarif.Viewer.VisualStudio.ResultSources.Domain.Core.Models;
 
 namespace Microsoft.Sarif.Viewer.Options
 {
@@ -40,7 +39,17 @@ namespace Microsoft.Sarif.Viewer.Options
         {
             this.package = package ?? throw new ArgumentNullException(nameof(package));
             this.optionPage = (SarifViewerGeneralOptionsPage)this.package.GetDialogPage(typeof(SarifViewerGeneralOptionsPage));
-            this.optionPage.SettingsEvent += SettingsEvent;
+            this.optionPage.SettingsEvent += Settings_ServiceEvent;
+        }
+
+        /// <summary>
+        /// Listens to when a setting event is fired.
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="e">Payload fired.</param>
+        public void Settings_ServiceEvent(object sender, ResultSources.Domain.Models.SettingsEventArgs e)
+        {
+            SettingsEvent?.Invoke(this, e);
         }
 
         private SarifViewerGeneralOptions() { }

--- a/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptions.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptions.cs
@@ -49,7 +49,6 @@ namespace Microsoft.Sarif.Viewer.Options
         /// </summary>
         public bool? DevCanvasLoggedIn => this.optionPage?.DevCanvasLoggedIn;
 
-
         public Dictionary<string, object> OptionStates => new Dictionary<string, object>
             {
                 { "MonitorSarifFolder", this.ShouldMonitorSarifFolder },

--- a/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptions.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptions.cs
@@ -6,10 +6,18 @@ using System.Collections.Generic;
 
 using Microsoft.VisualStudio.Shell;
 
+using Sarif.Viewer.VisualStudio.ResultSources.Domain.Core.Models;
+
 namespace Microsoft.Sarif.Viewer.Options
 {
     internal class SarifViewerGeneralOptions : ISarifViewerGeneralOptions
     {
+        /// <summary>
+        /// Fired when an event is fired by the settings ui.
+        /// Some examples of this are button clicks or other listeners.
+        /// </summary>
+        public event EventHandler<SettingsEventArgs> SettingsEvent;
+
         private const string DevCanvasLoggedInKey = "DevCanvasLoggedIn";
         private readonly bool shouldMonitorSarifFolderDefaultValue = true;
 
@@ -32,6 +40,7 @@ namespace Microsoft.Sarif.Viewer.Options
         {
             this.package = package ?? throw new ArgumentNullException(nameof(package));
             this.optionPage = (SarifViewerGeneralOptionsPage)this.package.GetDialogPage(typeof(SarifViewerGeneralOptionsPage));
+            this.optionPage.SettingsEvent += SettingsEvent;
         }
 
         private SarifViewerGeneralOptions() { }

--- a/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptions.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptions.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Sarif.Viewer.Options
 {
     internal class SarifViewerGeneralOptions : ISarifViewerGeneralOptions
     {
+        private const string DevCanvasLoggedInKey = "DevCanvasLoggedIn";
         private readonly bool shouldMonitorSarifFolderDefaultValue = true;
 
         private readonly bool isGitHubAdvancedSecurityEnabled = false;
@@ -43,12 +44,19 @@ namespace Microsoft.Sarif.Viewer.Options
 
         public int DevCanvasServerIndex => this.optionPage?.DevCanvasServerIndex ?? devCanvasServerIndexDefaultValue;
 
+        /// <summary>
+        /// Gets true if the user is logged in, false otherwise. Null only until the result source service loads.
+        /// </summary>
+        public bool? DevCanvasLoggedIn => this.optionPage?.DevCanvasLoggedIn;
+
+
         public Dictionary<string, object> OptionStates => new Dictionary<string, object>
             {
                 { "MonitorSarifFolder", this.ShouldMonitorSarifFolder },
                 { "GitHubAdvancedSecurity", this.IsGitHubAdvancedSecurityEnabled },
                 { "KeyEventAdornment", this.IsKeyEventAdornmentEnabled },
                 { "DevCanvasServer", this.DevCanvasServerIndex },
+                { DevCanvasLoggedInKey, this.DevCanvasLoggedIn },
             };
 
         /// <summary>
@@ -88,6 +96,24 @@ namespace Microsoft.Sarif.Viewer.Options
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Callback to allow other classes to set the current state of an option from the <see cref="OptionStates"/> dict.
+        /// If it fails to find an entry with the matching key, throws a new <see cref="KeyNotFoundException"/>.
+        /// </summary>
+        /// <param name="optionName">Key that is being looked up.</param>
+        /// <param name="optionValue">New value being assigned.</param>
+        public void SetOption(string optionName, object optionValue)
+        {
+            switch (optionName)
+            {
+                case DevCanvasLoggedInKey:
+                    this.optionPage.DevCanvasLoggedIn = bool.Parse(optionValue.ToString());
+                    break;
+                default:
+                    throw new KeyNotFoundException(optionName);
+            }
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptions.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptions.cs
@@ -127,6 +127,7 @@ namespace Microsoft.Sarif.Viewer.Options
             {
                 case DevCanvasLoggedInKey:
                     this.optionPage.DevCanvasLoggedIn = bool.Parse(optionValue.ToString());
+                    this.optionPage.InvokePropertyChanged();
                     break;
                 default:
                     throw new KeyNotFoundException(optionName);

--- a/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsControl.xaml
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsControl.xaml
@@ -67,7 +67,7 @@
                 <ComboBox SelectedIndex="{Binding DevCanvasServerIndex}" Margin="0,0,0,5">
                     <ComboBoxItem>Prod</ComboBoxItem>
                     <ComboBoxItem>Ppe</ComboBoxItem>
-                    <ComboBoxItem>Dev</ComboBoxItem>
+                    <ComboBoxItem>localhost</ComboBoxItem>
                 </ComboBox>
                 <Button Content="{Binding DevCanvasLoginButtonMessage, UpdateSourceTrigger=PropertyChanged}" Click="OnDevCanvasLoginButtonClick"/>
             </StackPanel>

--- a/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsControl.xaml
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsControl.xaml
@@ -69,6 +69,7 @@
                     <ComboBoxItem>Ppe</ComboBoxItem>
                     <ComboBoxItem>Dev</ComboBoxItem>
                 </ComboBox>
+                <Button Content="{Binding DevCanvasLoginButtonMessage}"/>
             </StackPanel>
         </GroupBox>
     </StackPanel>

--- a/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsControl.xaml
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsControl.xaml
@@ -63,13 +63,13 @@
                        Content="{StaticResource SarifViewerOptionsControl_DevCanvasGroupBoxHeader}"
                        AutomationProperties.AutomationId="DevCanvasGroupBoxLabel" />
             </GroupBox.Header>
-            <StackPanel Margin="5 ">
-                <ComboBox SelectedIndex="{Binding DevCanvasServerIndex}">
+            <StackPanel Margin="5">
+                <ComboBox SelectedIndex="{Binding DevCanvasServerIndex}" Margin="0,0,0,5">
                     <ComboBoxItem>Prod</ComboBoxItem>
                     <ComboBoxItem>Ppe</ComboBoxItem>
                     <ComboBoxItem>Dev</ComboBoxItem>
                 </ComboBox>
-                <Button Content="{Binding DevCanvasLoginButtonMessage}" Click="OnDevCanvasLoginButtonClick"/>
+                <Button Content="{Binding DevCanvasLoginButtonMessage, UpdateSourceTrigger=PropertyChanged}" Click="OnDevCanvasLoginButtonClick"/>
             </StackPanel>
         </GroupBox>
     </StackPanel>

--- a/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsControl.xaml
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsControl.xaml
@@ -63,13 +63,13 @@
                        Content="{StaticResource SarifViewerOptionsControl_DevCanvasGroupBoxHeader}"
                        AutomationProperties.AutomationId="DevCanvasGroupBoxLabel" />
             </GroupBox.Header>
-            <StackPanel>
+            <StackPanel Margin="5 ">
                 <ComboBox SelectedIndex="{Binding DevCanvasServerIndex}">
                     <ComboBoxItem>Prod</ComboBoxItem>
                     <ComboBoxItem>Ppe</ComboBoxItem>
                     <ComboBoxItem>Dev</ComboBoxItem>
                 </ComboBox>
-                <Button Content="{Binding DevCanvasLoginButtonMessage}"/>
+                <Button Content="{Binding DevCanvasLoginButtonMessage}" Click="OnDevCanvasLoginButtonClick"/>
             </StackPanel>
         </GroupBox>
     </StackPanel>

--- a/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsControl.xaml.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsControl.xaml.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Windows.Controls;
 
-using Sarif.Viewer.VisualStudio.ResultSources.Domain.Core.Models;
+using Microsoft.Sarif.Viewer.ResultSources.Domain.Models;
 
 namespace Microsoft.Sarif.Viewer.Options
 {
@@ -38,7 +38,7 @@ namespace Microsoft.Sarif.Viewer.Options
                 EventName = "DevCanvasLoginButtonClicked",
                 Value = true,
             };
-            SettingsEvent.Invoke(this, args);
+            SettingsEvent?.Invoke(this, args);
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsControl.xaml.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsControl.xaml.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Sarif.Viewer.Options
             SettingsEventArgs args = new SettingsEventArgs()
             {
                 EventName = "DevCanvasLoginButtonClicked",
-                Value = true,
+                Value = !this.generalOptionsPage.DevCanvasLoggedIn,
             };
             SettingsEvent?.Invoke(this, args);
         }

--- a/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsControl.xaml.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsControl.xaml.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Windows.Controls;
 
+using Sarif.Viewer.VisualStudio.ResultSources.Domain.Core.Models;
+
 namespace Microsoft.Sarif.Viewer.Options
 {
     /// <summary>
@@ -11,6 +13,12 @@ namespace Microsoft.Sarif.Viewer.Options
     /// </summary>
     public partial class SarifViewerGeneralOptionsControl : UserControl
     {
+        /// <summary>
+        /// Fired when an event is fired by the settings ui.
+        /// Some examples of this are button clicks or other listeners.
+        /// </summary>
+        public event EventHandler<SettingsEventArgs> SettingsEvent;
+
         /// <summary>
         /// A handle to the options page instance that this control is bound to.
         /// </summary>
@@ -21,6 +29,16 @@ namespace Microsoft.Sarif.Viewer.Options
             InitializeComponent();
             generalOptionsPage = page;
             this.DataContext = generalOptionsPage;
+        }
+
+        private void OnDevCanvasLoginButtonClick(object sender, System.Windows.RoutedEventArgs e)
+        {
+            SettingsEventArgs args = new SettingsEventArgs()
+            {
+                EventName = "DevCanvasLoginButtonClicked",
+                Value = true,
+            };
+            SettingsEvent.Invoke(this, args);
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsControl.xaml.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsControl.xaml.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.ComponentModel;
 using System.Windows.Controls;
 
 using Microsoft.Sarif.Viewer.ResultSources.Domain.Models;

--- a/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsPage.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsPage.cs
@@ -9,6 +9,8 @@ using System.Windows;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.Win32;
 
+using Sarif.Viewer.VisualStudio.ResultSources.Domain.Core.Models;
+
 namespace Microsoft.Sarif.Viewer.Options
 {
     [ComVisible(true)]
@@ -16,9 +18,20 @@ namespace Microsoft.Sarif.Viewer.Options
     {
         private readonly Lazy<SarifViewerGeneralOptionsControl> _sarifViewerOptionsControl;
 
+        /// <summary>
+        /// Fired when an event is fired by the settings ui.
+        /// Some examples of this are button clicks or other listeners.
+        /// </summary>
+        public event EventHandler<SettingsEventArgs> SettingsEvent;
+
         public SarifViewerGeneralOptionsPage()
         {
-            _sarifViewerOptionsControl = new Lazy<SarifViewerGeneralOptionsControl>(() => new SarifViewerGeneralOptionsControl(this));
+            _sarifViewerOptionsControl = new Lazy<SarifViewerGeneralOptionsControl>(() =>
+            {
+                SarifViewerGeneralOptionsControl options = new SarifViewerGeneralOptionsControl(this);
+                options.SettingsEvent += this.SettingsEvent;
+                return options;
+            });
         }
 
         public bool MonitorSarifFolder { get; set; } = true;

--- a/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsPage.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsPage.cs
@@ -29,6 +29,33 @@ namespace Microsoft.Sarif.Viewer.Options
 
         public int DevCanvasServerIndex { get; set; } = 0;
 
+        public bool? DevCanvasLoggedIn { get; set; } = null;
+
+        /// <summary>
+        /// Gets the message that the login button shows.
+        /// Empty when undecided, "Log out" when logged in, "Log in" when logged out.
+        /// </summary>
+        public string DevCanvasLoginButtonMessage
+        {
+            get
+            {
+                if (DevCanvasLoggedIn == null)
+                {
+                    return string.Empty;
+                }
+
+                bool devCanvasLoggedInNonNull = (bool)DevCanvasLoggedIn;
+                if (devCanvasLoggedInNonNull)
+                {
+                    return "Log out of DevCanvas";
+                }
+                else
+                {
+                    return "Log into DevCanvas";
+                }
+            }
+        }
+
         /// <summary>
         /// Gets a value indicating whether the user should be able to see the devcanvs settings. Not done for security reasons but for UI/UX reasons.
         /// </summary>

--- a/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsPage.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsPage.cs
@@ -13,7 +13,7 @@ using Microsoft.Win32;
 namespace Microsoft.Sarif.Viewer.Options
 {
     [ComVisible(true)]
-    public class SarifViewerGeneralOptionsPage : UIElementDialogPage
+    public class SarifViewerGeneralOptionsPage : UIElementDialogPage, INotifyPropertyChanged
     {
         private readonly Lazy<SarifViewerGeneralOptionsControl> _sarifViewerOptionsControl;
 
@@ -22,6 +22,8 @@ namespace Microsoft.Sarif.Viewer.Options
         /// Some examples of this are button clicks or other listeners.
         /// </summary>
         public event EventHandler<SettingsEventArgs> SettingsEvent;
+
+        public event PropertyChangedEventHandler PropertyChanged;
 
         public SarifViewerGeneralOptionsPage()
         {
@@ -42,6 +44,14 @@ namespace Microsoft.Sarif.Viewer.Options
         public int DevCanvasServerIndex { get; set; } = 0;
 
         public bool? DevCanvasLoggedIn { get; set; } = null;
+
+        public void InvokePropertyChanged()
+        {
+            if (PropertyChanged != null)
+            {
+                PropertyChanged(this, new PropertyChangedEventArgs(string.Empty));
+            }
+        }
 
         /// <summary>
         /// Gets the message that the login button shows.

--- a/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsPage.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsPage.cs
@@ -6,10 +6,9 @@ using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Windows;
 
+using Microsoft.Sarif.Viewer.ResultSources.Domain.Models;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.Win32;
-
-using Sarif.Viewer.VisualStudio.ResultSources.Domain.Core.Models;
 
 namespace Microsoft.Sarif.Viewer.Options
 {

--- a/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsPage.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/GeneralOptions/SarifViewerGeneralOptionsPage.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 
 using Microsoft.Sarif.Viewer.ResultSources.Domain.Models;
+using Microsoft.Sarif.Viewer.ResultSources.GitHubAdvancedSecurity.Resources;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.Win32;
 
@@ -69,11 +70,11 @@ namespace Microsoft.Sarif.Viewer.Options
                 bool devCanvasLoggedInNonNull = (bool)DevCanvasLoggedIn;
                 if (devCanvasLoggedInNonNull)
                 {
-                    return "Log out of DevCanvas";
+                    return Resources.SarifViewerOptionsControl_DevCanvasLogOut;
                 }
                 else
                 {
-                    return "Log into DevCanvas";
+                    return Resources.SarifViewerOptionsControl_DevCanvasLogIn;
                 }
             }
         }

--- a/src/Sarif.Viewer.VisualStudio.Core/Options/SarifViewerOptionsControlResources.xaml
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/SarifViewerOptionsControlResources.xaml
@@ -5,9 +5,6 @@
     <system:String x:Key="SarifViewerOptionsControl_GeneralGroupBoxHeader">General</system:String>
     <system:String x:Key="SarifViewerOptionsControl_DevCanvasGroupBoxHeader">DevCanvas</system:String>
     
-    <system:String x:Key="SarifViewerOptionsControl_DevCanvasLogOut">Log out of DevCanvas</system:String>
-    <system:String x:Key="SarifViewerOptionsControl_DevCanvasLogIn">Log Into DevCanvas</system:String>
-    
     <system:String x:Key="SarifViewerOptionsControl_ColorBoxHeader">Colors</system:String>
 
     <system:String x:Key="SarifViewerOptionsControl_MonitorSarifFolder">Load .sarif files from the .sarif folder automatically</system:String>

--- a/src/Sarif.Viewer.VisualStudio.Core/Options/SarifViewerOptionsControlResources.xaml
+++ b/src/Sarif.Viewer.VisualStudio.Core/Options/SarifViewerOptionsControlResources.xaml
@@ -5,6 +5,9 @@
     <system:String x:Key="SarifViewerOptionsControl_GeneralGroupBoxHeader">General</system:String>
     <system:String x:Key="SarifViewerOptionsControl_DevCanvasGroupBoxHeader">DevCanvas</system:String>
     
+    <system:String x:Key="SarifViewerOptionsControl_DevCanvasLogOut">Log out of DevCanvas</system:String>
+    <system:String x:Key="SarifViewerOptionsControl_DevCanvasLogIn">Log Into DevCanvas</system:String>
+    
     <system:String x:Key="SarifViewerOptionsControl_ColorBoxHeader">Colors</system:String>
 
     <system:String x:Key="SarifViewerOptionsControl_MonitorSarifFolder">Load .sarif files from the .sarif folder automatically</system:String>

--- a/src/Sarif.Viewer.VisualStudio.Core/Resources.Designer.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Resources.Designer.cs
@@ -848,5 +848,21 @@ namespace Microsoft.Sarif.Viewer {
                 return ResourceManager.GetString("WarningResultsHaveBeenFiltered", resourceCulture);
             }
         }
+
+        public static string SarifViewerOptionsControl_DevCanvasLogOut
+        {
+            get
+            {
+                return ResourceManager.GetString("SarifViewerOptionsControl_DevCanvasLogOut", resourceCulture);
+            }
+        }
+
+        public static string SarifViewerOptionsControl_DevCanvasLogIn
+        {
+            get
+            {
+                return ResourceManager.GetString("SarifViewerOptionsControl_DevCanvasLogIn", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.Core/Resources.resx
+++ b/src/Sarif.Viewer.VisualStudio.Core/Resources.resx
@@ -417,4 +417,10 @@ Do you want to open this file in Visual Studio?</value>
   <data name="OptionsDialog_Colors_DecorationLabel_WarningUnderline" xml:space="preserve">
     <value>Underline warning results with a:</value>
   </data>
+  <data name="SarifViewerOptionsControl_DevCanvasLogOut" xml:space="preserve">
+    <value>Log out of DevCanvas</value>
+  </data>
+  <data name="SarifViewerOptionsControl_DevCanvasLogIn" xml:space="preserve">
+    <value>Log into DevCanvas</value>
+  </data>
 </root>

--- a/src/Sarif.Viewer.VisualStudio.Core/SarifViewerPackage.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/SarifViewerPackage.cs
@@ -26,6 +26,7 @@ using Microsoft.Sarif.Viewer.Tags;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.Settings;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Events;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -231,6 +232,16 @@ namespace Microsoft.Sarif.Viewer
             SarifExplorerWindow.Find()?.Close();
         }
 
+        /// <summary>
+        /// Listens to when a setting event is fired.
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="e">Payload fired.</param>
+        public void Settings_ServiceEvent(object sender, ResultSources.Domain.Models.SettingsEventArgs e)
+        {
+            Console.WriteLine("hi");
+        }
+
         private async Task InitializeResultSourceHostAsync()
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync(DisposalToken);
@@ -239,6 +250,7 @@ namespace Microsoft.Sarif.Viewer
                 string solutionPath = GetSolutionDirectoryPath();
                 this.resultSourceHost = new ResultSourceHost(solutionPath, this, SarifViewerGeneralOptions.Instance.GetOption, SarifViewerGeneralOptions.Instance.SetOption);
                 this.resultSourceHost.ServiceEvent += this.ResultSourceHost_ServiceEvent;
+                SarifViewerGeneralOptions.Instance.SettingsEvent += this.resultSourceHost.Settings_ServiceEvent;
             }
 
             if (this.resultSourceHost != null)

--- a/src/Sarif.Viewer.VisualStudio.Core/SarifViewerPackage.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/SarifViewerPackage.cs
@@ -231,17 +231,6 @@ namespace Microsoft.Sarif.Viewer
 
             SarifExplorerWindow.Find()?.Close();
         }
-
-        /// <summary>
-        /// Listens to when a setting event is fired.
-        /// </summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="e">Payload fired.</param>
-        public void Settings_ServiceEvent(object sender, ResultSources.Domain.Models.SettingsEventArgs e)
-        {
-            Console.WriteLine("hi");
-        }
-
         private async Task InitializeResultSourceHostAsync()
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync(DisposalToken);

--- a/src/Sarif.Viewer.VisualStudio.Core/SarifViewerPackage.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/SarifViewerPackage.cs
@@ -231,6 +231,7 @@ namespace Microsoft.Sarif.Viewer
 
             SarifExplorerWindow.Find()?.Close();
         }
+
         private async Task InitializeResultSourceHostAsync()
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync(DisposalToken);

--- a/src/Sarif.Viewer.VisualStudio.Core/SarifViewerPackage.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/SarifViewerPackage.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Sarif.Viewer
             if (this.resultSourceHost == null)
             {
                 string solutionPath = GetSolutionDirectoryPath();
-                this.resultSourceHost = new ResultSourceHost(solutionPath, this, SarifViewerGeneralOptions.Instance.GetOption);
+                this.resultSourceHost = new ResultSourceHost(solutionPath, this, SarifViewerGeneralOptions.Instance.GetOption, SarifViewerGeneralOptions.Instance.SetOption);
                 this.resultSourceHost.ServiceEvent += this.ResultSourceHost_ServiceEvent;
             }
 

--- a/src/Sarif.Viewer.VisualStudio.Core/Tags/SarifLocationErrorTagger.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Tags/SarifLocationErrorTagger.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Sarif.Viewer.Tags
             if (this.tagsDirty)
             {
                 this.tagsDirty = false;
-                
+
                 IEnumerable<SarifErrorListItem> errorsInCurrentFile = CodeAnalysisResultManager
                     .Instance
                     .RunIndexToRunDataCache

--- a/src/Sarif.Viewer.VisualStudio.Core/Tags/SarifLocationErrorTagger.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Tags/SarifLocationErrorTagger.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Sarif.Viewer.Tags
             if (this.tagsDirty)
             {
                 this.tagsDirty = false;
+                
                 IEnumerable<SarifErrorListItem> errorsInCurrentFile = CodeAnalysisResultManager
                     .Instance
                     .RunIndexToRunDataCache

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Models/AuthState.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Models/AuthState.cs
@@ -90,6 +90,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Models
             catch (Exception)
             { 
                 // swallow
+                // TODO: send telemetry when this happens to prevent.
             }
         }
 

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Models/AuthState.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Models/AuthState.cs
@@ -56,7 +56,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Models
         public readonly string msalCacheFilePath = Path.Combine(MsalCacheHelper.UserRootDirectory, msalCacheFileName);
 
         /// <summary>
-        /// Determines if the user is logged in with a @microsoft.com account
+        /// Determines if the user is logged in with a @microsoft.com account.
         /// </summary>
         public bool IsLoggedIntoDevCanvas
         { 

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Models/AuthState.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Models/AuthState.cs
@@ -41,10 +41,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Models
             }
         }
 
-        private AuthState()
-        {
-
-        }
+        private AuthState() { }
 
         public static AuthState Instance;
 

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Models/AuthState.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Models/AuthState.cs
@@ -70,6 +70,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Models
 
         private AuthState()
         {
+#if !DEBUG
             // Get the settings manager for the current user
             SettingsManager settingsManager = new ShellSettingsManager(ServiceProvider.GlobalProvider);
 
@@ -84,6 +85,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Models
             }
 
             _refusedLogin = settingsStore.GetBoolean(nameof(AuthState), refusedLoginSettingString, false);
+#endif
         }
 
         public static AuthState Instance;

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Models/AuthState.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Models/AuthState.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Models
+{
+    internal class AuthState
+    {
+        /// <summary>
+        /// This flag is set to true when the user has intentionally refused to authenticate. In this case, we do not want to query for insights or continue to show auth popups.
+        /// </summary>
+        public bool RefusedLogin;
+
+        /// <summary>
+        /// Determines if the user is logged in with a @microsoft.com account
+        /// </summary>
+        public bool IsLoggedIntoDevCanvas;
+
+        private AuthState()
+        {
+
+        }
+
+        public static AuthState Instance;
+
+        public static bool isInitialized = false;
+        public static void Initialize()
+        {
+            if (isInitialized)
+            {
+                throw new Exception("Already initialized!");
+            }
+            Instance = new AuthState();
+        }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Models/AuthState.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Models/AuthState.cs
@@ -70,22 +70,27 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Models
 
         private AuthState()
         {
-#if !DEBUG
-            // Get the settings manager for the current user
-            SettingsManager settingsManager = new ShellSettingsManager(ServiceProvider.GlobalProvider);
-
-            // Get the writable settings store for your extension
-            settingsStore = settingsManager.GetWritableSettingsStore(SettingsScope.UserSettings);
-
-            // Save a setting
-
-            if (!settingsStore.CollectionExists(nameof(AuthState)))
+            try
             {
-                settingsStore.CreateCollection(nameof(AuthState));
-            }
+                // Get the settings manager for the current user
+                SettingsManager settingsManager = new ShellSettingsManager(ServiceProvider.GlobalProvider);
 
-            _refusedLogin = settingsStore.GetBoolean(nameof(AuthState), refusedLoginSettingString, false);
-#endif
+                // Get the writable settings store for your extension
+                settingsStore = settingsManager.GetWritableSettingsStore(SettingsScope.UserSettings);
+
+                // Save a setting
+
+                if (!settingsStore.CollectionExists(nameof(AuthState)))
+                {
+                    settingsStore.CreateCollection(nameof(AuthState));
+                }
+
+                _refusedLogin = settingsStore.GetBoolean(nameof(AuthState), refusedLoginSettingString, false);
+            }
+            catch (Exception)
+            { 
+                // swallow
+            }
         }
 
         public static AuthState Instance;

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Models/AuthState.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Models/AuthState.cs
@@ -3,7 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
+
+using Microsoft.Identity.Client.Extensions.Msal;
+
+using Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services;
 
 namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Models
 {
@@ -12,12 +17,29 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Models
         /// <summary>
         /// This flag is set to true when the user has intentionally refused to authenticate. In this case, we do not want to query for insights or continue to show auth popups.
         /// </summary>
-        public bool RefusedLogin;
+        public bool RefusedLogin { get; set; }
+
+
+        /// <summary>
+        /// The name of the file on the users file system that has the msal settings cached.
+        /// </summary>
+        public const string msalCacheFileName = $"{nameof(DevCanvasResultSourceService)}_MSAL_cache.txt";
+
+        /// <summary>
+        /// The absolute path of the file on the users file system that has the msal settings cached.
+        /// </summary>
+        public readonly string msalCacheFilePath = Path.Combine(MsalCacheHelper.UserRootDirectory, msalCacheFileName);
 
         /// <summary>
         /// Determines if the user is logged in with a @microsoft.com account
         /// </summary>
-        public bool IsLoggedIntoDevCanvas;
+        public bool IsLoggedIntoDevCanvas
+        { 
+            get
+            {
+                return File.Exists(msalCacheFilePath);
+            }
+        }
 
         private AuthState()
         {

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Models/AuthState.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Models/AuthState.cs
@@ -12,6 +12,9 @@ using Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services;
 
 namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Models
 {
+    /// <summary>
+    /// This class is a singleton that is the single point of truth as to if the user is logged in or not, and if they have actively refused to log in.
+    /// </summary>
     internal class AuthState
     {
         /// <summary>

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.projitems
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)DevCanvasTracer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Models\AuthState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\DevCanvasGeneratorInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\DevCanvasRequestV1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\DevCanvasVersionControlDetails.cs" />

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/AuthManager.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/AuthManager.cs
@@ -78,10 +78,10 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
         /// </summary>
         public void LogOutOfDevCanvas()
         {
+            DevCanvasTracer.WriteLine("Logging out...");
             if (AuthState.Instance.IsLoggedIntoDevCanvas)
             {
                 File.Delete(AuthState.Instance.msalCacheFilePath);
-                SetupClientApp();
                 setLoginMessage(false);
                 AuthState.Instance.RefusedLogin = true;
             }
@@ -96,6 +96,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
         /// </summary>
         public async Task<AuthenticationResult> LogIntoDevCanvasAsync(int endpointIndex, string claims)
         {
+            DevCanvasTracer.WriteLine("Logging in...");
             string[] scopes = serverScopes[endpointIndex];
             try
             {
@@ -106,6 +107,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
                    .WithUseEmbeddedWebView(true)
                    .ExecuteAsync();
                 setLoginMessage(true);
+                AuthState.Instance.RefusedLogin = false;
                 return res;
             }
             catch (Exception e)

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/AuthManager.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/AuthManager.cs
@@ -31,12 +31,10 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
         private IPublicClientApplication publicClientApplication;
 
         private const string existingClientIdApproved = "872cd9fa-d31f-45e0-9eab-6e460a02d1f1";
-        private readonly static string[] prodScopes = new string[] { "api://7ba8d231-9a00-4118-8a4d-9423b0f0a0f5/user_impersonation" };
         private readonly static string brokerTitle = "Log into DevCanvas. https://aka.ms/devcanvas";
+        private readonly static string[] prodScopes = new string[] { "api://7ba8d231-9a00-4118-8a4d-9423b0f0a0f5/user_impersonation" };
         private readonly static string[] ppeScopes = new string[] { "api://5360327a-4e80-4925-8701-51fa2000738e/user_impersonation" };
-        private readonly static string ppeBrokerTitle = "Log into DevCanvas PPE environment. https://aka.ms/devcanvas";
         private readonly static string[] devScopes = new string[] { "api://a5880bae-b129-42c5-9d6c-d8de8f305adf/user_impersonation" };
-        private readonly static string devBrokerTitle = "Log into DevCanvas Developer environment. https://aka.ms/devcanvas";
         private readonly static string[][] serverScopes = new string[][] { prodScopes, ppeScopes, devScopes };
         private const string AadInstanceUrlFormat = "https://login.microsoftonline.com/{0}/v2.0";
         private const string msAadTenant = "72f988bf-86f1-41af-91ab-2d7cd011db47"; // GUID for the microsoft AAD tenant;

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/AuthManager.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/AuthManager.cs
@@ -43,6 +43,8 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
         private readonly SemaphoreSlim slimSemaphore;
         private MsalCacheHelper cacheHelper;
 
+        private readonly Action<string, object> setOptionStateCallback;
+
         [DllImport("user32.dll")]
         private static extern IntPtr GetForegroundWindow();
 
@@ -53,10 +55,20 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
             return hWnd;
         }
 
-        public AuthManager()
+        public AuthManager(Action<string, object> setOptionStateCallback)
         {
             slimSemaphore = new SemaphoreSlim(1);
             SetupClientApp();
+            this.setOptionStateCallback = setOptionStateCallback;
+        }
+
+        /// <summary>
+        /// Sets the text for the log in button in the settings.
+        /// </summary>
+        /// <param name="loggedIn">Whether the user is now logged in or not.</param>
+        private void setLoginMessage(bool loggedIn)
+        {
+            setOptionStateCallback("DevCanvasLoggedIn", loggedIn);
         }
 
         /// <summary>
@@ -68,6 +80,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
             {
                 File.Delete(AuthState.Instance.msalCacheFilePath);
                 SetupClientApp();
+                setLoginMessage(false);
             }
             else
             {
@@ -89,6 +102,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
                    .WithClaims(claims)
                    .WithUseEmbeddedWebView(true)
                    .ExecuteAsync();
+                setLoginMessage(true);
                 return res;
             }
             catch (Exception e)

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/AuthManager.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/AuthManager.cs
@@ -132,7 +132,6 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
             this.publicClientApplication = PublicClientApplicationBuilder
                 .Create(existingClientIdApproved)
                 .WithRedirectUri("https://login.microsoftonline.com/common/oauth2/nativeclient")
-                //.WithAuthority(AzureCloudInstance.AzurePublic, msAadTenant)
                 .WithParentActivityOrWindow(GetIntPtr)
                 .WithBroker(brokerOpt)
                 .Build();

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/AuthManager.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/AuthManager.cs
@@ -83,6 +83,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
                 File.Delete(AuthState.Instance.msalCacheFilePath);
                 setLoginMessage(false);
                 AuthState.Instance.RefusedLogin = true;
+                DevCanvasTracer.WriteLine("Logged out");
             }
             else
             {
@@ -131,7 +132,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
             this.publicClientApplication = PublicClientApplicationBuilder
                 .Create(existingClientIdApproved)
                 .WithRedirectUri("https://login.microsoftonline.com/common/oauth2/nativeclient")
-                .WithAuthority(AzureCloudInstance.AzurePublic, msAadTenant)
+                //.WithAuthority(AzureCloudInstance.AzurePublic, msAadTenant)
                 .WithParentActivityOrWindow(GetIntPtr)
                 .WithBroker(brokerOpt)
                 .Build();
@@ -166,7 +167,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
                     AuthenticationResult result = await this.publicClientApplication
                         .AcquireTokenSilent(scopes, accounts.Where(acc => acc.Username.EndsWith("@microsoft.com")).FirstOrDefault())
                         .ExecuteAsync();
-                    DevCanvasTracer.WriteLine($"Automatically retrieved credentails for {accounts.First().Username} to access {endpointIndex}");
+                    DevCanvasTracer.WriteLine($"Automatically retrieved credentials for {accounts.First().Username}");
                     return result;
                 }
                 catch (MsalUiRequiredException ex)

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/AuthManager.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/AuthManager.cs
@@ -80,7 +80,14 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
             DevCanvasTracer.WriteLine("Logging out...");
             if (AuthState.Instance.IsLoggedIntoDevCanvas)
             {
-                File.Delete(AuthState.Instance.msalCacheFilePath);
+                try
+                {
+                    File.Delete(AuthState.Instance.msalCacheFilePath);
+                }
+                catch (Exception e)
+                {
+                    DevCanvasTracer.WriteLine($"Failed to delete file.\nException:{e}");
+                }
                 setLoginMessage(false);
                 AuthState.Instance.RefusedLogin = true;
                 DevCanvasTracer.WriteLine("Logged out");

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/AuthManager.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/AuthManager.cs
@@ -60,6 +60,8 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
             slimSemaphore = new SemaphoreSlim(1);
             SetupClientApp();
             this.setOptionStateCallback = setOptionStateCallback;
+
+            setLoginMessage(AuthState.Instance.IsLoggedIntoDevCanvas);
         }
 
         /// <summary>

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/AuthManager.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/AuthManager.cs
@@ -83,6 +83,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
                 File.Delete(AuthState.Instance.msalCacheFilePath);
                 SetupClientApp();
                 setLoginMessage(false);
+                AuthState.Instance.RefusedLogin = true;
             }
             else
             {

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
@@ -676,6 +676,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
                 }
                 else
                 {
+                    filePathQueue.Clear();
                     accessor.authManager.LogOutOfDevCanvas();
                 }
             }

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
@@ -144,6 +144,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
         /// <inheritdoc/>
         public System.Threading.Tasks.Task InitializeAsync()
         {
+            // TODO: Remove this when merging into main.
             DevCanvasTracer.WriteLine($"Initializing {nameof(DevCanvasResultSourceService)}. Version 9/7");
             string userName = (string)Registry.GetValue("HKEY_CURRENT_USER\\Software\\Microsoft\\VSCommon\\ConnectedUser\\IdeUserV4\\Cache", "EmailAddress", null);
 

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
@@ -152,7 +152,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
         /// <inheritdoc/>
         public System.Threading.Tasks.Task InitializeAsync()
         {
-            DevCanvasTracer.WriteLine($"Initializing {nameof(DevCanvasResultSourceService)}. Version 8/2");
+            DevCanvasTracer.WriteLine($"Initializing {nameof(DevCanvasResultSourceService)}. Version 8/17");
             string userName = (string)Registry.GetValue("HKEY_CURRENT_USER\\Software\\Microsoft\\VSCommon\\ConnectedUser\\IdeUserV4\\Cache", "EmailAddress", null);
 
             if (string.IsNullOrWhiteSpace(userName) || !userName.EndsWith("@microsoft.com"))

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
@@ -141,18 +141,10 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
 
         }
 
-        /// <summary>
-        /// Logs out the user. Will not query for new files until the user manually logs in again.
-        /// </summary>
-        private void LogOut()
-        {
-
-        }
-
         /// <inheritdoc/>
         public System.Threading.Tasks.Task InitializeAsync()
         {
-            DevCanvasTracer.WriteLine($"Initializing {nameof(DevCanvasResultSourceService)}. Version 8/17");
+            DevCanvasTracer.WriteLine($"Initializing {nameof(DevCanvasResultSourceService)}. Version 8/25");
             string userName = (string)Registry.GetValue("HKEY_CURRENT_USER\\Software\\Microsoft\\VSCommon\\ConnectedUser\\IdeUserV4\\Cache", "EmailAddress", null);
 
             if (string.IsNullOrWhiteSpace(userName) || !userName.EndsWith("@microsoft.com"))
@@ -285,7 +277,6 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
         {
             try
             {
-
                 // This will contain the message we'll display in the output window once the query is complete (and after we release the lock on cacheItem).
                 StringBuilder resultMessage = new StringBuilder();
 

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
@@ -135,10 +135,10 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
                 return (int)getOptionStateCallback("DevCanvasServer");
             };
 
+            AuthState.Initialize();
             AuthManager authManager = new AuthManager(SetOptionStateCallback);
             accessor = new DevCanvasWebAPIAccessor(serverOptionAccess, authManager);
 
-            AuthState.Initialize();
         }
 
         /// <summary>
@@ -667,7 +667,18 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
 
         public void Settings_ServiceEvent(object sender, SettingsEventArgs e)
         {
-            return;
+            if (e.EventName == "DevCanvasLoginButtonClicked")
+            {
+                bool turnOn = bool.Parse(e.Value.ToString());
+                if (turnOn)
+                {
+                     accessor.authManager.LogIntoDevCanvasAsync(0, string.Empty);
+                }
+                else
+                {
+                    accessor.authManager.LogOutOfDevCanvas();
+                }
+            }
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
@@ -664,5 +664,10 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
                 }
             }
         }
+
+        public void Settings_ServiceEvent(object sender, SettingsEventArgs e)
+        {
+            return;
+        }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
@@ -52,6 +52,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
         public Action<string, object> SetOptionStateCallback { get; set; }
 
         public event EventHandler<ServiceEventArgs> ServiceEvent;
+        public event EventHandler<SettingsEventArgs> SettingsEvent;
 
         private readonly IServiceProvider serviceProvider;
         private readonly IHttpClientAdapter httpClientAdapter;

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
@@ -144,7 +144,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
         /// <inheritdoc/>
         public System.Threading.Tasks.Task InitializeAsync()
         {
-            DevCanvasTracer.WriteLine($"Initializing {nameof(DevCanvasResultSourceService)}. Version 8/25");
+            DevCanvasTracer.WriteLine($"Initializing {nameof(DevCanvasResultSourceService)}. Version 9/7");
             string userName = (string)Registry.GetValue("HKEY_CURRENT_USER\\Software\\Microsoft\\VSCommon\\ConnectedUser\\IdeUserV4\\Cache", "EmailAddress", null);
 
             if (string.IsNullOrWhiteSpace(userName) || !userName.EndsWith("@microsoft.com"))

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
@@ -49,6 +49,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
         public int FirstMenuId { get; set; }
         public int FirstCommandId { get; set; }
         public Func<string, object> GetOptionStateCallback { get; set; }
+        public Action<string, object> SetOptionStateCallback { get; set; }
 
         public event EventHandler<ServiceEventArgs> ServiceEvent;
 
@@ -99,6 +100,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
         public DevCanvasResultSourceService(
             string solutionRootPath,
             Func<string, object> getOptionStateCallback,
+            Action<string, object> setOptionStateCallback,
             IServiceProvider serviceProvider,
             IHttpClientAdapter httpClientAdapter,
             ISecretStoreRepository secretStoreRepository,
@@ -110,6 +112,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
             IStatusBarService statusBarService)
         {
             this.GetOptionStateCallback = getOptionStateCallback;
+            this.SetOptionStateCallback = setOptionStateCallback;
             this.serviceProvider = serviceProvider;
             this.httpClientAdapter = httpClientAdapter;
             this.secretStoreRepository = secretStoreRepository;
@@ -131,7 +134,8 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
                 return (int)getOptionStateCallback("DevCanvasServer");
             };
 
-            accessor = new DevCanvasWebAPIAccessor(serverOptionAccess);
+            AuthManager authManager = new AuthManager(SetOptionStateCallback);
+            accessor = new DevCanvasWebAPIAccessor(serverOptionAccess, authManager);
 
             AuthState.Initialize();
         }

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasWebAPIAccessor.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasWebAPIAccessor.cs
@@ -62,10 +62,10 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
 
         private readonly Func<int> endpointIndex;
 
-        internal DevCanvasWebAPIAccessor(Func<int> endpointIndex, IAuthManager authManager = null)
+        internal DevCanvasWebAPIAccessor(Func<int> endpointIndex, IAuthManager authManager)
         {
             this.endpointIndex = endpointIndex;
-            this.authManager = authManager ?? new AuthManager();
+            this.authManager = authManager;
         }
 
         /// <inhertidoc/>

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasWebAPIAccessor.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasWebAPIAccessor.cs
@@ -45,7 +45,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
         /// <summary>
         /// The class that handles the authentication to the endpoint.
         /// </summary>
-        private readonly IAuthManager authManager;
+        public readonly IAuthManager authManager;
 
         /// <summary>
         /// The version of the API we want to use.

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasWebAPIAccessor.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasWebAPIAccessor.cs
@@ -58,7 +58,8 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
         public const string prodServer = "insightwebv2.azurewebsites.net";
         public const string ppeServer = "insightwebv2-ppe.azurewebsites.net";
         public const string devServer = "insightwebv2-dev.azurewebsites.net";
-        public readonly static string[] servers = new string[] { prodServer, ppeServer, devServer };
+        public const string localServer = "localhost:44327";
+        public readonly static string[] servers = new string[] { prodServer, ppeServer, localServer };
 
         private readonly Func<int> endpointIndex;
 

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/IAuthManager.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/IAuthManager.cs
@@ -14,12 +14,22 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
     /// <summary>
     /// Handles the credentials retreival for the user.
     /// </summary>
-    internal interface IAuthManager
+    public interface IAuthManager
     {
         /// <summary>
         /// Gets an <see cref="HttpClient"/> that has the credentials to interact with the DevCanvas API.
         /// </summary>
         /// <returns>A <see cref="HttpClient"/> that can be used with DevCanvas APIs if authenticated, null otherwise.</returns>
         public Task<HttpClient> GetHttpClientAsync(int endpointIndex);
+
+        /// <summary>
+        /// Attemptes to log into devcanvas
+        /// </summary>
+        public Task<AuthenticationResult> LogIntoDevCanvasAsync(int endpointIndex, string claims);
+
+        /// <summary>
+        /// Wipes the cached accounts for devcanvas access, will reset the client app.
+        /// </summary>
+        public void LogOutOfDevCanvas();
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.Domain.Core/Models/SettingsEventArgs.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.Domain.Core/Models/SettingsEventArgs.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Sarif.Viewer.ResultSources.Domain.Models
+{
+    /// <summary>
+    /// Fired when an event in settings menu needs to be transmit to the result source services.
+    /// </summary>
+    public class SettingsEventArgs : EventArgs
+    {
+        /// <summary>
+        /// An ID for the event that was fired.
+        /// </summary>
+        public string EventName;
+
+        /// <summary>
+        /// Any additional information tranmitted.
+        /// </summary>
+        public object Value;
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.Domain.Core/Sarif.Viewer.VisualStudio.ResultSources.Domain.Core.projitems
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.Domain.Core/Sarif.Viewer.VisualStudio.ResultSources.Domain.Core.projitems
@@ -29,6 +29,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Models\ResultsUpdatedEventArgs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\Secret.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\ServiceEventArgs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Models\SettingsEventArgs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\ErrorType.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\IResultSourceService.cs" />
   </ItemGroup>

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.Domain.Core/Services/IResultSourceService.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.Domain.Core/Services/IResultSourceService.cs
@@ -65,5 +65,12 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.Services
         /// <param name="filePaths">List of files that were loaded.</param>
         /// <returns>True if succeeded, otherwise an error.</returns>
         Task<Result<bool, ErrorType>> OnDocumentEventAsync(string[] filePaths);
+
+        /// <summary>
+        /// Listens to when a setting event is fired.
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="e">Payload fired.</param>
+        public void Settings_ServiceEvent(object sender, SettingsEventArgs e);
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.Domain.Core/Services/IResultSourceService.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.Domain.Core/Services/IResultSourceService.cs
@@ -36,6 +36,11 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.Services
         Func<string, object> GetOptionStateCallback { get; set; }
 
         /// <summary>
+        /// Gets or sets the callback method to set the option state for the specified key.
+        /// </summary>
+        Action<string, object> SetOptionStateCallback { get; set; }
+
+        /// <summary>
         /// Initializes the service instance.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.Core/ResultSourceHost.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.Core/ResultSourceHost.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 
 using CSharpFunctionalExtensions;
 
+using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.ResultSources.Domain.Models;
 using Microsoft.Sarif.Viewer.ResultSources.Domain.Services;
 using Microsoft.VisualStudio.Shell;
@@ -54,8 +55,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory
         public event EventHandler<ServiceEventArgs> ServiceEvent;
 
         /// <summary>
-        /// Fired when an event is fired by the settings ui.
-        /// Some examples of this are button clicks or other listeners.
+        /// The event raised when settings fires an event.
         /// </summary>
         public event EventHandler<SettingsEventArgs> SettingsEvent;
 
@@ -73,6 +73,16 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory
         /// Gets the number of services in <see cref="resultSourceServices"/>.
         /// </summary>
         public int ServiceCount => resultSourceServices.Count;
+
+        /// <summary>
+        /// Listens to when a setting event is fired.
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="e">Payload fired.</param>
+        public void Settings_ServiceEvent(object sender, SettingsEventArgs e)
+        {
+            SettingsEvent.Invoke(sender, e);
+        }
 
         /// <summary>
         /// Requests analysis results from the active source service, if any.
@@ -100,6 +110,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory
                     foreach (IResultSourceService service in this.resultSourceServices)
                     {
                         service.ServiceEvent += this.ResultSourceService_ServiceEvent;
+                        this.SettingsEvent += service.Settings_ServiceEvent;
                         await service.InitializeAsync();
                     }
                 }

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.Core/ResultSourceHost.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.Core/ResultSourceHost.cs
@@ -54,6 +54,12 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory
         public event EventHandler<ServiceEventArgs> ServiceEvent;
 
         /// <summary>
+        /// Fired when an event is fired by the settings ui.
+        /// Some examples of this are button clicks or other listeners.
+        /// </summary>
+        public event EventHandler<SettingsEventArgs> SettingsEvent;
+
+        /// <summary>
         /// Gets the maximum number of child menus per flyout in the Error List context menu.
         /// </summary>
         public static int ErrorListContextdMenuChildFlyoutsPerFlyout => 3;

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.Core/ResultSourceHost.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.Core/ResultSourceHost.cs
@@ -29,12 +29,14 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory
         /// <param name="solutionRootPath">The local root path of the current project/solution.</param>
         /// <param name="serviceProvider">The service provider.</param>
         /// <param name="getOptionStateCallback">Callback <see cref="Func{T, TResult}"/> to retrieve option state.</param>
+        /// <param name="setOptionStateCallback">Callback to set option state.</param>
         public ResultSourceHost(
             string solutionRootPath,
             IServiceProvider serviceProvider,
-            Func<string, object> getOptionStateCallback)
+            Func<string, object> getOptionStateCallback,
+            Action<string, object> setOptionStateCallback)
         {
-            this.resultSourceFactory = new ResultSourceFactory(solutionRootPath, serviceProvider, getOptionStateCallback);
+            this.resultSourceFactory = new ResultSourceFactory(solutionRootPath, serviceProvider, getOptionStateCallback, setOptionStateCallback);
         }
 
         /// <summary>

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.Core/SampleResultSourceService.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.Core/SampleResultSourceService.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory
         /// </summary>
         /// <param name="solutionRootPath">The full path of the solution directory.</param>
         /// <param name="getOptionStateCallback">Callback <see cref="Func{T, TResult}"/> to retrieve option state.</param>
+        /// <param name="setOptionStateCallback">Callback to set option state.</param>
         /// <param name="serviceProvider">The service provider.</param>
         /// <param name="httpClientAdapter">The <see cref="IHttpClientAdapter"/>.</param>
         /// <param name="secretStoreRepository">The <see cref="ISecretStoreRepository"/>.</param>
@@ -46,6 +47,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory
             string solutionRootPath,
 #pragma warning restore SA1114 // Parameter list should follow declaration
             Func<string, object> getOptionStateCallback,
+            Action<string, object> setOptionStateCallback,
             IServiceProvider serviceProvider,
             IHttpClientAdapter httpClientAdapter,
             ISecretStoreRepository secretStoreRepository,
@@ -58,6 +60,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory
 #pragma warning restore IDE0060 // Remove unused parameter
         {
             Console.Write(ServiceEvent);
+            this.SetOptionStateCallback = setOptionStateCallback;
         }
 
         public SampleResultSourceService() { }
@@ -69,6 +72,10 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory
         public int FirstCommandId { get; set; }
 
         public Func<string, object> GetOptionStateCallback { get; set; }
+
+        public Action<string, object> SetOptionStateCallback { get; }
+
+        Action<string, object> IResultSourceService.SetOptionStateCallback { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
         public Task InitializeAsync()
         {

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.Core/SampleResultSourceService.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.Core/SampleResultSourceService.cs
@@ -96,5 +96,10 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory
         {
             return Task.Run(() => { return Result.Success<bool, ErrorType>(true); });
         }
+
+        public void Settings_ServiceEvent(object sender, SettingsEventArgs e)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.UnitTests/ResultSourceFactoryTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.UnitTests/ResultSourceFactoryTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory.UnitTests
             standardKernel.Bind<IInfoBarService>().ToConstant(mockInfoBarService.Object);
             standardKernel.Bind<IStatusBarService>().ToConstant(mockStatusBarService.Object);
 
-            var resultSourceFactory = new ResultSourceFactory(path, standardKernel, (string key) => true);
+            var resultSourceFactory = new ResultSourceFactory(path, standardKernel, (string key) => true, null);
             Result<List<IResultSourceService>, ErrorType> result = resultSourceFactory.GetResultSourceServicesAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
             result.IsSuccess.Should().BeTrue();
@@ -105,7 +105,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory.UnitTests
             standardKernel.Bind<IInfoBarService>().ToConstant(mockInfoBarService.Object);
             standardKernel.Bind<IStatusBarService>().ToConstant(mockStatusBarService.Object);
 
-            var resultSourceFactory = new ResultSourceFactory(path, standardKernel, (string key) => true);
+            var resultSourceFactory = new ResultSourceFactory(path, standardKernel, (string key) => true, null);
             Result<List<IResultSourceService>, ErrorType> result = resultSourceFactory.GetResultSourceServicesAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
             result.Value.Count.Should().Be(1);
@@ -164,7 +164,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory.UnitTests
             standardKernel.Bind<IInfoBarService>().ToConstant(mockInfoBarService.Object);
             standardKernel.Bind<IStatusBarService>().ToConstant(mockStatusBarService.Object);
 
-            ResultSourceFactory factory = new ResultSourceFactory("/solutionRoot", standardKernel, (string s) => true);
+            ResultSourceFactory factory = new ResultSourceFactory("/solutionRoot", standardKernel, (string s) => true, null);
             factory.AddResultSource(new SampleResultSourceService().GetType(), 1, 1);
             ResultSourceHost resultSourceHost = new ResultSourceHost(factory);
             await resultSourceHost.RequestAnalysisResultsAsync();

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.UnitTests/ResultSourceFactoryTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.UnitTests/ResultSourceFactoryTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory.UnitTests
             standardKernel.Bind<IInfoBarService>().ToConstant(mockInfoBarService.Object);
             standardKernel.Bind<IStatusBarService>().ToConstant(mockStatusBarService.Object);
 
-            var resultSourceFactory = new ResultSourceFactory(path, standardKernel, (string key) => true, null);
+            var resultSourceFactory = new ResultSourceFactory(path, standardKernel, (string key) => true, SetOptionStateCallback);
             Result<List<IResultSourceService>, ErrorType> result = resultSourceFactory.GetResultSourceServicesAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
             result.IsSuccess.Should().BeTrue();
@@ -105,7 +105,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory.UnitTests
             standardKernel.Bind<IInfoBarService>().ToConstant(mockInfoBarService.Object);
             standardKernel.Bind<IStatusBarService>().ToConstant(mockStatusBarService.Object);
 
-            var resultSourceFactory = new ResultSourceFactory(path, standardKernel, (string key) => true, null);
+            var resultSourceFactory = new ResultSourceFactory(path, standardKernel, (string key) => true, SetOptionStateCallback);
             Result<List<IResultSourceService>, ErrorType> result = resultSourceFactory.GetResultSourceServicesAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
             result.Value.Count.Should().Be(1);
@@ -128,6 +128,13 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory.UnitTests
             await resultSourceHost.RequestAnalysisResultsAsync();
 
             mockResultSource.Verify(s => s.RequestAnalysisScanResultsAsync(null), Times.Once);
+        }
+
+#pragma warning disable IDE0060 // Remove unused parameter
+        private void SetOptionStateCallback(string s, object o)
+#pragma warning restore IDE0060 // Remove unused parameter
+        {
+            return;
         }
 
         /// <summary>
@@ -164,7 +171,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory.UnitTests
             standardKernel.Bind<IInfoBarService>().ToConstant(mockInfoBarService.Object);
             standardKernel.Bind<IStatusBarService>().ToConstant(mockStatusBarService.Object);
 
-            ResultSourceFactory factory = new ResultSourceFactory("/solutionRoot", standardKernel, (string s) => true, null);
+            ResultSourceFactory factory = new ResultSourceFactory("/solutionRoot", standardKernel, (string s) => true, SetOptionStateCallback);
             factory.AddResultSource(new SampleResultSourceService().GetType(), 1, 1);
             ResultSourceHost resultSourceHost = new ResultSourceHost(factory);
             await resultSourceHost.RequestAnalysisResultsAsync();

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.GitHubAdvancedSecurity.Core/Services/GitHubSourceService.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.GitHubAdvancedSecurity.Core/Services/GitHubSourceService.cs
@@ -95,6 +95,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.GitHubAdvancedSecurity.Services
         /// </summary>
         /// <param name="solutionRootPath">The full path of the solution directory.</param>
         /// <param name="getOptionStateCallback">Callback <see cref="Func{T, TResult}"/> to retrieve option state.</param>
+        /// <param name="setOptionStateCallback">Callback to set option state.</param>
         /// <param name="serviceProvider">The service provider.</param>
         /// <param name="httpClientAdapter">The <see cref="IHttpClientAdapter"/>.</param>
         /// <param name="secretStoreRepository">The <see cref="ISecretStoreRepository"/>.</param>
@@ -107,6 +108,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.GitHubAdvancedSecurity.Services
         public GitHubSourceService(
             string solutionRootPath,
             Func<string, object> getOptionStateCallback,
+            Action<string, object> setOptionStateCallback,
             IServiceProvider serviceProvider,
             IHttpClientAdapter httpClientAdapter,
             ISecretStoreRepository secretStoreRepository,
@@ -118,6 +120,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.GitHubAdvancedSecurity.Services
             IStatusBarService statusBarService)
         {
             this.GetOptionStateCallback = getOptionStateCallback;
+            this.SetOptionStateCallback = setOptionStateCallback;
             this.serviceProvider = serviceProvider;
             this.httpClientAdapter = httpClientAdapter;
             this.secretStoreRepository = secretStoreRepository;
@@ -145,6 +148,9 @@ namespace Microsoft.Sarif.Viewer.ResultSources.GitHubAdvancedSecurity.Services
 
         /// <inheritdoc cref="IResultSourceService.GetOptionStateCallback"/>
         public Func<string, object> GetOptionStateCallback { get; set; }
+
+        /// <inheritdoc cref="IResultSourceService.SetOptionStateCallback"/>
+        public Action<string, object> SetOptionStateCallback { get; set;  }
 
         /// <inheritdoc cref="IResultSourceService.InitializeAsync()"/>
         public async Task InitializeAsync()

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.GitHubAdvancedSecurity.Core/Services/GitHubSourceService.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.GitHubAdvancedSecurity.Core/Services/GitHubSourceService.cs
@@ -335,6 +335,11 @@ namespace Microsoft.Sarif.Viewer.ResultSources.GitHubAdvancedSecurity.Services
             return Task.FromResult(Result.Success<bool, ErrorType>(true));
         }
 
+        public void Settings_ServiceEvent(object sender, SettingsEventArgs e)
+        {
+            return;
+        }
+
         internal (string Path, string Name) ParseBranchString(string branch)
         {
             // This needs to handle goofy branch names like "//asdf///-".

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.GitHubAdvancedSecurity.UnitTests/GitHubSourceServiceTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.GitHubAdvancedSecurity.UnitTests/GitHubSourceServiceTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
             var mockGitExe = new Mock<IGitExe>();
             mockGitExe.Setup(g => g.GetRepoRootAsync(null)).Returns(new ValueTask<string>(path));
 
-            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), (string key) => true, null, null, null, null, null, mockFileSystem.Object, mockGitExe.Object, null, null);
+            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), (string key) => true, null, null, null, null, null, null, mockFileSystem.Object, mockGitExe.Object, null, null);
             CSharpFunctionalExtensions.Result result = await gitHubSourceService.IsActiveAsync();
             result.IsSuccess.Should().BeTrue();
         }
@@ -59,7 +59,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
             var mockGitExe = new Mock<IGitExe>();
             mockGitExe.Setup(g => g.GetRepoRootAsync(null)).Returns(new ValueTask<string>(path));
 
-            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), null, null, null, null, null, null, mockFileSystem.Object, mockGitExe.Object, null, null);
+            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), null, null, null, null, null, null, null, mockFileSystem.Object, mockGitExe.Object, null, null);
             CSharpFunctionalExtensions.Result result = await gitHubSourceService.IsActiveAsync();
             result.IsSuccess.Should().BeFalse();
         }
@@ -75,7 +75,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
             var mockGitExe = new Mock<IGitExe>();
             mockGitExe.Setup(g => g.GetRepoRootAsync(null)).Returns(new ValueTask<string>(path));
 
-            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), (string key) => false, null, null, null, null, null, mockFileSystem.Object, mockGitExe.Object, null, null);
+            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), (string key) => false, null, null, null, null, null, null, mockFileSystem.Object, mockGitExe.Object, null, null);
             CSharpFunctionalExtensions.Result result = await gitHubSourceService.IsActiveAsync();
             result.IsSuccess.Should().BeFalse();
         }
@@ -89,7 +89,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
 
             var mockGitExe = new Mock<IGitExe>();
 
-            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), null, null, null, null, null, null, null, mockGitExe.Object, null, null);
+            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), null, null, null, null, null, null, null, null, mockGitExe.Object, null, null);
 
             (string Path, string Name) result = gitHubSourceService.ParseBranchString(input);
             result.Path.Should().Be(expectedPath);
@@ -105,7 +105,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
 
             var mockGitExe = new Mock<IGitExe>();
 
-            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), null, null, null, null, null, null, null, mockGitExe.Object, null, null);
+            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), null, null, null, null, null, null, null, null, mockGitExe.Object, null, null);
 
             (string Path, string Name) result = gitHubSourceService.ParseBranchString(input);
             result.Path.Should().Be(expectedPath);
@@ -121,7 +121,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
 
             var mockGitExe = new Mock<IGitExe>();
 
-            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), null, null, null, null, null, null, null, mockGitExe.Object, null, null);
+            var gitHubSourceService = new GitHubSourceService(It.IsAny<string>(), null, null, null, null, null, null, null, null, mockGitExe.Object, null, null);
 
             (string Path, string Name) result = gitHubSourceService.ParseBranchString(input);
             result.Path.Should().Be(expectedPath);
@@ -159,6 +159,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
             var gitHubSourceService = new GitHubSourceService(
                 path,
                 (string key) => true,
+                null,
                 mockServiceProvider.Object,
                 mockHttpClientAdapter.Object,
                 mockSecretStoreRepository.Object,
@@ -211,6 +212,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
             var gitHubSourceService = new GitHubSourceService(
                 path,
                 (string key) => true,
+                null, 
                 mockServiceProvider.Object,
                 mockHttpClientAdapter.Object,
                 mockSecretStoreRepository.Object,
@@ -258,6 +260,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
             var gitHubSourceService = new GitHubSourceService(
                 path,
                 null,
+                null, 
                 mockServiceProvider.Object,
                 mockHttpClientAdapter.Object,
                 mockSecretStoreRepository.Object,
@@ -312,6 +315,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
 
             var gitHubSourceService = new GitHubSourceService(
                 path,
+                null,
                 null,
                 mockServiceProvider.Object,
                 mockHttpClientAdapter.Object,
@@ -374,6 +378,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
             var gitHubSourceService = new GitHubSourceService(
                 path,
                 (string key) => true,
+                null,
                 mockServiceProvider.Object,
                 mockHttpClientAdapter.Object,
                 mockSecretStoreRepository.Object,
@@ -436,6 +441,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
             var gitHubSourceService = new GitHubSourceService(
                 path,
                 (string key) => true,
+                null, 
                 mockServiceProvider.Object,
                 mockHttpClientAdapter.Object,
                 mockSecretStoreRepository.Object,
@@ -481,6 +487,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
             var gitHubSourceService = new GitHubSourceService(
                 path,
                 null,
+                null, 
                 mockServiceProvider.Object,
                 mockHttpClientAdapter.Object,
                 mockSecretStoreRepository.Object,
@@ -529,6 +536,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
 
             var gitHubSourceService = new GitHubSourceService(
                 path,
+                null,
                 null,
                 mockServiceProvider.Object,
                 mockHttpClientAdapter.Object,
@@ -580,6 +588,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
             var gitHubSourceService = new GitHubSourceService(
                 path,
                 null,
+                null,
                 mockServiceProvider.Object,
                 mockHttpClientAdapter.Object,
                 mockSecretStoreRepository.Object,
@@ -628,6 +637,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
 
             var gitHubSourceService = new GitHubSourceService(
                 path,
+                null,
                 null,
                 mockServiceProvider.Object,
                 mockHttpClientAdapter.Object,
@@ -680,6 +690,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Domain.UnitTests
 
             var gitHubSourceService = new GitHubSourceService(
                 path,
+                null,
                 null,
                 mockServiceProvider.Object,
                 mockHttpClientAdapter.Object,


### PR DESCRIPTION
This PR adds the ability for the user to log in and out of their account. This can be useful in cases like debugging, or if a user had logged into the incorrect account.

Main changes to look at:
- The new ```SetOption``` that allows other parts of the code base to dynamically set settings. This is used to set the current state of the "log in" or "log out" button text/behavior
- The new ```SettingsEventArgs``` that the settings can use to fire events to other parts of the code base such as the result source services. In this PR this is used to fire the log in/out event to the result source service.