### PR TITLE
Markdown rendering fix

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ColumnFilterer.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ColumnFilterer.cs
@@ -62,7 +62,12 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
         public IEnumerable<string> GetFilteredValues(string columnName)
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
+            if (!SarifViewerPackage.IsUnitTesting)
+            {
+#pragma warning disable VSTHRD108 // Assert thread affinity unconditionally
+                ThreadHelper.ThrowIfNotOnUIThread();
+#pragma warning restore VSTHRD108
+            }
 
             var filter = this.ErrorListTableControl?.GetFilter(columnName) as ColumnHashSetFilter;
 

--- a/src/Sarif.Viewer.VisualStudio.Core/Models/ScrollViewerWrapper.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Models/ScrollViewerWrapper.cs
@@ -108,15 +108,18 @@ namespace Sarif.Viewer.VisualStudio.Core.Models
                 }
 
                 int maxHeight = 800;
+                int maxWidth = 1000;
                 var dte = AsyncPackage.GetGlobalService(typeof(DTE)) as DTE2;
                 if (dte != null && dte.MainWindow != null)
                 {
-                    maxHeight = dte.MainWindow.Height / 3;
+                    maxHeight = (int)(dte.MainWindow.Height / 3.5);
+                    maxWidth = dte.MainWindow.Width / 3;
                 }
 
                 var scrollViewer = new ScrollViewer()
                 {
                     MaxHeight = maxHeight,
+                    MaxWidth = maxWidth,
                     VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
                     Content = stackPanel,
                 };

--- a/src/Sarif.Viewer.VisualStudio.Core/Models/ScrollViewerWrapper.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Models/ScrollViewerWrapper.cs
@@ -5,13 +5,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
-
+using System.Windows.Media;
 using EnvDTE;
-
 using EnvDTE80;
-
 using Microsoft.Sarif.Viewer.Options;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text.Tagging;
 
 namespace Sarif.Viewer.VisualStudio.Core.Models
@@ -123,6 +122,13 @@ namespace Sarif.Viewer.VisualStudio.Core.Models
                     VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
                     Content = stackPanel,
                 };
+
+/*                scrollViewer.Background = Brushes.Red;
+                scrollViewer.Foreground = Brushes.Blue;*/
+
+                // scrollViewer.Background = GetBrush(dte, vsThemeColors.vsThemeColorDesignerBackground);
+                // scrollViewer.Background = GetBrush(dte, vsThemeColors.vsThemeColorEnvironmentBackground);
+                // scrollViewer.Foreground = GetBrush(dte, vsThemeColors.vsThemeColorTitlebarActiveText);
 
                 return scrollViewer;
             }

--- a/src/Sarif.Viewer.VisualStudio.Core/Models/ScrollViewerWrapper.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Models/ScrollViewerWrapper.cs
@@ -5,12 +5,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media;
 using EnvDTE;
 using EnvDTE80;
 using Microsoft.Sarif.Viewer.Options;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text.Tagging;
 
 namespace Sarif.Viewer.VisualStudio.Core.Models
@@ -122,13 +120,6 @@ namespace Sarif.Viewer.VisualStudio.Core.Models
                     VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
                     Content = stackPanel,
                 };
-
-/*                scrollViewer.Background = Brushes.Red;
-                scrollViewer.Foreground = Brushes.Blue;*/
-
-                // scrollViewer.Background = GetBrush(dte, vsThemeColors.vsThemeColorDesignerBackground);
-                // scrollViewer.Background = GetBrush(dte, vsThemeColors.vsThemeColorEnvironmentBackground);
-                // scrollViewer.Foreground = GetBrush(dte, vsThemeColors.vsThemeColorTitlebarActiveText);
 
                 return scrollViewer;
             }

--- a/src/Sarif.Viewer.VisualStudio.Core/Models/ScrollViewerWrapper.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Models/ScrollViewerWrapper.cs
@@ -5,8 +5,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+
 using EnvDTE;
+
 using EnvDTE80;
+
 using Microsoft.Sarif.Viewer.Options;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text.Tagging;

