### PR TITLE
Fix issue cannot open a SARIF log if there is any tool notification.

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
@@ -701,21 +701,22 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                 this.ShowFilteredSuppressionStateColumn();
             }
 
-            if (!skipRemapping && dataCache.SarifErrors.Any())
+            var sarifResults = dataCache.SarifErrors.Where(r => r.SarifResult != null).ToList();
+            if (!skipRemapping && sarifResults.Any())
             {
-                IEnumerable<string> relativeFilePaths = dataCache.SarifErrors.Select(x => x.FileName);
-                IEnumerable<string> uriBaseIds = dataCache.SarifErrors.Select(x => x.SarifResult.Locations?.FirstOrDefault()?.PhysicalLocation?.ArtifactLocation?.UriBaseId);
+                IEnumerable<string> relativeFilePaths = sarifResults.Select(x => x.FileName);
+                IEnumerable<string> uriBaseIds = sarifResults.Select(x => x.SarifResult.Locations?.FirstOrDefault()?.PhysicalLocation?.ArtifactLocation?.UriBaseId);
 
                 // now we need to map from relative file path to absolute.
-                string workingDirectory = dataCache.SarifErrors.FirstOrDefault().WorkingDirectory;
+                string workingDirectory = sarifResults.FirstOrDefault().WorkingDirectory;
 
                 // find the mapped path with codeanalysisresultmanager
                 List<string> resolvedFilePaths = CodeManagerInstance.ResolveFilePaths(dataCache, workingDirectory, logFilePath, uriBaseIds.ToList(), relativeFilePaths.ToList());
-                CodeManagerInstance.RemapFilePaths(dataCache.SarifErrors, relativeFilePaths.ToList(), resolvedFilePaths);
+                CodeManagerInstance.RemapFilePaths(sarifResults, relativeFilePaths.ToList(), resolvedFilePaths);
 
                 // remap regions and lineNumber of the sarif error list items
                 var codeFinderCache = new Dictionary<string, CodeFinder>(); // local file path -> codefinder
-                foreach (SarifErrorListItem item in dataCache.SarifErrors)
+                foreach (SarifErrorListItem item in sarifResults)
                 {
                     List<(Uri filePath, MatchQuery query)?> queries = item.GetMatchQueries();
                     if (queries != null)


### PR DESCRIPTION
If the SARIF log contains tool notifications (which is not a SARIF result), viewer got unhandled exception and not able to load the results.

Attached the repro SARIF log.
[repros.zip](https://github.com/microsoft/sarif-visualstudio-extension/files/13058566/repros.zip)

The fix is to skip the notifications in new added code finder process.