### PR TITLE
File rooting bugfixes + VS 19 json fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "devCanvas.insightsServerName": "PROD"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "devCanvas.insightsServerName": "PROD"
+}

--- a/src/Sarif.Viewer.VisualStudio.Core/CodeAnalysisResultManager.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/CodeAnalysisResultManager.cs
@@ -465,7 +465,7 @@ namespace Microsoft.Sarif.Viewer
                     if (window.Document != null)
                     {
                         string fileName = window.Document.FullName;
-                        if (fileName.EndsWith(relativeFilePath, StringComparison.OrdinalIgnoreCase))
+                        if (fileName.EndsWith(relativeFilePath.Replace('/', Path.DirectorySeparatorChar), StringComparison.OrdinalIgnoreCase))
                         {
                             return window.Document.FullName;
                         }

--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ColumnFilterer.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ColumnFilterer.cs
@@ -25,7 +25,12 @@ namespace Microsoft.Sarif.Viewer.ErrorList
         {
             get
             {
-                ThreadHelper.ThrowIfNotOnUIThread();
+                if (!SarifViewerPackage.IsUnitTesting)
+                {
+#pragma warning disable VSTHRD108 // Assert thread affinity unconditionally
+                    ThreadHelper.ThrowIfNotOnUIThread();
+#pragma warning restore VSTHRD108
+                }
 
                 if (this.errorListTableControl == null)
                 {
@@ -42,7 +47,12 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
         public void FilterOut(string columnName, string filteredValue)
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
+            if (!SarifViewerPackage.IsUnitTesting)
+            {
+#pragma warning disable VSTHRD108 // Assert thread affinity unconditionally
+                ThreadHelper.ThrowIfNotOnUIThread();
+#pragma warning restore VSTHRD108
+            }
 
             var filteredColumnValue = new FilteredColumnValue(columnName, filteredValue);
             if (!this.filteredColumnValues.Contains(filteredColumnValue))

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
@@ -145,7 +145,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
         public System.Threading.Tasks.Task InitializeAsync()
         {
             // TODO: Remove this when merging into main.
-            DevCanvasTracer.WriteLine($"Initializing {nameof(DevCanvasResultSourceService)}. Version 10/3");
+            DevCanvasTracer.WriteLine($"Initializing {nameof(DevCanvasResultSourceService)}. Version 10/5");
             string userName = (string)Registry.GetValue("HKEY_CURRENT_USER\\Software\\Microsoft\\VSCommon\\ConnectedUser\\IdeUserV4\\Cache", "EmailAddress", null);
 
             if (string.IsNullOrWhiteSpace(userName) || !userName.EndsWith("@microsoft.com"))

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
@@ -145,7 +145,7 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
         public System.Threading.Tasks.Task InitializeAsync()
         {
             // TODO: Remove this when merging into main.
-            DevCanvasTracer.WriteLine($"Initializing {nameof(DevCanvasResultSourceService)}. Version 9/7");
+            DevCanvasTracer.WriteLine($"Initializing {nameof(DevCanvasResultSourceService)}. Version 10/3");
             string userName = (string)Registry.GetValue("HKEY_CURRENT_USER\\Software\\Microsoft\\VSCommon\\ConnectedUser\\IdeUserV4\\Cache", "EmailAddress", null);
 
             if (string.IsNullOrWhiteSpace(userName) || !userName.EndsWith("@microsoft.com"))

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.Domain/Sarif.Viewer.VisualStudio.ResultSources.Domain.csproj
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.Domain/Sarif.Viewer.VisualStudio.ResultSources.Domain.csproj
@@ -47,7 +47,7 @@
       <Version>16.0.206</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.1</Version>
+      <Version>12.0.3</Version>
     </PackageReference>
     <PackageReference Include="Sarif.Sdk">
       <Version>2.4.15</Version>

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.GitHubAdvancedSecurity/Sarif.Viewer.VisualStudio.ResultSources.GitHubAdvancedSecurity.csproj
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.GitHubAdvancedSecurity/Sarif.Viewer.VisualStudio.ResultSources.GitHubAdvancedSecurity.csproj
@@ -62,7 +62,7 @@
       <Version>16.0.206</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.1</Version>
+      <Version>12.0.3</Version>
     </PackageReference>
     <PackageReference Include="Octokit">
       <Version>0.51.0</Version>

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -68,7 +68,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Sarif.Converters">
       <Version>2.4.15</Version>
     </PackageReference>


### PR DESCRIPTION
This PR addresses 2 main bugfixes:
1. The extension does not play well in VS 19 after I tried to upgrade the ver of the json nuget. [Here](https://devblogs.microsoft.com/visualstudio/using-newtonsoft-json-in-a-visual-studio-extension/) is a blogpost about it but in short every ver of VS ships with its own ver of the newtonsoft json nuget, but when you use a ver that is outside the one that it is shipped with, it can cause issues. In this case, vs 19 comes w/ newtonsoft 12 and so it didn't like how I increased the ver to 13.
2. When opening files through the drag and drop or through the File > Open > File and you don't have the appropriate folder/solution open, it will fail to link the relative file path in the sarif object to the absolute file path on disk if they file seperators are different (/ vs \)