--- a/src/Sarif.Viewer.VisualStudio.Core/Tags/SarifLocationErrorTag.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Tags/SarifLocationErrorTag.cs
@@ -33,11 +33,6 @@ namespace Microsoft.Sarif.Viewer.Tags
         private const int FontSize = 16;
 
         /// <summary>
-        /// The color for text. Changes based on user theme.
-        /// </summary>
-        private static readonly SolidColorBrush TextBrush = GetBrushFromThemeColor(EnvironmentColors.ToolWindowTextColorKey);
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="SarifLocationErrorTag"/> class.
         /// </summary>
         /// <param name="persistentSpan">The persistent span for the tag within a document.</param>
@@ -98,6 +93,7 @@ namespace Microsoft.Sarif.Viewer.Tags
                             ParseBlocks(viewer.Document.Blocks);
 
                             viewer.Margin = new Thickness(-15, -15, 0, 0); // There is a small amount of padding that MarkdownViewer comes with that makes it awkward when a textfield is put alongside it.
+
                             return viewer;
                         }
                         catch (NotSupportedException)
@@ -109,7 +105,7 @@ namespace Microsoft.Sarif.Viewer.Tags
                     {
                         TextBlock textblock = new TextBlock() { Text = item.strContent };
                         textblock.FontSize = FontSize;
-                        textblock.Foreground = TextBrush;
+                        textblock.Foreground = GetBrushFromThemeColor(EnvironmentColors.ToolWindowTextColorKey);
                         textblock.TextWrapping = TextWrapping.Wrap;
                         return textblock;
                     }
@@ -129,19 +125,20 @@ namespace Microsoft.Sarif.Viewer.Tags
         /// <param name="blocks">A list of blocks to parse.</param>
         private void ParseBlocks(BlockCollection blocks)
         {
+            Brush textBrush = GetBrushFromThemeColor(EnvironmentColors.ToolWindowTextColorKey);
+            Brush hyperlinkBrush = GetBrushFromThemeColor(EnvironmentColors.PanelHyperlinkColorKey);
             foreach (Block block in blocks)
             {
                 foreach (object blockChild in LogicalTreeHelper.GetChildren(block))
                 {
                     if (blockChild is Hyperlink hyperlink)
                     {
-                        SolidColorBrush hyperlinkBrush = GetBrushFromThemeColor(EnvironmentColors.PanelHyperlinkColorKey);
                         hyperlink.Foreground = hyperlinkBrush;
                         hyperlink.MouseDown += Block_MouseDown;
                     }
                     else if (blockChild is Run runBlock)
                     {
-                        runBlock.Foreground = TextBrush;
+                        runBlock.Foreground = textBrush;
                     }
                     else if (blockChild is ListItem listBlock)
                     {
@@ -149,7 +146,7 @@ namespace Microsoft.Sarif.Viewer.Tags
                     }
                 }
 
-                block.Foreground = TextBrush;
+                block.Foreground = textBrush;
             }
         }
 

--- a/src/Sarif.Viewer.VisualStudio.Core/Tags/SarifLocationErrorTag.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Tags/SarifLocationErrorTag.cs
@@ -10,6 +10,7 @@ using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Shapes;
 
 using Markdig.Wpf;
 
