### PR TITLE
Small markdown rendering fixes

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ColumnFilterer.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ColumnFilterer.cs
@@ -25,7 +25,12 @@ namespace Microsoft.Sarif.Viewer.ErrorList
         {
             get
             {
-                ThreadHelper.ThrowIfNotOnUIThread();
+                if (!SarifViewerPackage.IsUnitTesting)
+                {
+#pragma warning disable VSTHRD108 // Assert thread affinity unconditionally
+                    ThreadHelper.ThrowIfNotOnUIThread();
+#pragma warning restore VSTHRD108
+                }
 
                 if (this.errorListTableControl == null)
                 {
@@ -42,7 +47,12 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
         public void FilterOut(string columnName, string filteredValue)
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
+            if (!SarifViewerPackage.IsUnitTesting)
+            {
+#pragma warning disable VSTHRD108 // Assert thread affinity unconditionally
+                ThreadHelper.ThrowIfNotOnUIThread();
+#pragma warning restore VSTHRD108
+            }
 
             var filteredColumnValue = new FilteredColumnValue(columnName, filteredValue);
             if (!this.filteredColumnValues.Contains(filteredColumnValue))

--- a/src/Sarif.Viewer.VisualStudio.Core/ResultTextMarker.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ResultTextMarker.cs
@@ -430,7 +430,15 @@ namespace Microsoft.Sarif.Viewer
                         out resolvedUri)))
                 {
                     // Fill out the region's properties
-                    this.fullyPopulatedRegion = FileRegionsCache.Instance.PopulateTextRegionProperties(this.region, resolvedUri, populateSnippet: true);
+                    try
+                    {
+                        this.fullyPopulatedRegion = FileRegionsCache.Instance.PopulateTextRegionProperties(this.region, resolvedUri, populateSnippet: true);
+                    }
+                    catch (ArgumentOutOfRangeException)
+                    {
+                        // in the case there is a mismatch between the file opened on the users device and the file used to create the insight, this can throw an error due to one being larger than the other.
+                        return false;
+                    }
                 }
             }
 

--- a/src/Sarif.Viewer.VisualStudio.Core/Tags/SarifLocationErrorTag.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/Tags/SarifLocationErrorTag.cs
@@ -207,10 +207,17 @@ namespace Microsoft.Sarif.Viewer.Tags
         /// <param name="e">The event of being clicked.</param>
         private void Block_MouseDown(object sender, MouseButtonEventArgs e)
         {
-            if (sender is Hyperlink hyperlink)
+            try
             {
-                Process.Start(new ProcessStartInfo(hyperlink.NavigateUri.AbsoluteUri));
-                e.Handled = true;
+                if (sender is Hyperlink hyperlink)
+                {
+                    Process.Start(new ProcessStartInfo(hyperlink.NavigateUri.AbsoluteUri));
+                    e.Handled = true;
+                }
+            }
+            catch (Exception)
+            {
+                // in case that we cannot navigate to the uri for whatever reason we want to swallow as we do not want to crash VS as a whole.
             }
         }
 


### PR DESCRIPTION
In this PR I am changing 2 things, 1 being to prevent errors occurring when the sarif references line numbers past the end of the document, the other being to prevent vs from crashing when a user clicks a bad link