### PR TITLE
Using registry keys to limit devcanvas usage to just team members

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "devCanvas.insightsServerName": "PROD"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "devCanvas.insightsServerName": "PROD"
+}

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
@@ -144,13 +144,10 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
         /// <inheritdoc/>
         public System.Threading.Tasks.Task InitializeAsync()
         {
-            try
+            string devcanvasKey = (string)Registry.GetValue("HKEY_CURRENT_USER\\Software\\Microsoft\\VisualStudio\\devcanvas", "sampleKey", null);
+            if (string.IsNullOrEmpty(devcanvasKey))
             {
-                RegistryKey devCanvasKey = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\VisualStudio\devcanvas", false);
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e.ToString());
+                return System.Threading.Tasks.Task.FromResult(Result.Failure("Not a DevCanvas user."));
             }
 
             // TODO: Remove this when merging into main.

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
@@ -144,13 +144,19 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
         /// <inheritdoc/>
         public System.Threading.Tasks.Task InitializeAsync()
         {
+            return IsActiveAsync();
+        }
+
+        /// <inheritdoc/>
+        public Task<Result> IsActiveAsync()
+        {
+            // TODO: remove below to release to general users.
             string devcanvasKey = (string)Registry.GetValue("HKEY_CURRENT_USER\\Software\\Microsoft\\VisualStudio\\devcanvas", "sampleKey", null);
             if (string.IsNullOrEmpty(devcanvasKey))
             {
                 return System.Threading.Tasks.Task.FromResult(Result.Failure("Not a DevCanvas user."));
             }
 
-            // TODO: Remove this when merging into main.
             DevCanvasTracer.WriteLine($"Initializing {nameof(DevCanvasResultSourceService)}. Version 11/20");
             string userName = (string)Registry.GetValue("HKEY_CURRENT_USER\\Software\\Microsoft\\VSCommon\\ConnectedUser\\IdeUserV4\\Cache", "EmailAddress", null);
 
@@ -164,12 +170,6 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
                 DevCanvasTracer.WriteLine($"Initialized {nameof(DevCanvasResultSourceService)}");
                 return System.Threading.Tasks.Task.FromResult(Result.Success());
             }