@@ -129,6 +130,7 @@ namespace Microsoft.Sarif.Viewer.Tags
             Brush hyperlinkBrush = GetBrushFromThemeColor(EnvironmentColors.PanelHyperlinkColorKey);
             foreach (Block block in blocks)
             {
+                block.Margin = new Thickness(0, 0, 0, 4);
                 foreach (object blockChild in LogicalTreeHelper.GetChildren(block))
                 {
                     if (blockChild is Hyperlink hyperlink)
@@ -143,10 +145,38 @@ namespace Microsoft.Sarif.Viewer.Tags
                     else if (blockChild is ListItem listBlock)
                     {
                         ParseBlocks(listBlock.Blocks);
+                        block.Margin = new Thickness(0, 0, 0, 1);
+                    }
+                    else if (blockChild is InlineUIContainer inlineUIContainer)
+                    {
+                        // block.Foreground = Brushes.Red;
+                        // block.Background = Brushes.Yellow;
+                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.EnvironmentBackgroundBrushKey);
+                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.EnvironmentBackgroundColorKey);
+                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.MainWindowSolutionNameActiveBackgroundBrushKey);
+                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.MainWindowSolutionNameActiveBackgroundColorKey);
+                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.DropDownBackgroundColorKey);
+                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.DropDownBackgroundBrushKey);
+                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.FileTabBackgroundBrushKey);
+                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.FileTabBackgroundColorKey);
+                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.ScrollBarArrowBackgroundBrushKey);
+                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.ScrollBarArrowBackgroundColorKey);
+                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.SystemBackgroundColorKey);
+                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.ScrollBarThumbGlyphColorKey);
+                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.ScrollBarThumbBackgroundColorKey);
+                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.ScrollBarThumbBackgroundColorKey);
+                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.ScrollBarArrowGlyphColorKey);
+                        if (inlineUIContainer.Child is Line line)
+                        {
+                            line.Stroke = GetBrushFromThemeColor(EnvironmentColors.FileTabBackgroundColorKey);
+                        }
+
+                        // inlineUIContainer.Foreground = Brushes.Blue;
+                        // inlineUIContainer.Background = Brushes.Green;
                     }
                 }
 
-                block.Foreground = textBrush;
+                // block.Foreground = textBrush;
             }
         }
 

--- a/src/Sarif.Viewer.VisualStudio.Core/Tags/SarifLocationErrorTag.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Tags/SarifLocationErrorTag.cs
@@ -20,6 +20,8 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Adornments;
 using Microsoft.VisualStudio.Text.Tagging;
 
+using Newtonsoft.Json;
+
 namespace Microsoft.Sarif.Viewer.Tags
 {
     /// <summary>
@@ -149,34 +151,12 @@ namespace Microsoft.Sarif.Viewer.Tags
                     }
                     else if (blockChild is InlineUIContainer inlineUIContainer)
                     {
-                        // block.Foreground = Brushes.Red;
-                        // block.Background = Brushes.Yellow;
-                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.EnvironmentBackgroundBrushKey);
-                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.EnvironmentBackgroundColorKey);
-                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.MainWindowSolutionNameActiveBackgroundBrushKey);
-                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.MainWindowSolutionNameActiveBackgroundColorKey);
-                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.DropDownBackgroundColorKey);
-                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.DropDownBackgroundBrushKey);
-                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.FileTabBackgroundBrushKey);
-                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.FileTabBackgroundColorKey);
-                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.ScrollBarArrowBackgroundBrushKey);
-                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.ScrollBarArrowBackgroundColorKey);
-                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.SystemBackgroundColorKey);
-                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.ScrollBarThumbGlyphColorKey);
-                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.ScrollBarThumbBackgroundColorKey);
-                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.ScrollBarThumbBackgroundColorKey);
-                        // block.Background = GetBrushFromThemeColor(EnvironmentColors.ScrollBarArrowGlyphColorKey);
                         if (inlineUIContainer.Child is Line line)
                         {
                             line.Stroke = GetBrushFromThemeColor(EnvironmentColors.FileTabBackgroundColorKey);
                         }
-
-                        // inlineUIContainer.Foreground = Brushes.Blue;
-                        // inlineUIContainer.Background = Brushes.Green;
                     }
                 }
-
-                // block.Foreground = textBrush;
             }
         }
 


### PR DESCRIPTION
Fixing some markdown bugs that were found as well as making it more appealing visually
- When switching between themes, the color of the font would not automatically update, making it so that the font color would blend into the background and be unreadable
- Fixing some margins
- Changing the color of the divider to be more visually appealing. 
- Preventing the markdown from fitting the width of the screen, taking up more space than usually needed.

Before and after example:
![image](https://github.com/microsoft/sarif-visualstudio-extension/assets/126511432/7feefd09-2bad-4180-9c68-e996652c9297)
