### PR TITLE
Updating code finder to better work with multi line snippets

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.Core/CodeFinding/Internals/CStyle/CStyleFinder.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/CodeFinding/Internals/CStyle/CStyleFinder.cs
@@ -175,6 +175,7 @@ namespace Microsoft.Sarif.Viewer.CodeFinding.Internal.CStyle
         /// <returns>The list of matching results.</returns>
         public override List<MatchResult> FindMatchesWithFunction(MatchQuery query)
         {
+            query.ChangeLineEndings(lineEndings);
             string textToFind = query.TextToFind;
 
             // Because curly braces define scopes, they present an interesting challenge to this

--- a/src/Sarif.Viewer.VisualStudio.Core/CodeFinding/Internals/CodeFinderBase.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/CodeFinding/Internals/CodeFinderBase.cs
@@ -14,6 +14,12 @@ namespace Microsoft.Sarif.Viewer.CodeFinding.Internal
     internal abstract class CodeFinderBase
     {
         /// <summary>
+        /// The character or sequence of characters that designate a line end.
+        /// Either will be \r\n, \r, or \n.
+        /// </summary>
+        protected string lineEndings;
+
+        /// <summary>
         /// The complete contents of the file.
         /// </summary>
         protected string fileContents;
@@ -47,6 +53,19 @@ namespace Microsoft.Sarif.Viewer.CodeFinding.Internal
             lineCount = GetLineNumber(endOfFile);
 
             IgnoredSpans = GetIgnoredSpans();
+
+            if (fileContents.Contains("\r\n"))
+            {
+                lineEndings = "\r\n";
+            }
+            else if (fileContents.Contains("\r"))
+            {
+                lineEndings = "\r";
+            }
+            else
+            {
+                lineEndings = "\n";
+            }
         }
 
         /// <summary>
@@ -96,6 +115,8 @@ namespace Microsoft.Sarif.Viewer.CodeFinding.Internal
         /// <returns>The list of possible matches.</returns>
         private List<MatchResult> FindMatchesBasic(MatchQuery query)
         {
+            query.ChangeLineEndings(lineEndings);
+
             var matches = new List<MatchResult>();
 
             // Find all instances of the given text.

--- a/src/Sarif.Viewer.VisualStudio.Core/CodeFinding/MatchQuery.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/CodeFinding/MatchQuery.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Sarif.Viewer.CodeFinding
         public string Id { get; }
 
         /// <summary>
-        /// Gets the text to search for.
+        /// Gets or sets the text to search for.
         /// </summary>
-        public string TextToFind { get; }
+        public string TextToFind { get; set; }
 
         /// <summary>
         /// Gets optional function signature.
@@ -94,6 +94,26 @@ namespace Microsoft.Sarif.Viewer.CodeFinding
             LineNumberHint = lineNumberHint;
             TypeHint = typeHint;
             MatchWholeTokens = matchWholeTokens;
+        }
+
+        /// <summary>
+        /// Changes the line endings in the text to find to make matching simpler. Automatically tries to detect the line endings being used in the text.
+        /// </summary>
+        /// <param name="newLineEndings">The new line endings that we will use.</param>
+        public void ChangeLineEndings(string newLineEndings)
+        {
+            if (this.TextToFind.Contains("\r\n"))
+            {
+                this.TextToFind = this.TextToFind.Replace("\r\n", newLineEndings);
+            }
+            else if (this.TextToFind.Contains("\r"))
+            {
+                this.TextToFind = this.TextToFind.Replace("\r", newLineEndings);
+            }
+            else
+            {
+                this.TextToFind = this.TextToFind.Replace("\n", newLineEndings);
+            }
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.Core/CodeFinding/MatchQuery.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/CodeFinding/MatchQuery.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Linq;
+
 namespace Microsoft.Sarif.Viewer.CodeFinding
 {
     /// <summary>
@@ -74,6 +76,28 @@ namespace Microsoft.Sarif.Viewer.CodeFinding
         /// Gets a value indicating whether only whole tokens will be matched. Not supported by <see cref="CodeFinder.FindMatches(MatchQuery)"/>.
         /// </summary>
         public bool MatchWholeTokens { get; }
+
+        /// <summary>
+        /// Gets the number of lines we are searching for with this query.
+        /// </summary>
+        public int LineNumbers
+        {
+            get
+            {
+                if (this.TextToFind.Contains("\r\n"))
+                {
+                    return this.TextToFind.Split(new string[] { "\r\n" }, System.StringSplitOptions.None).Count();
+                }
+                else if (this.TextToFind.Contains("\r"))
+                {
+                    return this.TextToFind.Split('\r').Count();
+                }
+                else
+                {
+                    return this.TextToFind.Split('\n').Count();
+                }
+            }
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MatchQuery"/> class.

--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
@@ -327,8 +327,10 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                 (SarifLog log, string outputPath) logTuple = await ConvertLogsToSarifStableAsync(toolFormat, filePath, promptOnLogConversions);
                 await ProcessSarifLogAsync(logTuple.log, logTuple.outputPath, cleanErrors: cleanErrors, openInEditor: openInEditor).ConfigureAwait(continueOnCapturedContext: false);
             }
-            catch (Exception)
+            catch (Exception e)
             {
+                Trace.WriteLine($"Failed to process log file. Reason: {e.Message}");
+
                 // swallow to prevent crashing.
             }
         }
@@ -746,11 +748,11 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                                 {
                                     item.LineNumber = bestResult.LineNumber;
                                     item.Region.StartLine = bestResult.LineNumber;
-                                    item.Region.EndLine = bestResult.LineNumber + query.LineNumbers;
+                                    item.Region.EndLine = bestResult.LineNumber + query.LineNumbers - 1;
                                 }
 
                                 item.SarifResult.Locations[i].PhysicalLocation.Region.StartLine = bestResult.LineNumber;
-                                item.SarifResult.Locations[i].PhysicalLocation.Region.EndLine = bestResult.LineNumber + query.LineNumbers;
+                                item.SarifResult.Locations[i].PhysicalLocation.Region.EndLine = bestResult.LineNumber + query.LineNumbers - 1;
                             }
                         }
                     }