-        }
-
-        /// <inheritdoc/>
-        public Task<Result> IsActiveAsync()
-        {
-            return System.Threading.Tasks.Task.FromResult(Result.Success());
         }
 
         /// <inheritdoc/>

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
@@ -151,8 +151,8 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
         public Task<Result> IsActiveAsync()
         {
             // TODO: remove below to release to general users.
-            string devcanvasKey = (string)Registry.GetValue("HKEY_CURRENT_USER\\Software\\Microsoft\\VisualStudio\\devcanvas", "sampleKey", null);
-            if (string.IsNullOrEmpty(devcanvasKey))
+            string devcanvasKey = (string)Registry.GetValue("HKEY_CURRENT_USER\\Software\\Microsoft\\VisualStudio\\devcanvas", "DevCanvasInsider", null);
+            if (devcanvasKey != "True")
             {
                 return System.Threading.Tasks.Task.FromResult(Result.Failure("Not a DevCanvas user."));
             }

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core/Services/DevCanvasResultSourceService.cs
@@ -144,6 +144,15 @@ namespace Sarif.Viewer.VisualStudio.ResultSources.DeveloperCanvas.Core.Services
         /// <inheritdoc/>
         public System.Threading.Tasks.Task InitializeAsync()
         {
+            try
+            {
+                RegistryKey devCanvasKey = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\VisualStudio\devcanvas", false);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.ToString());
+            }
+
             // TODO: Remove this when merging into main.
             DevCanvasTracer.WriteLine($"Initializing {nameof(DevCanvasResultSourceService)}. Version 11/20");
             string userName = (string)Registry.GetValue("HKEY_CURRENT_USER\\Software\\Microsoft\\VSCommon\\ConnectedUser\\IdeUserV4\\Cache", "EmailAddress", null);

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.UnitTests/ResultSourceFactoryTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.UnitTests/ResultSourceFactoryTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory.UnitTests
         }
 
         [Fact]
-        public void GetResultSourceService_ReturnsPlatformNotSupported_WhenPathDoesNotContainsDotGitDirectory()
+        public async Task GetResultSourceService_ReturnsPlatformNotSupported_WhenPathDoesNotContainsDotGitDirectoryAsync()
         {
             string path = @"C:\Git\MyProject";
             string uri = "https://github.com/user/myproject.git";
@@ -106,9 +106,9 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory.UnitTests
             standardKernel.Bind<IStatusBarService>().ToConstant(mockStatusBarService.Object);
 
             var resultSourceFactory = new ResultSourceFactory(path, standardKernel, (string key) => true, SetOptionStateCallback);
-            Result<List<IResultSourceService>, ErrorType> result = resultSourceFactory.GetResultSourceServicesAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            Result<List<IResultSourceService>, ErrorType> result = await resultSourceFactory.GetResultSourceServicesAsync().ConfigureAwait(false);
 
-            result.Value.Count.Should().Be(0);
+            result.Error.Should().Be(ErrorType.PlatformNotSupported);
         }
 
         [Fact]

--- a/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.UnitTests/ResultSourceFactoryTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.ResultSources.Factory.UnitTests/ResultSourceFactoryTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory.UnitTests
 
             result.IsSuccess.Should().BeTrue();
             result.Value.Should().NotBeNull();
-            result.Value.Count.Should().Be(2);
+            result.Value.Count.Should().Be(1);
             result.Value[0].GetType().Name.Should().Be("GitHubSourceService");
         }
 
@@ -108,9 +108,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory.UnitTests
             var resultSourceFactory = new ResultSourceFactory(path, standardKernel, (string key) => true, SetOptionStateCallback);
             Result<List<IResultSourceService>, ErrorType> result = resultSourceFactory.GetResultSourceServicesAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
-            result.Value.Count.Should().Be(1);
-            result.IsSuccess.Should().BeTrue();
-            result.Value[0].GetType().Name.Should().Be("DevCanvasResultSourceService");
+            result.Value.Count.Should().Be(0);
         }
 
         [Fact]
@@ -175,7 +173,7 @@ namespace Microsoft.Sarif.Viewer.ResultSources.Factory.UnitTests
             factory.AddResultSource(new SampleResultSourceService().GetType(), 1, 1);
             ResultSourceHost resultSourceHost = new ResultSourceHost(factory);
             await resultSourceHost.RequestAnalysisResultsAsync();
-            resultSourceHost.ServiceCount.Should().Be(3);
+            resultSourceHost.ServiceCount.Should().Be(2);
         }
     }
 }


### PR DESCRIPTION
This is a temporary change that will allow the DevCanvas team to make sure our changes do not affect the wider audience while also allowing us to merge back into main in the near future.

Our current plan for releasing this feature branch is:
1. Commit this PR to the feature branch
2. Get access to the app insights cluster from @michaelcfanning
3. Set up some telemetry points around our auth stack/plugin in order to validate that it is working
4. Merge this feature branch into main in order to guarantee nothing gets changed or refactored in main that would cause headaches in the feature branch
5. When we feel ready, remove the changes in this PR that check for the devcanvas reg key to release to the wider MSFT audience

While we are not going to commit it to the repo, the following is a simple .reg file that can be used to turn on the reg key flag that we are using in this PR.
```reg
Windows Registry Editor Version 5.00

[HKEY_CURRENT_USER\Software\Microsoft\VisualStudio\devcanvas]
"DevCanvasInsider"="True"

```
To use this .reg file, copy the content to a file and make sure the file extension is .reg. Once you have the file saved, double click it and it should automatically apply the registry key changes needed to active the plugin.