### PR TITLE
Stopping un necessary file rooting requests

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/CodeAnalysisResultManager.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/CodeAnalysisResultManager.cs
@@ -391,6 +391,11 @@ namespace Microsoft.Sarif.Viewer
 #pragma warning restore VSTHRD108
             }
 
+            if (Path.IsPathRooted(relativePath))
+            {
+                return relativePath;
+            }
+
             // File contents embedded in SARIF.
             bool hasHash = dataCache.FileDetails.TryGetValue(relativePath, out ArtifactDetailsModel model) && !string.IsNullOrEmpty(model?.Sha256Hash);
             string embeddedTempFilePath = this.CreateFileFromContents(dataCache.FileDetails, relativePath);


### PR DESCRIPTION
There is a bug where if you open just a .sarif file, even if the file paths given are absolute it will prompt the user to root the file path. 