--- a/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio.Core/ErrorList/ErrorListService.cs
@@ -746,11 +746,11 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                                 {
                                     item.LineNumber = bestResult.LineNumber;
                                     item.Region.StartLine = bestResult.LineNumber;
-                                    item.Region.EndLine = bestResult.LineNumber;
+                                    item.Region.EndLine = bestResult.LineNumber + query.LineNumbers;
                                 }
 
                                 item.SarifResult.Locations[i].PhysicalLocation.Region.StartLine = bestResult.LineNumber;
-                                item.SarifResult.Locations[i].PhysicalLocation.Region.EndLine = bestResult.LineNumber;
+                                item.SarifResult.Locations[i].PhysicalLocation.Region.EndLine = bestResult.LineNumber + query.LineNumbers;
                             }
                         }
                     }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/CodeFinding/UnitTests/CsharpTestMultiLine.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/CodeFinding/UnitTests/CsharpTestMultiLine.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.Sarif.Viewer.CodeFinding;
+
+using Xunit;
+
+namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests.CodeFinding.UnitTests
+{
+    public class CsharpTestMultiLine
+    {
+        /// <summary>
+        /// Tests if we are able to match multi line snippets
+        /// </summary>
+        [Theory]
+        [InlineData("\r")]
+        [InlineData("\r\n")]
+        [InlineData("\n")]
+        public void TestMultiLine(string lineEndings)
+
+        {
+            string filePath = @"CodeFinding\TestFiles\CSharp2.cs";
+            CodeFinder codeFinder = new CodeFinder(filePath);
+
+            string textToFind = $"            Console.WriteLine(\"return a + b + c\");{lineEndings}            return a + b + c;";
+
+            MatchQuery query = new MatchQuery(textToFind);
+            List<MatchResult> matches = codeFinder.FindMatches(query);
+            matches.Count().Should().Be(1);
+            var bestMatch = MatchResult.GetBestMatch(matches);
+            bestMatch.LineNumber.Should().Be(38);
+        }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
@@ -62,6 +62,7 @@
     <Compile Include="CodeFinding\UnitTests\CodeFinderUnitTestBase.cs" />
     <Compile Include="CodeFinding\UnitTests\CppTests.cs" />
     <Compile Include="CodeFinding\UnitTests\CppTests2.cs" />
+    <Compile Include="CodeFinding\UnitTests\CsharpTestMultiLine.cs" />
     <Compile Include="CodeFinding\UnitTests\CsharpTests.cs" />
     <Compile Include="CodeFinding\UnitTests\CTests.cs" />
     <Compile Include="CodeFinding\UnitTests\CTests2.cs" />


### PR DESCRIPTION
Previously our code finder had only been used with single line snippets. However due to new scenarios, we are encountering snippets that are multi line and so we have to update the code finder algorithm to be more resistant to the different line endings as well as modify the ending line number.